### PR TITLE
Force installation of libyui-qt for graphical autoinstallation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 23 12:01:31 UTC 2015 - ancor@suse.com
+
+- Ensure libyui-qt is installed when using autoyast in graphical
+  mode (bnc#923901)
+- 3.1.68
+
+-------------------------------------------------------------------
 Fri Apr 10 14:10:39 UTC 2015 - lslezak@suse.cz
 
 - register addons from media (FATE#318505)

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,9 +1,14 @@
 -------------------------------------------------------------------
+Thu May  7 14:02:11 UTC 2015 - igonzalezsosa@suse.com
+
+- Packages module uses tags instead of package names (bnc#923901)
+- 3.1.68
+
+-------------------------------------------------------------------
 Thu Apr 23 12:01:31 UTC 2015 - ancor@suse.com
 
 - Ensure libyui-qt is installed when using autoyast in graphical
   mode (bnc#923901)
-- 3.1.68
 
 -------------------------------------------------------------------
 Fri Apr 10 14:10:39 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.67
+Version:        3.1.68
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2658,7 +2658,7 @@ module Yast
       providers = Pkg.PkgQueryProvides(tag).select { |provide| provide[1] != :NONE }
       names = providers.map(&:first)
       if names.size > 1
-        log.info "More than one provider was found for '#{tag}': "\
+        log.warn "More than one provider was found for '#{tag}': "\
           "#{names.sort.join(', ')}."
       end
       names.first

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2657,11 +2657,12 @@ module Yast
     def find_provider(tag)
       providers = Pkg.PkgQueryProvides(tag).select { |provide| provide[1] != :NONE }
       names = providers.map(&:first)
+      provider = names.include?(tag) ? tag : names.sort.first
       if names.size > 1
         log.warn "More than one provider was found for '#{tag}': "\
-          "#{names.sort.join(', ')}."
+          "#{names.join(', ')}. Selecting '#{provider}'."
       end
-      names.first
+      provider
     end
 
     publish :variable => :install_sources, :type => "boolean"

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2625,11 +2625,11 @@ module Yast
       end
     end
 
-    # Search providers for a list of tags
+    # Search for providers for a list of tags
     #
     # The use case of this method is to convert and array of tags into an array
     # of packages. If a tag does not have a provider, then the tag is included
-    # in the array and an error will be logged.
+    # in the array.
     #
     # @param tags [Array<String>] List of tags (ie. package names) to search for.
     # @return     [Array<String>] List contaning a package for each tag.
@@ -2648,26 +2648,21 @@ module Yast
 
     # Search a provider for a tag
     #
-    # If a provider is installed yet, that one is preferred.
+    # If a provider is not found, an error will be logged.
     #
     # @param tag [String]     Tag to search a package for.
     # @return    [String,nil] Name of the package which provides that tag.
     #                         It returns nil if no provider is found.
     # @see find_providers
     def find_provider(tag)
-      providers = Pkg.PkgQueryProvides(tag).select { |pr| pr[1] != :NONE }
-      installed = providers.find { |pr| pr[1] == :INST || pr[1] == :BOTH }
-      if installed
-        installed.first
-      else
-        names = providers.map(&:first)
-        provider = names.include?(tag) ? tag : names.sort.first
-        if names.size > 1
-          log.warn "More than one provider was found for '#{tag}': "\
-            "#{names.join(', ')}. Selecting '#{provider}'."
-        end
-        provider
+      providers = Pkg.PkgQueryProvides(tag).select { |provide| provide[1] != :NONE }
+      names = providers.map(&:first)
+      provider = names.include?(tag) ? tag : names.sort.first
+      if names.size > 1
+        log.warn "More than one provider was found for '#{tag}': "\
+          "#{names.join(', ')}. Selecting '#{provider}'."
       end
+      provider
     end
 
     publish :variable => :install_sources, :type => "boolean"

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -943,20 +943,20 @@ module Yast
     # Compute special packages
     # @return [Array](string)
     def modePackages
-      packages = []
+      tags = []
+      tags << "sbl" if Linuxrc.braille
+      # ssh installation
+      if Linuxrc.usessh
+        # "ip" tool is needed by the YaST2.ssh start script (bnc#920175)
+        tags.concat(["openssh", "iproute2"])
+      end
 
+      packages = find_providers(tags)
       packages.concat(vnc_packages) if Linuxrc.vnc
       #this means we have a remote X server
       packages.concat(remote_x11_packages) if Linuxrc.display_ip
-      packages << "sbl" if Linuxrc.braille
-
-      # ssh installation
-      packages << "openssh" if Linuxrc.usessh
-      # "ip" tool is needed by the YaST2.ssh start script (bnc#920175)
-      packages << "iproute2" if Linuxrc.usessh
 
       Builtins.y2milestone("Installation mode packages: %1", packages)
-
       packages
     end
 

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2625,11 +2625,11 @@ module Yast
       end
     end
 
-    # Search for providers for a list of tags
+    # Search providers for a list of tags
     #
     # The use case of this method is to convert and array of tags into an array
     # of packages. If a tag does not have a provider, then the tag is included
-    # in the array.
+    # in the array and an error will be logged.
     #
     # @param tags [Array<String>] List of tags (ie. package names) to search for.
     # @return     [Array<String>] List contaning a package for each tag.
@@ -2648,21 +2648,26 @@ module Yast
 
     # Search a provider for a tag
     #
-    # If a provider is not found, an error will be logged.
+    # If a provider is installed yet, that one is preferred.
     #
     # @param tag [String]     Tag to search a package for.
     # @return    [String,nil] Name of the package which provides that tag.
     #                         It returns nil if no provider is found.
     # @see find_providers
     def find_provider(tag)
-      providers = Pkg.PkgQueryProvides(tag).select { |provide| provide[1] != :NONE }
-      names = providers.map(&:first)
-      provider = names.include?(tag) ? tag : names.sort.first
-      if names.size > 1
-        log.warn "More than one provider was found for '#{tag}': "\
-          "#{names.join(', ')}. Selecting '#{provider}'."
+      providers = Pkg.PkgQueryProvides(tag).select { |pr| pr[1] != :NONE }
+      installed = providers.find { |pr| pr[1] == :INST || pr[1] == :BOTH }
+      if installed
+        installed.first
+      else
+        names = providers.map(&:first)
+        provider = names.include?(tag) ? tag : names.sort.first
+        if names.size > 1
+          log.warn "More than one provider was found for '#{tag}': "\
+            "#{names.join(', ')}. Selecting '#{provider}'."
+        end
+        provider
       end
-      provider
     end
 
     publish :variable => :install_sources, :type => "boolean"

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -18,6 +18,10 @@ module Yast
     RESOLVABLE_TYPES = [:product, :patch, :package, :pattern, :language]
     # Minimum set of packages required to enable VNC server
     VNC_BASE_PACKAGES = ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts", "xinetd"]
+    # Additional packages needed to run second stage in graphical mode
+    # Use exact package name (i.e. libyui-qt6 instead of libyui-qt) to prevent
+    # the UI from asking for confirmation
+    AUTOYAST_X11_PACKAGES = ["libyui-qt6", "yast2-x11"]
     # Default window manager for VNC if none is installed
     DEFAULT_WM = "icewm"
     # Minimum set of packages required for installation with remote X11 server
@@ -2559,7 +2563,7 @@ module Yast
       # At least one windowmanager must be installed (#427044)
       # If none is there, use a fallback
       packages << DEFAULT_WM unless has_window_manager?
-      packages << "yast2-x11" if Mode.autoinst
+      packages.concat(AUTOYAST_X11_PACKAGES) if Mode.autoinst
       packages
     end
 
@@ -2569,7 +2573,7 @@ module Yast
     # @return [Array<String>] package list
     def remote_x11_packages
       packages = REMOTE_X11_BASE_PACKAGES.dup
-      packages << "yast2-x11" if Mode.autoinst
+      packages.concat(AUTOYAST_X11_PACKAGES) if Mode.autoinst
       packages
     end
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -509,6 +509,22 @@ describe Yast::Packages do
         expect(subject.vnc_packages).to include(package)
       end
     end
+
+    context "when more than one package provides a tag" do
+      let(:package) { 'multi-provider-pkg' }
+
+      before do
+        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [package])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :CAND, :NONE]])
+      end
+
+      it "includes the first provider and logs a message" do
+        expect(Yast::Package.log).to receive(:info).
+          with("More than one provider was found for '#{package}': prov1, prov2.")
+        expect(subject.vnc_packages).to include('prov1')
+      end
+    end
   end
 
   describe "#remote_x11_packages" do
