### PR TITLE
Product license nil check

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct 21 14:29:50 UTC 2015 - lslezak@suse.cz
+
+- fixed crash (missing nil check) at ProductLicense.rb when
+  displaying EULA in the firstboot workflow in a Studio image
+  (bsc#951210)
+- 3.1.83
+
+-------------------------------------------------------------------
 Fri Oct 16 08:21:20 UTC 2015 - lslezak@suse.cz
 
 - repository manager - properly close the main window when aborting

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.82
+Version:        3.1.83
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1087,7 +1087,7 @@ module Yast
 
 
     # Ask user to confirm license agreement
-    # @param [Fixnum] src_id integer repository to get the license from.
+    # @param [Fixnum,nil] src_id integer repository to get the license from.
     #   If set to 'nil', the license is considered to belong to a base product
     # @param [String] dir string directory to look for the license in if src_id is nil
     #   and not 1st stage installation
@@ -1145,12 +1145,13 @@ module Yast
 
       licenses_ref = arg_ref(licenses)
 
-      label = Pkg::SourceGeneralData(src_id)["name"]
       title = _("License Agreement")
 
-      if !label.empty?
-        # %s is an extension name, e.g. "SUSE Linux Enterprise Software Development Kit"
-        title = _("%s License Agreement") % label
+      if src_id
+        label = Pkg::SourceGeneralData(src_id)["name"]
+        # TRANSLATORS: %s is an extension name
+        # e.g. "SUSE Linux Enterprise Software Development Kit"
+        title = _("%s License Agreement") % label unless label.empty?
       end
 
       DisplayLicenseDialogWithTitle(
@@ -1163,7 +1164,7 @@ module Yast
       )
       licenses = licenses_ref.value
 
-      update_license_archive_location(src_id)
+      update_license_archive_location(src_id) if src_id
 
       # Display info as a popup if exists
       InstShowInfo.show_info_txt(@info_file) if @info_file != nil

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1148,10 +1148,14 @@ module Yast
       title = _("License Agreement")
 
       if src_id
-        label = Pkg::SourceGeneralData(src_id)["name"]
-        # TRANSLATORS: %s is an extension name
-        # e.g. "SUSE Linux Enterprise Software Development Kit"
-        title = _("%s License Agreement") % label unless label.empty?
+        repo_data = Pkg::SourceGeneralData(src_id)
+
+        if repo_data
+          label = repo_data["name"]
+          # TRANSLATORS: %s is an extension name
+          # e.g. "SUSE Linux Enterprise Software Development Kit"
+          title = _("%s License Agreement") % label unless label.empty?
+        end
       end
 
       DisplayLicenseDialogWithTitle(
@@ -1617,7 +1621,10 @@ module Yast
     # update license location displayed in the dialog
     # @param [Fixnum] src_id integer repository to get the license from.
     def update_license_archive_location(src_id)
-      src_url = Pkg::SourceGeneralData(src_id)["url"]
+      repo_data = Pkg::SourceGeneralData(src_id)
+      return unless repo_data
+
+      src_url = repo_data["url"]
       if location_is_url?(src_url) && UI.WidgetExists(:printing_hint)
         lic_url = File.join(src_url, @license_file_print)
         UI.ReplaceWidget(:printing_hint, Label(license_download_label(lic_url)))


### PR DESCRIPTION
This is a fix for a P1 bug [bsc#951210](https://bugzilla.suse.com/show_bug.cgi?id=951210).

- Only the firstboot sequence is affected, in a standard installation/upgrade the `src_id` is defined (it refers to the installation repository) and is not `nil`.
