### PR TITLE
Fix typo when trying to create mount point directory to detect size

### DIFF
--- a/src/modules/SpaceCalculation.rb
+++ b/src/modules/SpaceCalculation.rb
@@ -638,7 +638,7 @@ module Yast
                   # This part should be refactored to rely on libstorage.
 
                   tmpdir = SCR.Read(path(".target.tmpdir")) + "/diskspace_mount"
-                  SCR.Execute(path(".target.bash"), "mkdir -p #{Shellwords.escape(tmpdir)})")
+                  SCR.Execute(path(".target.bash"), "mkdir -p #{Shellwords.escape(tmpdir)}")
 
                   # mount options determined by partitioner
                   mount_options = (part["fstopt"] || "").split(",")


### PR DESCRIPTION
When trying an nfsroot installation this message is shown at the final
installation summary screen and the installation cannot be triggered:

Error: Cannot check free space in basic directory / (device
d46:/abuild/nfsroot_2), cannot start installation.

This patch was tested to fix this issue.

Signed-off-by: Thomas Renninger trenn@suse.de