@@ -586,6 +602,21 @@ describe Yast::Packages do
       end
     end
 
+    context "when more than one package provides a tag" do
+      let(:package) { 'multi-provider-pkg' }
+
+      before do
+        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [package])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :CAND, :NONE]])
+      end
+
+      it "includes the first provider and logs a message" do
+        expect(Yast::Package.log).to receive(:info).
+          with("More than one provider was found for '#{package}': prov1, prov2.")
+        expect(subject.remote_x11_packages).to include('prov1')
+      end
+    end
   end
 
   describe "#modePackages" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -510,20 +510,6 @@ describe Yast::Packages do
       end
     end
 
-    context "when a provider is installed yet" do
-      let(:package) { 'package' }
-
-      before do
-        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [package])
-        allow(Yast::Pkg).to receive(:PkgQueryProvides).
-          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :INST, :INST]])
-      end
-
-      it "selects the installed package" do
-        expect(subject.vnc_packages).to include('prov2')
-      end
-    end
-
     context "when more than one package provides a tag" do
       let(:package) { 'multi-provider-pkg' }
 
@@ -629,20 +615,6 @@ describe Yast::Packages do
       it "includes the tag name in the packages list but logs an error" do
         expect(Yast::Packages.log).to receive(:error).with("Provider not found for '#{package}'")
         expect(subject.remote_x11_packages).to include(package)
