### PR TITLE
Fixed building a local ISO URL (bnc#919138)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 21:24:46 UTC 2015 - lslezak@suse.cz
+
+- fixed building a local ISO URL (bnc#919138)
+- 3.1.69
+
+-------------------------------------------------------------------
 Thu May  7 14:02:11 UTC 2015 - igonzalezsosa@suse.com
 
 - Packages module uses tags instead of package names (bnc#923901)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.68
+Version:        3.1.69
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -333,6 +333,7 @@ module Yast
       new_url = uri.dup
       new_url.path = File.dirname(uri.path || "")
       new_url.query = nil
+      new_url.scheme = "dir" if uri.scheme.downcase == "iso"
       params["url"] = new_url.to_s
 
       processed = URI("")

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -333,6 +333,9 @@ module Yast
       new_url = uri.dup
       new_url.path = File.dirname(uri.path || "")
       new_url.query = nil
+      # URL scheme in the "url" option must be set to "dir" (or empty)
+      # for a local ISO image (see https://bugzilla.suse.com/show_bug.cgi?id=919138
+      # and https://en.opensuse.org/openSUSE:Libzypp_URIs#ISO_Images )
       new_url.scheme = "dir" if uri.scheme.downcase == "iso"
       params["url"] = new_url.to_s
 

--- a/test/source_dialogs_test.rb
+++ b/test/source_dialogs_test.rb
@@ -58,5 +58,12 @@ describe Yast::SourceDialogs do
 
       expect(subject.PostprocessISOURL(converted)).to eq(url)
     end
+
+    it "uses dir url scheme parameter for local ISO files" do
+      converted = "iso:///install/openSUSE-13.2-DVD-x86_64.iso"
+      url = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall"
+
+      expect(subject.PostprocessISOURL(converted)).to eq(url)
+    end
   end
 end


### PR DESCRIPTION
The `url` parameter for a local ISO URL needs to use `dir` scheme, not `iso`.

E.g. the final URL should be `iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall`, not `iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=iso%3A%2Finstall`

- 3.1.69

Fixes https://bugzilla.suse.com/show_bug.cgi?id=919138.