### PR TITLE
fixed wrong constant name resulting in a crash during installation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 15 11:44:30 UTC 2014 - lslezak@suse.cz
+
+- fixed wrong constant name resulting in a crash during
+  installation
+- 3.1.15
+
+-------------------------------------------------------------------
 Tue May 13 17:44:20 UTC 2014 - lslezak@suse.cz
 
 - add-on protocol dialog: display a global checkbox when selecting

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.14
+Version:        3.1.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -2279,7 +2279,7 @@ module Yast
       if UI.WidgetExists(:add_addon)
         enabled = UI.QueryWidget(Id(:add_addon), :Value)
 
-        URL_SCHEMA_DESCRIPTIONS.keys.each do |widget|
+        WIDGET_LABELS.keys.each do |widget|
           UI.ChangeWidget(Id(widget), :Enabled, enabled) if UI.WidgetExists(widget)
         end
       end


### PR DESCRIPTION
- 3.1.15

Fixes http://openqa.suse.de/viewimg/show/SLED-12-DVD-x86_64-Build0260-gnome-uefi-suse/partitioning/1 crash