-      end
-    end
-
-    context "when a provider is installed yet" do
-      let(:package) { 'package' }
-
-      before do
-        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [package])
-        allow(Yast::Pkg).to receive(:PkgQueryProvides).
-          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :INST, :INST]])
-      end
-
-      it "selects the installed package" do
-        expect(subject.remote_x11_packages).to include('prov2')
       end
     end
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -510,6 +510,20 @@ describe Yast::Packages do
       end
     end
 
+    context "when a provider is installed yet" do
+      let(:package) { 'package' }
+
+      before do
+        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [package])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :INST, :INST]])
+      end
+
+      it "selects the installed package" do
+        expect(subject.vnc_packages).to include('prov2')
+      end
+    end
+
     context "when more than one package provides a tag" do
       let(:package) { 'multi-provider-pkg' }
 
@@ -615,6 +629,20 @@ describe Yast::Packages do
       it "includes the tag name in the packages list but logs an error" do
         expect(Yast::Packages.log).to receive(:error).with("Provider not found for '#{package}'")
         expect(subject.remote_x11_packages).to include(package)
+      end
+    end
+
+    context "when a provider is installed yet" do
+      let(:package) { 'package' }
+
+      before do
+        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [package])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :INST, :INST]])
+      end
+
+      it "selects the installed package" do
+        expect(subject.remote_x11_packages).to include('prov2')
       end
     end
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -47,7 +47,7 @@ describe Yast::Packages do
   describe "#kernelCmdLinePackages" do
     before(:each) do
       # default value
-      Yast::Product.stub(:Product).and_return(nil)
+      allow(Yast::Product).to receive(:Product).and_return nil
     end
 
     after(:each) do
@@ -79,7 +79,7 @@ describe Yast::Packages do
       context "and running on a Dell system" do
         it "returns biosdevname within the list of packages" do
           # 0 means `grep` succeeded
