### PR TITLE
do not write Xen initrd modules (bnc#895084)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  5 14:53:10 UTC 2014 - lslezak@suse.cz
+
+- /etc/sysconfig/kernel:INITRD_MODULES has been dropped, do not
+  write Xen modules there (bnc#895084)
+- 3.1.46
+
+-------------------------------------------------------------------
 Thu Sep  4 11:03:03 UTC 2014 - jreidinger@suse.com
 
 - use new rubygem dependency syntax (bnc#895069)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.45
+Version:        3.1.46
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -24,7 +24,6 @@ module Yast
       Yast.import "Popup"
       Yast.import "Directory"
       Yast.import "ModuleLoading"
-      Yast.import "Initrd"
       Yast.import "Kernel"
       Yast.import "Arch"
       Yast.import "FileUtils"
@@ -244,35 +243,7 @@ module Yast
         end
       end
 
-      # add Xen and HyperV PV drivers to initrd
-      XenPVToInitrd()
-
       :next
-    end
-
-    # add xen paravirtualized drivers to initrd if thery are selected for installation
-    def XenPVToInitrd
-      # is any xen-kmp-* package selected?
-      if Pkg.IsSelected("xen-kmp-default") || Pkg.IsSelected("xen-kmp-smp") ||
-          Pkg.IsSelected("xen-kmp-pae") ||
-          Pkg.IsSelected("xen-kmp-bigsmp") ||
-          Pkg.IsSelected("xen-kmp-kdump")
-        # add disk driver
-        Initrd.AddModule("xen-vbd", "")
-        # add network driver
-        Initrd.AddModule("xen-vnif", "")
-
-        Builtins.y2milestone(
-          "Added Xen PV drivers to initrd, configured drivers: %1",
-          Initrd.ListModules
-        )
-      else
-        Builtins.y2milestone(
-          "No xen-kmp-* package is selected for installation, skipping XEN PV driver installation"
-        )
-      end
-
-      nil
     end
 
     #  Write a fake mtab to the target system since some %post scripts might


### PR DESCRIPTION
- `/etc/sysconfig/kernel:INITRD_MODULES` has been dropped
- 3.1.46
