### PR TITLE
removed obsolete patch download callbacks

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  4 15:15:26 UTC 2015 - lslezak@suse.cz
+
+- removed obsolete patch download callbacks
+- 3.1.63
+
+-------------------------------------------------------------------
 Wed Feb 11 21:00:06 UTC 2015 - lslezak@suse.cz
 
 - process "workgroup" parameter in URL properly (bnc#784978)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.62
+Version:        3.1.63
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -653,11 +653,6 @@ module Yast
       Pkg.CallbackProblemDeltaApply(nil)
       Pkg.CallbackFinishDeltaApply(nil)
 
-      Pkg.CallbackStartPatchDownload(nil)
-      Pkg.CallbackProgressPatchDownload(nil)
-      Pkg.CallbackProblemPatchDownload(nil)
-      Pkg.CallbackFinishPatchDownload(nil)
-
       Pkg.CallbackScriptStart(nil)
       Pkg.CallbackScriptProgress(nil)
       Pkg.CallbackScriptProblem(nil)


### PR DESCRIPTION
The callbacks are not used anymore, the functions are empty and nothing (see https://github.com/yast/yast-pkg-bindings/pull/37/files#diff-1011952c6a9106aee70878d145bfae66).

- 3.1.63