### PR TITLE
Do not check the free space on a CD/DVD mounted medium (bsc#952112)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,6 +3,9 @@ Tue Oct  6 11:36:25 UTC 2015 - ancor@suse.com
 
 - Repository editor can now manage urls with repo variables like
   $arch, $releasever, etc. (bsc#944505)
+- Do not check the free space on a CD/DVD mounted medium during
+  online migration (the mount point has been changed from /media to
+  /run/media) (bsc#952112)
 - 3.1.52.1
 
 -------------------------------------------------------------------

--- a/src/modules/SpaceCalculation.rb
+++ b/src/modules/SpaceCalculation.rb
@@ -142,6 +142,7 @@ module Yast
               mountName != "/dev/shm" &&
               part["spec"] != "udev" &&
               !mountName.start_with?("/media/") &&
+              !mountName.start_with?("/run/media/") &&
               !mountName.start_with?("/var/adm/mount/")
             part_info["name"] = mountName
           end


### PR DESCRIPTION
... during online migration

the mount point has been changed from `/media` to `/run/media`