### PR TITLE
Properly abort the addon workflow (bsc#956597)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 16 13:03:07 UTC 2015 - lslezak@suse.cz
+
+- Do not remove the system repository when adding an addon fails,
+  better handle errors (bsc#956597)
+- 3.1.84
+
+-------------------------------------------------------------------
 Wed Nov 11 15:48:33 UTC 2015 - lslezak@suse.cz
 
 - Do not check the free space on a CD/DVD mounted medium during

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.83
+Version:        3.1.84
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -464,7 +464,7 @@ module Yast
 
       if ret == :again
         return :back
-      elsif ret == :abort
+      elsif ret == :abort || ret == :cancel
         return :abort
       end
       :next

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -462,12 +462,17 @@ module Yast
 
       ret = createSource(url, plaindir, @download_meta, name)
 
-      if ret == :again
-        return :back
-      elsif ret == :abort || ret == :cancel
-        return :abort
+      case ret
+      when :again 
+        :back
+      when :abort, :cancel
+        :abort
+      when :next
+        :next
+      else
+        log.warn "Received unknown result: #{ret}, using :next instead"
+        :next
       end
-      :next
     end
 
     def TypeDialogOpts(download, url)


### PR DESCRIPTION
... when adding a new addon fails, avoid removing a system repo by mistake.

- 3.1.84

Notes: The code at [this line](https://github.com/yast/yast-packager/blob/c3ff51a53b527b171ac701c3f6d1f9d89f125301/src/include/packager/repositories_include.rb#L349) returns `:cancel` which was treated as a success.

The fix has been tested in SLE12-SP1-GM, the exact steps how to reproduce the problem are described at [this bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=956597#c4).