-          Yast::SCR.stub(:Execute).with(SCR_BASH_PATH, CHECK_FOR_DELL_SYSTEM).and_return(0)
+          allow(Yast::SCR).to receive(:Execute).with(SCR_BASH_PATH, CHECK_FOR_DELL_SYSTEM).and_return(0)
           expect(Yast::Packages.kernelCmdLinePackages.include?("biosdevname")).to eq(true)
         end
       end
@@ -87,7 +87,7 @@ describe Yast::Packages do
       context "and running on a non-Dell system" do
         it "does not return biosdevname within the list of packages" do
           # 1 means `grep` has not succeeded
-          Yast::SCR.stub(:Execute).with(SCR_BASH_PATH, CHECK_FOR_DELL_SYSTEM).and_return(1)
+          allow(Yast::SCR).to receive(:Execute).with(SCR_BASH_PATH, CHECK_FOR_DELL_SYSTEM).and_return(1)
           expect(Yast::Packages.kernelCmdLinePackages.include?("biosdevname")).to eq(false)
         end
       end
@@ -98,20 +98,20 @@ describe Yast::Packages do
   describe "#default_patterns" do
     context "software->default_patterns is not defined in control file" do
       it "returns empty list" do
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "default_patterns").and_return("")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "default_patterns").and_return("")
         expect(Yast::Packages.default_patterns).to be_empty
       end
     end
 
     context "software->default_patterns is filled with list of patterns" do
       it "returns list of patterns" do
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "default_patterns").and_return("a b c d")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "default_patterns").and_return("a b c d")
         expect(Yast::Packages.default_patterns).to eq(["a", "b", "c", "d"])
 
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "default_patterns").and_return("  a    b\t c d\t  ")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "default_patterns").and_return("  a    b\t c d\t  ")
         expect(Yast::Packages.default_patterns).to eq(["a", "b", "c", "d"])
 
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "default_patterns").and_return("  a b \n c\nd  ")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "default_patterns").and_return("  a b \n c\nd  ")
         expect(Yast::Packages.default_patterns).to eq(["a", "b", "c", "d"])
       end
     end
@@ -120,20 +120,20 @@ describe Yast::Packages do
   describe "#optional_default_patterns" do
     context "software->optional_default_patterns is not defined in control file" do
       it "returns empty list" do
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "optional_default_patterns").and_return("")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "optional_default_patterns").and_return("")
         expect(Yast::Packages.optional_default_patterns).to be_empty
       end
     end
 
     context "software->optional_default_patterns is filled with list of patterns" do
       it "returns list of patterns" do
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "optional_default_patterns").and_return("a b c d")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "optional_default_patterns").and_return("a b c d")
         expect(Yast::Packages.optional_default_patterns).to eq(["a", "b", "c", "d"])
 
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "optional_default_patterns").and_return("  a    b\t c d\t  ")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "optional_default_patterns").and_return("  a    b\t c d\t  ")
         expect(Yast::Packages.optional_default_patterns).to eq(["a", "b", "c", "d"])
 
-        Yast::ProductFeatures.stub(:GetStringFeature).with("software", "optional_default_patterns").and_return("  a b \n c\nd  ")
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature).with("software", "optional_default_patterns").and_return("  a b \n c\nd  ")
         expect(Yast::Packages.optional_default_patterns).to eq(["a", "b", "c", "d"])
       end
     end
@@ -154,8 +154,8 @@ describe Yast::Packages do
     context "if this is the initial run or it is being reinitialized" do
       context "and patterns are not unselected by user" do
         it "selects patterns for installation" do
