### PR TITLE
Enabled YARD docs for rubydoc.info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ tmp.*
 /test-driver
 /testsuite/site.bak
 /test/*.trs
+/.yardoc/

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--no-private
+--markup markdown
+--protected
+src/**/*.rb
+--readme README.md
+--output-dir ./doc/autodocs

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
-ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+srcdir = File.expand_path("../../src", __FILE__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
In https://github.com/yast/yast-kdump/pull/30 we use an API from this package, so it should have documentation.