### PR TITLE
Proper fix for a float remaining time (bnc#882240)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 11 14:58:58 UTC 2015 - lslezak@suse.cz
+
+- proper fix for a float remaining time (bnc#882240)
+- 3.1.71
+
+-------------------------------------------------------------------
 Thu Jun  4 14:21:22 UTC 2015 - lslezak@suse.cz
 
 - use the full URL (incl. the password) when editing a repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.70
+Version:        3.1.71
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -681,7 +681,7 @@ module Yast
           remaining_time = remaining_size
 
           if remaining_size > 0
-            remaining_time = remaining_size.to_f / @bytes_per_second
+            remaining_time = (remaining_size.to_f / @bytes_per_second).round
 
             if remaining_time < MIN_TIME_PER_CD
               # It takes at least this long for the CD drive to spin up and
@@ -693,12 +693,6 @@ module Yast
               # cut off the predicted time at a reasonable maximum.
               remaining_time = MAX_TIME_PER_CD
             end
-          end
-
-          if remaining_time.is_a?(Float)
-            log.warn "Float time appeared: #{remaining_time}"
-            remaining_time = remaining_time.round
-            log.warn "Converted to integer: #{remaining_time}"
           end
 
           remaining_times_list << remaining_time


### PR DESCRIPTION
- 3.1.71

The workaround has been replaced by a proper fix (originally I didn't have time for debugging, I just placed a sanity check).