### PR TITLE
Fixing bnc#869653: Adding using SLP: Filter is case-sensitive

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jul 25 09:48:59 UTC 2014 - cwh@suse.com
+
+- Made SLP browser filter case-insensitive (bnc#869653)
+
+-------------------------------------------------------------------
 Fri Jul 11 12:29:40 UTC 2014 - lslezak@suse.cz
 
 - fixed finding product upgrades (bnc#886621)


### PR DESCRIPTION
Since the old code escaped most of the regexp characters I decided to go to s simple string compare using pure ruby. So I removed the escaping of the special characters in the filter_string. Instead of Builtins.regexpmatch I went for String::index which does not need character escaping.
