### PR TITLE
repository manager - properly close the main window (bsc#950525)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 16 08:21:20 UTC 2015 - lslezak@suse.cz
+
+- repository manager - properly close the main window when aborting
+  after failed initialization to avoid a segfault (bsc#950525)
+- 3.1.82
+
+-------------------------------------------------------------------
 Thu Oct  8 07:43:44 UTC 2015 - lslezak@suse.cz
 
 - repository manager - fixed switch between dvd:// and cd:// URL

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.81
+Version:        3.1.82
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/repositories.rb
+++ b/src/clients/repositories.rb
@@ -1883,7 +1883,10 @@ module Yast
         )
 
         # really continue?
-        return :abort if !cont
+        if !cont
+          Wizard.CloseDialog
+          return :abort
+        end
       end
 
       # read known GPG keys


### PR DESCRIPTION
...when aborting after failed initialization to avoid a segfault

See [bsc#950525](https://bugzilla.suse.com/show_bug.cgi?id=950525)

- 3.1.82