### PR TITLE
Fixed SLES11 SMT upgrade to SLES12

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 29 10:34:34 UTC 2015 - lslezak@suse.cz
+
+- handle properly the SLES11 SMT upgrade to SLES12 (evaluate all
+  removed products when checking product upgrades) (bsc#946717)
+- 3.1.78
+
+-------------------------------------------------------------------
 Fri Aug 28 13:39:23 UTC 2015 - lslezak@suse.cz
 
 - Do not show a warning for the removed SMT product when upgrading

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.77
+Version:        3.1.78
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2728,7 +2728,7 @@ module Yast
       # map content: old_product => new_product
       updated_products = {}
       installed_products.each do |installed_product|
-        removed = removed_products.find do |removed_product|
+        removed = removed_products.select do |removed_product|
           installed_name = installed_product["name"]
           removed_name = removed_product["name"]
 
@@ -2737,7 +2737,7 @@ module Yast
             AddOnProduct.renamed?(removed_name, installed_name)
         end
 
-        updated_products[removed] = installed_product if removed
+        removed.each { |r| updated_products[r] = installed_product }
       end
 
       updated_products

--- a/test/data/zypp/products_update_smt.yml
+++ b/test/data/zypp/products_update_smt.yml
@@ -1,0 +1,108 @@
+---
+- arch: x86_64
+  category: base
+  description: SUSE Linux Enterprise offers ...
+  display_name: SUSE Linux Enterprise Server 11 SP3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SUSE_SLES
+  on_system_by_user: false
+  product_file: "/mnt/etc/products.d/SUSE_SLES.prod"
+  product_line: sles
+  register_release: ''
+  register_target: sle-11-x86_64
+  register_urls:
+  - http://register.novell.com/
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/11-SP3/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/11-SP3/release-notes-sles.rpm
+  short_name: SLES11_SP3
+  smolt_urls:
+  - http://smolt.novell.com/register.pl
+  source: -1
+  status: :removed
+  summary: SUSE Linux Enterprise Server 11 SP3
+  transact_by: :solver
+  type: base
+  update_urls: []
+  upgrades:
+  - name: SUSE_SLES-SP4-migration
+    notify: true
+    product: SUSE_SLES-SP4-migration
+    repository: ''
+    status: stable
+    summary: SUSE Linux Enterprise Server 11 SP4
+  vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
+  version: 11.3-1.201
+  version_epoch: 
+  version_release: '1.201'
+  version_version: '11.3'
+- arch: x86_64
+  category: addon
+  description: Subscription Management Tool for SUSE Linux Enterprise 11 SP3.
+  display_name: Subscription Management Tool for SUSE Linux Enterprise 11 SP3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-smt
+  on_system_by_user: false
+  product_file: "/mnt/etc/products.d/sle-smt.prod"
+  product_line: smt
+  register_release: ''
+  register_target: sle-11-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLE-SMT/11-SP3/release-notes-smt.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLE-SMT/11-SP3/release-notes-smt.rpm
+  short_name: sle-smt
+  source: -1
+  status: :removed
+  summary: Subscription Management Tool for SUSE Linux Enterprise 11 SP3
+  transact_by: :user
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
+  version: 11.3-1.7
+  version_epoch: 
+  version_release: '1.7'
+  version_version: '11.3'
+- arch: x86_64
+  category: addon
+  description: SUSE Linux Enterprise offers ...
+  display_name: SUSE Linux Enterprise Server 12 SP1 RC1
+  download_size: 0
+  eol: 1730332800
+  flags: []
+  flavor: DVD
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SLES
+  on_system_by_user: false
+  product_file: SLES.prod
+  product_line: ''
+  product_package: sles-release
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP1/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP1/release-notes-sles.rpm
+  short_name: SLES12-SP1
+  source: 0
+  status: :selected
+  summary: SUSE Linux Enterprise Server 12 SP1 RC1
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 12.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12.1'


### PR DESCRIPTION
Fix for https://bugzilla.suse.com/show_bug.cgi?id=946717

The code for finding the product upgrades expected only 1:1 upgrades (one old product upgraded by one new product).

However, in the SMT case there are 2 old products (SLES11 and SMT addon) upgraded to a single product (SLE12-SP1). The SMT addon functionality has been merged into the base SLES12-SP1 so it actually replaces 2 products.

Note: The new `products_update_smt.yml` file was obtained from a dump in `y2log`, it contains the exact product states from a SMT upgrade.