### PR TITLE
Use InstLan instead of InstNetworkSetup (bnc#911132)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  9 17:41:43 UTC 2015 - ancor@suse.com
+
+- Fixed the network configuration during upgrade (bnc#911132)
+- 3.1.52.1
+
+-------------------------------------------------------------------
 Thu Oct 16 08:54:15 UTC 2014 - lslezak@suse.cz
 
 - fixed crash when using custom license in firstboot workflow

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.52
+Version:        3.1.52.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_productsources.rb
+++ b/src/clients/inst_productsources.rb
@@ -316,8 +316,11 @@ module Yast
         end
 
         Builtins.y2milestone("User wants to setup the network")
-        # Call network-setup client
-        netret = WFM.call("inst_network_setup")
+        # Call InstLan client
+        netret = WFM.call(
+          "inst_lan",
+          [GetInstArgs.argmap.merge({"skip_detection" => true})]
+        )
 
         if netret == :abort
           Builtins.y2milestone("Aborting the network setup")


### PR DESCRIPTION
Tested on real hardware.

I have a question. This affects the installation process, thus a maintenance update would not be enough. Do we release DUDs, updated ISOs or something similar for openSUSE? I'll create a maintenance request anyways but...