### PR TITLE
Package tightvnc is no more required while installing over VNC

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 17 16:30:26 CET 2014 - locilka@suse.com
+
+- Package tightvnc is no more required while installing over VNC
+  (bnc#859903)
+- 3.1.4
+
+-------------------------------------------------------------------
 Mon Feb 10 15:15:43 UTC 2014 - lslezak@suse.cz
 
 - display a warning when using online repositories with less than

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.3
+Version:        3.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -818,7 +818,7 @@ module Yast
       packages = []
 
       if Linuxrc.vnc
-        packages.concat [ "tightvnc", "yast2-qt", "xorg-x11-Xvnc",
+        packages.concat [ "yast2-qt", "xorg-x11-Xvnc",
           "xorg-x11-fonts", "icewm", "sax2-tools", "yast2-x11", "xinetd" ]
       end
 


### PR DESCRIPTION
- Bug 859903 - YaST VNC module suggest installation of tightvnc which is no longer relevant.