-          Yast::Packages.stub(:patterns_to_install).and_return(["p1", "p2", "p3"])
-          Yast::Pkg.stub(:ResolvableProperties).and_return(
+          allow(Yast::Packages).to receive(:patterns_to_install).and_return(["p1", "p2", "p3"])
+          allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
             [pattern({ "name" => "p1" })],
             [pattern({ "name" => "p2" })],
             [pattern({ "name" => "p3" })]
@@ -168,8 +168,8 @@ describe Yast::Packages do
 
       context "and some patterns are already unselected by user" do
         it "selects patterns for installation that were not unselected by user already" do
-          Yast::Packages.stub(:patterns_to_install).and_return(["p1", "p2", "p3"])
-          Yast::Pkg.stub(:ResolvableProperties).and_return(
+          allow(Yast::Packages).to receive(:patterns_to_install).and_return(["p1", "p2", "p3"])
+          allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
             [pattern({ "name" => "p1", "transact_by" => :user })],
             [pattern({ "name" => "p2", "transact_by" => :user })],
             [pattern({ "name" => "p3" })]
@@ -185,8 +185,8 @@ describe Yast::Packages do
 
     context "if this is a subsequent run" do
       it "re-selects all patterns already selected for installation" do
-        Yast::Packages.stub(:patterns_to_install).and_return(["p1", "p2", "p3"])
-        Yast::Pkg.stub(:ResolvableProperties).and_return(
+        allow(Yast::Packages).to receive(:patterns_to_install).and_return(["p1", "p2", "p3"])
+        allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
           [pattern({ "name" => "p1", "transact_by" => :user, "status" => :selected })],
           [pattern({ "name" => "p2", "transact_by" => :user, "status" => :selected })],
           [pattern({ "name" => "p3" })]
@@ -201,9 +201,9 @@ describe Yast::Packages do
     it "reports an error if pattern is not found" do
       default_patterns = ["p1", "p2", "p3"]
 
-      Yast::Packages.stub(:patterns_to_install).and_return(default_patterns)
-      Yast::Pkg.stub(:ResolvableProperties).and_return([])
-      Yast::Report.stub(:Error).and_return(nil)
+      allow(Yast::Packages).to receive(:patterns_to_install).and_return(default_patterns)
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([])
+      allow(Yast::Report).to receive(:Error).and_return(nil)
 
       # Called twice with reselect=true/false
       Yast::Packages.SelectSystemPatterns(true)
@@ -216,31 +216,34 @@ describe Yast::Packages do
       optional_default_patterns = ["p3", "p4"]
 
       # No default patterns, all are optional
-      Yast::Packages.stub(:default_patterns).and_return([])
-      Yast::Packages.stub(:optional_default_patterns).and_return(optional_default_patterns)
-      Yast::Packages.stub(:ComputeSystemPatternList).and_return([])
-      Yast::Pkg.stub(:ResolvableProperties).and_return([])
+      allow(Yast::Packages).to receive(:default_patterns).and_return([])
+      allow(Yast::Packages).to receive(:optional_default_patterns).and_return(optional_default_patterns)
+      allow(Yast::Packages).to receive(:ComputeSystemPatternList).and_return([])
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([])
 
       expect(Yast::Report).not_to receive(:Error)
 
-      expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
-        expect(msg).to match(/optional pattern p[3-4] does not exist/i).exactly(4).times
-      end.at_least(4).times.and_call_original
+      logged_errors = 0
+      allow(Yast::Y2Logger.instance).to receive(:info) do |msg|
+        logged_errors += 1 if msg =~ /optional pattern p[3-4] does not exist/i
+      end
 
       # Called twice with reselect=true/false
       Yast::Packages.SelectSystemPatterns(true)
       Yast::Packages.SelectSystemPatterns(false)
+
+      expect(logged_errors).to eq 4
     end
   end
 
   describe "#log_software_selection" do
     it "logs all currently changed resolvables set by user or application (excluding solver)" do
-      Yast::Pkg.stub(:ResolvableProperties).and_return([])
-      Yast::Pkg.stub(:ResolvableProperties).with("", :product, "").and_return(PRODUCTS_FROM_ZYPP.dup)
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([])
+      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "").and_return(PRODUCTS_FROM_ZYPP.dup)
 
       expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
         expect(msg).to match(/(transaction status [begin|end]|(locked)?resolvables of type .* set by .*|:name=>.*:version=>)/i)
-      end.exactly(8).times.and_call_original
+      end.exactly(8).times
 
       expect(Yast::Packages.log_software_selection).to be_nil
     end
@@ -384,6 +387,7 @@ describe Yast::Packages do
     let(:packages) { Yast::Packages.vnc_packages.sort.uniq }
     let(:base_packages) { ["xinetd", "xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"] }
     let(:base_packages_and_wm) { ["icewm"] + base_packages }
+    let(:autoyast_x11_packages) { ["libyui-qt6", "yast2-x11"] }
 
     context "during installation" do
       before do
@@ -423,8 +427,9 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsSelected).and_return true
         end
 
-        it "includes xinetd, xorg and yast2-x11" do
-          expect(packages).to eq(base_packages + ["yast2-x11"])
+        it "includes xinetd, xorg and autoyast X11 packages" do
+          expected = (base_packages + autoyast_x11_packages).sort
+          expect(packages).to eq(expected)
         end
       end
 
@@ -434,7 +439,8 @@ describe Yast::Packages do
         end
 
         it "includes xinetd, xorg and icewm" do
-          expect(packages).to eq(base_packages_and_wm + ["yast2-x11"])
+          expected = (base_packages_and_wm + autoyast_x11_packages).sort
+          expect(packages).to eq(expected)
         end
       end
     end
@@ -497,6 +503,7 @@ describe Yast::Packages do
       let(:xorg_icewm_and_ssh) {
         ["icewm", "iproute2", "openssh", "xorg-x11-fonts", "xorg-x11-server"]
       }
+      let(:autoyast_x11_packages) { ["libyui-qt6", "yast2-x11"] }
 
       context "during installation" do
         let(:mode) { "installation" }
@@ -509,8 +516,9 @@ describe Yast::Packages do
       context "during autoinstallation" do
         let(:mode) { "autoinstallation" }
 
-        it "includes xorg, icewm, openssh, iproute2 and yast2-x11" do
-          expect(packages).to eq(xorg_icewm_and_ssh + ["yast2-x11"])
+        it "includes xorg, icewm, openssh, iproute2 and autoinstall packages" do
+          expected = (xorg_icewm_and_ssh + autoyast_x11_packages).sort
+          expect(packages).to eq(expected)
         end
       end
     end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -516,13 +516,29 @@ describe Yast::Packages do
       before do
         stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [package])
         allow(Yast::Pkg).to receive(:PkgQueryProvides).
