### PR TITLE
Do not show a warning for the removed SMT product (bsc#942639)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug 28 13:39:23 UTC 2015 - lslezak@suse.cz
+
+- Do not show a warning for the removed SMT product when upgrading
+  from SLES11 + SMT (the SMT functionality has been integrated into
+  SLES12) (bsc#942639)
+- 3.1.77
+
+-------------------------------------------------------------------
 Tue Jul 21 08:32:41 UTC 2015 - jreidinger@suse.com
 
 - fix crash when adding addon on DVD (bnc#938786)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.76
+Version:        3.1.77
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -138,7 +138,9 @@ module Yast
         # SLED or Workstation extension
         "SUSE_SLED"  => [ "SLED", "sle-we" ],
         "sle-haegeo" => [ "sle-ha-geo" ],
-        "sle-hae"    => [ "sle-ha" ]
+        "sle-hae"    => [ "sle-ha" ],
+        # SMT is now integrated into the base SLES
+        "sle-smt"    => [ "SLES" ]
       }
 
     end


### PR DESCRIPTION
...when upgrading from SLES11 + SMT

(the SMT functionality has been integrated into SLES12)

- 3.1.77

Details: there is an internal mapping with known product renames, when a replacement is found in the mapping the product removal warning is not displayed.