### PR TITLE
Do not select additional products when initializing the default packages

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 27 12:16:51 UTC 2016 - lslezak@suse.cz
+
+- Fixed selecting additional products in the SLES-for-SAP product
+  (do not select previously unselected products when initializing
+  the default package selection) (bsc#963036)
+- 3.1.84.1
+
+-------------------------------------------------------------------
 Mon Jan  4 09:33:33 UTC 2016 - jreidinger@suse.com
 
 -  do not crash if adding unknown repo type (bnc#960460) 

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------
 Wed Jan 27 12:16:51 UTC 2016 - lslezak@suse.cz
 
-- Fixed selecting additional products in the SLES-for-SAP product
-  (do not select previously unselected products when initializing
-  the default package selection) (bsc#963036)
+- Fixed selecting additional products during system installation
+  (do not select previously unselected products after adding
+  repositories from the registration server) (bsc#963036)
 - 3.1.84.1
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.84
+Version:        3.1.84.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -788,30 +788,29 @@ module Yast
       nil
     end
 
-    # Reset package selection, but keep objects of specified type
-    # @param [Array<Symbol>] keep a list of symbols specifying type of objects to be kept
+    # Reset package selection, but keep the selected objects of the specified type
+    # @param [Array<Symbol>] keep a list of symbols specifying type of objects to be kept selected
     def Reset(keep)
-      keep = deep_copy(keep)
       restore = []
-      Builtins.foreach(keep) do |type|
-        selected = Pkg.ResolvableProperties("", type, "")
-        Builtins.foreach(selected) do |s|
-          restore = Builtins.add(
-            restore,
-            { "type" => type, "name" => Ops.get_string(s, "name", "") }
-          )
+
+      # collect the currently selected resolvables
+      keep.each do |type|
+        resolvables = Pkg.ResolvableProperties("", type, "")
+
+        resolvables.each do |resolvable|
+          # only selected items but ignore the selections done by solver,
+          # during restoration they would be changed to be selected by YaST and they
+          # will be selected by solver again anyway
+          if resolvable["status"] == :selected && resolvable["transact_by"] != :solver
+            restore << { "type" => type, "name" => resolvable["name"] }
+          end
         end
       end
 
-      # This reset keep user-made changes
-      # BNC #446406
+      # This keeps the user-made changes (BNC#446406)
       Pkg.PkgApplReset
-      Builtins.foreach(restore) do |res|
-        Pkg.ResolvableInstall(
-          Ops.get_string(res, "name", ""),
-          Ops.get_symbol(res, "type")
-        )
-      end
+
+      restore.each { |res| Pkg.ResolvableInstall(res["name"], res["type"]) }
 
       @system_packages_selected = false
 
@@ -2211,7 +2210,7 @@ module Yast
     # Make a proposal for package selection
     #
     # @param [Boolean] force_reset force reset (fully resets the proposal and creates a new one)
-    # @param [Boolean] reinit re-initialize (soft-reset, doesn't reset resolbavle manually selected by user)
+    # @param [Boolean] reinit re-initialize (soft-reset, doesn't reset resolvable manually selected by user)
     #
     # @return [Hash] for the API proposal
     def Proposal(force_reset, reinit, simple)

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -158,6 +158,17 @@ describe Yast::Packages do
     DEFAULT_PATTERN.merge(properties)
   end
 
+  DEFAULT_PRODUCT = {
+    "name" => "name",
+    "version" => "1.0.0",
+    "status" => :available,
+    "transact_by" => :app_high,
+  }
+
+  def product(properties = {})
+    DEFAULT_PRODUCT.merge(properties)
+  end
+
   describe "#SelectSystemPatterns" do
     context "if this is the initial run or it is being reinitialized" do
       context "and patterns are not unselected by user" do
@@ -834,6 +845,34 @@ describe Yast::Packages do
       it "includes vnc packages" do
         expect(packages).to eq(vnc_packages)
       end
+    end
+  end
+
+  describe "#Reset" do
+    # see bsc#963036
+    it "does not select previously unselected items" do
+      allow(Yast::Pkg).to receive(:PkgApplReset)
+
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
+        [product("name" => "p1", "status" => :selected), product("name" => "p2")]
+      )
+
+      expect(Yast::Pkg).to receive(:ResolvableInstall).with("p1", :product)
+      expect(Yast::Pkg).not_to receive(:ResolvableInstall).with("p2", :product)
+
+      Yast::Packages.Reset([:product])
+    end
+
+    it "does not select items selected by solver" do
+      allow(Yast::Pkg).to receive(:PkgApplReset)
+
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
+        [product("name" => "p1", "status" => :selected, "transact_by" => :solver)]
+      )
+
+      expect(Yast::Pkg).not_to receive(:ResolvableInstall).with("p1", :product)
+
+      Yast::Packages.Reset([:product])
     end
   end
 end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -849,9 +849,8 @@ describe Yast::Packages do
   end
 
   describe "#Reset" do
-    # Reset package changes done by YaST but select the installe products back.
-    # Do not select previously not selected products which were added by
-    # registration (see bsc#963036).
+    # Reset all package changes done by YaST then re-select only the products
+    # which previously were selected. (see bsc#963036).
     it "does not select previously unselected items" do
       allow(Yast::Pkg).to receive(:PkgApplReset)
 
@@ -865,11 +864,9 @@ describe Yast::Packages do
       Yast::Packages.Reset([:product])
     end
 
-    # When restoring the selected products after reset ignore the products
-    # selected by solver. Their status would change, they would be now selected
-    # by YaST which would prevent from deselecting them by solver later after
-    # changing the dependencies. Moreover they will be selected by solver again
-    # if they are still needed.
+    # When restoring the selected products ignore the items selected by solver
+    # (to not change their "transact_by" value). They will be selected again by
+    # solver if they are still needed.
     it "does not restore items selected by solver" do
       allow(Yast::Pkg).to receive(:PkgApplReset)
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -849,7 +849,9 @@ describe Yast::Packages do
   end
 
   describe "#Reset" do
-    # see bsc#963036
+    # Reset package changes done by YaST but select the installe products back.
+    # Do not select previously not selected products which were added by
+    # registration (see bsc#963036).
     it "does not select previously unselected items" do
       allow(Yast::Pkg).to receive(:PkgApplReset)
 
@@ -863,7 +865,12 @@ describe Yast::Packages do
       Yast::Packages.Reset([:product])
     end
 
-    it "does not select items selected by solver" do
+    # When restoring the selected products after reset ignore the products
+    # selected by solver. Their status would change, they would be now selected
+    # by YaST which would prevent from deselecting them by solver later after
+    # changing the dependencies. Moreover they will be selected by solver again
+    # if they are still needed.
+    it "does not restore items selected by solver" do
       allow(Yast::Pkg).to receive(:PkgApplReset)
 
       allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(


### PR DESCRIPTION
The code resets the package selection and re-selects the default products. Unfortunately it did not check the original product status and selected all available products even those originally not selected to install.

The problem happens only with the SLE-for-SAP product because during registration it receives also the HA repository and the standard SLES repo. And the products from these additional repositories gets selected by mistake.

### The Fix

Originally also the standard SLES and HA products were preselected by default:

![sles-sap-broken-products](https://cloud.githubusercontent.com/assets/907998/12614685/bf80202e-c501-11e5-9901-c5c53f5d9c45.png)

After applying the fix only the SLES-for-SAP product is selected:

![sles-sap-fixed-products](https://cloud.githubusercontent.com/assets/907998/12614719/edefbfd2-c501-11e5-9639-8757ede8a000.png)


### Notes

- Added test cases
- Rubyfied the code a bit