-          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :CAND, :NONE]])
+          with(package).and_return(providers.map { |n| [n, :CAND, :NONE] })
       end
 
-      it "includes the first provider and logs a message" do
-        expect(Yast::Package.log).to receive(:info).
-          with("More than one provider was found for '#{package}': prov1, prov2.")
-        expect(subject.vnc_packages).to include('prov1')
+      context "when a package named after the tag is found" do
+        let(:providers) { ['prov1', package] }
+
+        it "includes the tag as package name and logs a message" do
+          expect(Yast::Package.log).to receive(:warn).
+            with("More than one provider was found for '#{package}': " \
+                 "prov1, #{package}. Selecting '#{package}'.")
+          expect(subject.vnc_packages).to include(package)
+        end
+      end
+
+      context "when a package named after the tag is not found" do
+        let(:providers) { ['prov2', 'prov1'] }
+
+        it "includes the first provider (according to alphabetic order) and logs a message" do
+          expect(Yast::Package.log).to receive(:warn).
+            with("More than one provider was found for '#{package}': " \
+                 "prov2, prov1. Selecting 'prov1'.")
+          expect(subject.vnc_packages).to include('prov1')
+        end
       end
     end
   end
@@ -608,13 +624,29 @@ describe Yast::Packages do
       before do
         stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [package])
         allow(Yast::Pkg).to receive(:PkgQueryProvides).
-          with(package).and_return([['prov1', :CAND, :NONE], ['prov2', :CAND, :NONE]])
+          with(package).and_return(providers.map { |n| [n, :CAND, :NONE] })
       end
 
