### PR TITLE
Remove leftover richtext tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,8 @@ stamp-h*
 Makefile.am.common
 *.ami
 *.bz2
-*.spec
-.dep
 tmp.*
 *.log
-*.ybc
 /test-driver
 /testsuite/site.bak
 /test/*.trs

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 21 13:13:47 UTC 2015 - lslezak@suse.cz
+
+- Removed leftover closing rich text tag (bsc#950866)
+- 3.1.85
+
+-------------------------------------------------------------------
 Wed Dec 16 13:03:07 UTC 2015 - lslezak@suse.cz
 
 - Do not remove the system repository when adding an addon fails,

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.84
+Version:        3.1.85
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -731,7 +731,7 @@ module Yast
         # (just warn if removed by user or by YaST)
         msg = (transact_by == :user || transact_by == :app_high) ?
           _("<b>Warning:</b> Product <b>%s</b> will be removed.") % h(product_label(product)) :
-          _("<b>Error:</b> Product <b>%s</b> will be automatically removed.</font>") \
+          _("<b>Error:</b> Product <b>%s</b> will be automatically removed.") \
             % h(product_label(product))
 
         HTML.Colorize(msg, "red")


### PR DESCRIPTION
Fixes https://bugzilla.suse.com/show_bug.cgi?id=950866

(`master` only to not break the existing translations.)