### PR TITLE
Display a warning when using online repositories with less than 1GiB RAM

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 10 15:15:43 UTC 2014 - lslezak@suse.cz
+
+- display a warning when using online repositories with less than
+  1GiB RAM (the installer may crash or freeze) (bnc#854755)
+- 3.1.3
+
+-------------------------------------------------------------------
 Fri Feb  7 11:30:54 UTC 2014 - jsrain@suse.cz
 
 - use text version of release notes for NCurses (bnc#862578)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.2
+Version:        3.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -28,7 +28,8 @@ License:        GPL-2.0+
 BuildRequires:	yast2-country-data yast2-xml update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools >= 3.1.10
 
-BuildRequires: yast2 >= 3.0.5
+# HwDetection
+BuildRequires: yast2 >= 3.1.19
 
 # Pkg::SetZConfig()
 BuildRequires:	yast2-pkg-bindings >= 2.21.8
@@ -39,8 +40,8 @@ Requires:	yast2-country-data >= 2.16.3
 # Pkg::SetZConfig()
 Requires:	yast2-pkg-bindings >= 2.21.8
 
-# OSRelease
-Requires: yast2 >= 3.0.5
+# HwDetection
+Requires: yast2 >= 3.1.19
 
 # unzipping license file
 Requires:	unzip


### PR DESCRIPTION
- the installer may crash or freeze on low memory ([bnc#854755](https://bugzilla.novell.com/show_bug.cgi?id=854755))
- 3.1.1