-      it "includes the first provider and logs a message" do
-        expect(Yast::Package.log).to receive(:info).
-          with("More than one provider was found for '#{package}': prov1, prov2.")
-        expect(subject.remote_x11_packages).to include('prov1')
+      context "when a package named after the tag is found" do
+        let(:providers) { ['prov1', package] }
+
+        it "includes the tag as package name and logs a message" do
+          expect(Yast::Package.log).to receive(:warn).
+            with("More than one provider was found for '#{package}': " \
+                 "prov1, #{package}. Selecting '#{package}'.")
+          expect(subject.remote_x11_packages).to include(package)
+        end
+      end
+
+      context "when a package named after the tag is not found" do
+        let(:providers) { ['prov2', 'prov1'] }
+
+        it "includes the first provider (according to alphabetic order) and logs a message" do
+          expect(Yast::Package.log).to receive(:warn).
+            with("More than one provider was found for '#{package}': " \
+                 "prov2, prov1. Selecting 'prov1'.")
+          expect(subject.remote_x11_packages).to include('prov1')
+        end
       end
     end
   end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -541,6 +541,52 @@ describe Yast::Packages do
         end
       end
     end
+
+    context "when a package is installed and have also a valid candidate (:BOTH)" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :CAND, :NONE], ['prov2', :BOTH, :INST]] }
+
+      before do
+        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "the yet installed package must be preferred" do
+        expect(subject.vnc_packages).to include('prov2')
+      end
+    end
+
+    context "when a package is installed but a valid candidate exists" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :INST, :INST], ['prov2', :CAND, :NONE]] }
+
+      before do
+        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "the candidate must be preferred" do
+        expect(subject.vnc_packages).to include('prov2')
+      end
+    end
+
+    context "when a package is installed but no valid candidate" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :INST, :INST]] }
+
+      before do
+        stub_const("Yast::PackagesClass::VNC_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "that installed package is ignored and an error is logged" do
+        expect(Yast::Packages.log).to receive(:error).with("Provider not found for '#{tag}'")
+        expect(subject.vnc_packages).to include(tag)
+      end
+    end
   end
 
   describe "#remote_x11_packages" do
@@ -647,6 +693,52 @@ describe Yast::Packages do
                  "prov2, prov1. Selecting 'prov1'.")
           expect(subject.remote_x11_packages).to include('prov1')
         end
+      end
+    end
+
+    context "when a package is installed and have also a valid candidate (:BOTH)" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :CAND, :NONE], ['prov2', :BOTH, :INST]] }
+
+      before do
+        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "the yet installed package must be preferred" do
+        expect(subject.remote_x11_packages).to include('prov2')
+      end
+    end
+
+    context "when a package is installed but a valid candidate exists" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :INST, :INST], ['prov2', :CAND, :NONE]] }
+
+      before do
+        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "the candidate must be preferred" do
+        expect(subject.remote_x11_packages).to include('prov2')
+      end
+    end
+
+    context "when a package is installed but no valid candidate" do
+      let(:tag) { 'some-tag' }
+      let(:providers) { [['prov1', :INST, :INST]] }
+
+      before do
+        stub_const("Yast::PackagesClass::REMOTE_X11_BASE_TAGS", [tag])
+        allow(Yast::Pkg).to receive(:PkgQueryProvides).
+          with(tag).and_return(providers)
+      end
+
+      it "that installed package is ignored and an error is logged" do
+        expect(Yast::Packages.log).to receive(:error).with("Provider not found for '#{tag}'")
+        expect(subject.remote_x11_packages).to include(tag)
       end
     end
   end


### PR DESCRIPTION
The bug should affect VNC and remote X11 autoyast installations with the minimal pattern (that is, graphical autoinstallations but with X11 not selected for installation).

This was, for example, causing yast to start in ncurses during second stage at https://bugzilla.suse.com/show_bug.cgi?id=923901