### PR TITLE
Process "workgroup" parameter in URL properly (bnc#784978)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 11 21:00:06 UTC 2015 - lslezak@suse.cz
+
+- process "workgroup" parameter in URL properly (bnc#784978)
+- 3.1.62
+
+-------------------------------------------------------------------
 Mon Feb  9 17:41:43 UTC 2015 - ancor@suse.com
 
 - Fixed the network configuration during upgrade (bnc#911132)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.61
+Version:        3.1.62
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/source_dialogs_test.rb
+++ b/test/source_dialogs_test.rb
@@ -5,25 +5,58 @@ require_relative "./test_helper"
 Yast.import "SourceDialogs"
 
 describe Yast::SourceDialogs do
+  subject { Yast::SourceDialogs }
+
   describe "#valid_scheme?" do
 
     it "returns true for 'https://' URL" do
-      expect(Yast::SourceDialogs.valid_scheme?("https://")).to eq(true)
+      expect(subject.valid_scheme?("https://")).to eq(true)
     end
 
     it "returns false for empty URL and reports error" do
       expect(Yast::Report).to receive(:Error)
-      expect(Yast::SourceDialogs.valid_scheme?("")).to eq(false)
+      expect(subject.valid_scheme?("")).to eq(false)
     end
 
     it "returns false for 'foo://' URL and reports error" do
       expect(Yast::Report).to receive(:Error)
-      expect(Yast::SourceDialogs.valid_scheme?("foo://")).to eq(false)
+      expect(subject.valid_scheme?("foo://")).to eq(false)
     end
 
     it "returns false for 'foo' URL and reports error" do
       expect(Yast::Report).to receive(:Error)
-      expect(Yast::SourceDialogs.valid_scheme?("foo")).to eq(false)
+      expect(subject.valid_scheme?("foo")).to eq(false)
+    end
+  end
+
+  describe "#PreprocessISOURL" do
+    it "keeps additional URL parameter (workgroup)" do
+      url = "iso:///?iso=openSUSE-12.2-DVD-i586.iso&workgroup=WORKGROUP&url=" \
+        "smb://USERNAME:PASSWORD@192.168.1.66/install/images"
+      converted = "smb://USERNAME:PASSWORD@192.168.1.66/install/images/" \
+        "openSUSE-12.2-DVD-i586.iso?workgroup=WORKGROUP"
+
+      expect(subject.PreprocessISOURL(url)).to eq(converted)
+    end
+
+    it "handles escaped URL parameter" do
+      url = "iso:///?workgroup=WORKGROUP&iso=openSUSE-12.2-DVD-i586.iso&url=" \
+        "smb%3A%2F%2FUSERNAME%3APASSWORD%40192.168.1.66%2Finstall%2Fimages"
+      converted = "smb://USERNAME:PASSWORD@192.168.1.66/install/images/" \
+        "openSUSE-12.2-DVD-i586.iso?workgroup=WORKGROUP"
+
+      expect(subject.PreprocessISOURL(url)).to eq(converted)
+    end
+  end
+
+  describe "#PostprocessISOURL" do
+    it "keeps additional URL parameter (workgroup)" do
+      converted = "smb://USERNAME:PASSWORD@192.168.1.66/install/images/" \
+        "openSUSE-12.2-DVD-i586.iso?workgroup=WORKGROUP"
+      url = "iso:///?workgroup=WORKGROUP&iso=openSUSE-12.2-DVD-i586.iso&url=" \
+        "smb%3A%2F%2FUSERNAME%3APASSWORD%40192.168.1.66%2Finstall%2Fimages"
+
+      expect(subject.PostprocessISOURL(converted)).to eq(url)
     end
   end
 end


### PR DESCRIPTION
- Fully parse the URL when peocessing an ISO URL, simple splitting by `&url=` substring does not work reliably.
- Use `URI` Ruby module for parsing the URL
- 3.1.62