### PR TITLE
repositories - fixed switch between dvd:// and cd:// URL (bsc#947595)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  8 07:43:44 UTC 2015 - lslezak@suse.cz
+
+- repository manager - fixed switch between dvd:// and cd:// URL
+  scheme (bsc#947595)
+- 3.1.81
+
+-------------------------------------------------------------------
 Tue Oct  6 11:36:25 UTC 2015 - ancor@suse.com
 
 - Repository editor can now manage urls with repo variables like

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.80
+Version:        3.1.81
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -814,9 +814,9 @@ module Yast
       # preserve other URL options, e.g. ?devices=/dev/sr0
       # change the URL only when necessary
       if device == :cd && scheme != "cd"
-        @_url = "cd://"
+        @_url = "cd:///"
       elsif device == :dvd && scheme != "dvd"
-        @_url = "dvd://"
+        @_url = "dvd:///"
       end
 
       nil


### PR DESCRIPTION
Libzypp failed with `Url scheme requires path name` for `cd://` or `dvd://` URL, it requires `cd:///` and `dvd:///`.

Tested manually.