### PR TITLE
Make product renames updatable from SCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache
+/coverage
 config.cache
 config.guess
 config.h

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul  4 12:09:55 UTC 2014 - lslezak@suse.cz
+
+- make product renames updatable from SCC (related to bnc#883206)
+- 3.1.27
+
+-------------------------------------------------------------------
 Fri Jun 27 12:00:38 UTC 2014 - lslezak@suse.cz
 
 - updated known product renames (bnc#883047)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.25
+Version:        3.1.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -17,15 +17,6 @@ module Yast
     # All known types of resolvables
     RESOLVABLE_TYPES = [:product, :patch, :package, :pattern, :language]
 
-    # product renames needed for detecting the product update
-    # <old_name> => [ <new_name> ]
-    PRODUCT_RENAMES = {
-      "SUSE_SLES"  => [ "SLES" ],
-      # SLED or Workstation extension
-      "SUSE_SLED"  => [ "SLED", "sle-we" ],
-      "sle-haegeo" => [ "sle-ha-geo" ]
-    }
-
     def main
       Yast.import "UI"
       Yast.import "Pkg"
@@ -2660,9 +2651,8 @@ module Yast
           removed_name = removed_product["name"]
 
           # check the current product names or product renames
-          removed_name == installed_name ||
-            (PRODUCT_RENAMES[removed_name] &&
-              PRODUCT_RENAMES[removed_name].include?(installed_name))
+          removed_name == installed_name
+            AddOnProduct.renamed?(removed_name, installed_name)
         end
 
         updated_products[removed] = installed_product if removed

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,5 @@
 TESTS = \
+  addon_product_test.rb \
   packages_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -1,0 +1,35 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+Yast.import "AddOnProduct"
+
+describe Yast::AddOnProduct do
+  describe "#renamed?" do
+    it "returns true if product has been renamed" do
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES")).to be_true
+    end
+
+    it "returns false if the product rename is not known" do
+      expect(Yast::AddOnProduct.renamed?("foo", "bar")).to be_false
+    end
+  end
+
+  describe "#add_rename" do
+    it "adds a new product rename" do
+      expect(Yast::AddOnProduct.renamed?("FOO", "BAR")).to be_false
+      Yast::AddOnProduct.add_rename("FOO", "BAR")
+      expect(Yast::AddOnProduct.renamed?("FOO", "BAR")).to be_true
+    end
+
+    it "keeps the existing renames" do
+      # add new rename
+      Yast::AddOnProduct.add_rename("SUSE_SLES", "SLES_NEW")
+      # check the new rename
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES_NEW")).to be_true
+      # check the already known rename
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES")).to be_true
+    end
+  end
+
+end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1,8 +1,7 @@
 #! /usr/bin/env rspec
 
-ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+require_relative "./test_helper"
 
-require "yast"
 require "yaml"
 
 include Yast::Logger

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,8 @@
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start
+end
+
+require "yast"


### PR DESCRIPTION
- related to bnc#883206
- the code has been moved from `Packages` to `AddOnProduct`
- 3.1.27
