### PR TITLE
Handle file:// URL scheme (boo#869399)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  3 09:01:07 UTC 2015 - lslezak@suse.cz
+
+- fixed file:// URL handling (same as dir://) (boo#869399)
+- validate entered URL schema
+- 3.1.58
+
+-------------------------------------------------------------------
 Thu Jan 29 14:45:40 UTC 2015 - jreidinger@suse.com
 
 - remove obsolete legacy patch callbacks

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.57
+Version:        3.1.58
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -61,6 +61,10 @@ module Yast
       :download_metadata => N_("&Download repository description files"),
     }
 
+    # @see https://github.com/openSUSE/libzypp/blob/master/zypp/media/MediaManager.h#L163
+    VALID_URL_SCHEMES = ["ftp", "tftp", "http", "https", "nfs",
+      "nfs4", "cifs", "smb", "cd", "dvd", "iso", "dir", "file", "hd"]
+
     def main
       Yast.import "Pkg"
       Yast.import "UI"
@@ -213,7 +217,7 @@ module Yast
         # label / dialog caption
         "dir"   => _("Local Directory"),
         # label / dialog caption
-        "file"  => _("Local ISO Image"),
+        "iso"  => _("Local ISO Image"),
         # label / dialog caption
         "http"  => _("Server and Directory"),
         # label / dialog caption
@@ -525,7 +529,8 @@ module Yast
         Popup.Message(_("URL cannot be empty."))
         return false
       end
-      true
+
+      valid_scheme?(url)
     end
 
     # Get widget description map
@@ -822,7 +827,11 @@ module Yast
     # @param [String] key string widget key
     def DirInit(key)
       parsed = URL.Parse(@_url)
-      UI.ChangeWidget(Id(:dir), :Value, Ops.get_string(parsed, "path", ""))
+
+      path = parsed["path"]
+      path = "/" if path.empty?
+
+      UI.ChangeWidget(Id(:dir), :Value, path)
       UI.SetFocus(:dir)
 
       # is it a plain directory?
@@ -846,10 +855,15 @@ module Yast
     # Store function of a widget
     # @param [String] key string widget key
     # @param [Hash] event map which caused settings being stored
-    def DirStore(key, event)
-      event = deep_copy(event)
+    def DirStore(key, _event)
+      parsed = URL.Parse(@_url)
+
+      # keep file:// scheme if it was used originally
+      scheme = parsed["scheme"] || ""
+      scheme = "dir" if scheme.downcase != "file"
+
       parsed = {
-        "scheme" => "dir",
+        "scheme" => scheme,
         "path"   => Convert.to_string(UI.QueryWidget(Id(:dir), :Value))
       }
 
@@ -868,7 +882,7 @@ module Yast
     def IsoStore(key, event)
       event = deep_copy(event)
       parsed = {
-        "scheme" => "file",
+        "scheme" => "iso",
         "path"   => Convert.to_string(UI.QueryWidget(Id(:dir), :Value))
       }
 
@@ -1815,6 +1829,9 @@ module Yast
             return false
           end
         end
+      else
+        url = UI.QueryWidget(Id(:complete_url), :Value)
+        return valid_scheme?(url)
       end
 
       true
@@ -2240,7 +2257,7 @@ module Yast
         elsif selected == :local_dir
           @_url = "dir://"
         elsif selected == :local_iso
-          @_url = "file://"
+          @_url = "iso://"
         elsif selected == :slp
           @_url = "slp://"
         elsif selected == :comm_repos
@@ -2279,9 +2296,9 @@ module Yast
         current = :hd
       elsif @_url == "usb://"
         current = :usb
-      elsif @_url == "dir://"
+      elsif @_url == "dir://" || @_url == "file://"
         current = :local_dir
-      elsif @_url == "file://"
+      elsif @_url == "iso://"
         current = :local_iso
       elsif @_url == "slp://"
         current = :slp
@@ -2401,7 +2418,8 @@ module Yast
           "hd"           => DiskWidget(),
           "usb"          => USBWidget(),
           "dir"          => DirWidget(),
-          "file"         => IsoWidget(),
+          "file"         => DirWidget(),
+          "iso"          => IsoWidget(),
           "http"         => ServerWidget(),
           "https"        => ServerWidget(),
           "ftp"          => ServerWidget(),
@@ -2623,6 +2641,16 @@ module Yast
     # @return [Boolean] whether to abort
     def confirm_abort?
       (Stage.initial ? Popup.ConfirmAbort(:painless) : Popup.ReallyAbort(SourceManager.Modified()))
+    end
+
+    def valid_scheme?(url)
+      scheme = URL.Parse(url)["scheme"] || ""
+      scheme.downcase!
+      ret = VALID_URL_SCHEMES.include?(scheme)
+
+      Report.Error(_("URL scheme '%s' is not valid.") % scheme) unless ret
+
+      ret
     end
 
     publish :function => :SetURL, :type => "void (string)"

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,7 @@
 TESTS = \
   addon_product_test.rb \
   packages_test.rb \
+  source_dialogs_test.rb \
   space_calculation_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/test/source_dialogs_test.rb
+++ b/test/source_dialogs_test.rb
@@ -1,0 +1,29 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+Yast.import "SourceDialogs"
+
+describe Yast::SourceDialogs do
+  describe "#valid_scheme?" do
+
+    it "returns true for 'https://' URL" do
+      expect(Yast::SourceDialogs.valid_scheme?("https://")).to eq(true)
+    end
+
+    it "returns false for empty URL and reports error" do
+      expect(Yast::Report).to receive(:Error)
+      expect(Yast::SourceDialogs.valid_scheme?("")).to eq(false)
+    end
+
+    it "returns false for 'foo://' URL and reports error" do
+      expect(Yast::Report).to receive(:Error)
+      expect(Yast::SourceDialogs.valid_scheme?("foo://")).to eq(false)
+    end
+
+    it "returns false for 'foo' URL and reports error" do
+      expect(Yast::Report).to receive(:Error)
+      expect(Yast::SourceDialogs.valid_scheme?("foo")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
- Treat `file://` scheme as `dir://`, it's the same for libzypp (just keep the scheme when editing)
- Validate scheme for a manually entered URL
- Display `/` path if path is empty (for `file` and `dir` scheme)

See https://bugzilla.suse.com/show_bug.cgi?id=869399