### PR TITLE
Fill options value if /proc/cmdline is empty

### DIFF
--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -969,7 +969,7 @@ module Yast
       ret = []
 
       add_biosdevname = false
-      options = SCR.Read(path(".proc.cmdline"))
+      options = SCR.Read(path(".proc.cmdline")) || ""
       option = options.grep(/^biosdevname=/i).first
       if option
         value = option[/^biosdevname=(\d+)/i, 1]


### PR DESCRIPTION
In case installer have empty /proc/cmdline set options value to "empty"
Otherwise it would fail. bsc#908185

Signed-off-by: Dinar Valeev dvaleev@suse.com
