### PR TITLE
Handle update messages

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 22 11:13:20 UTC 2016 - igonzalezsosa@suse.com
+
+- Show messages coming from libzypp except during installation
+  (bsc#943805)
+- 3.1.90
+
+-------------------------------------------------------------------
 Thu Feb 11 15:25:26 CET 2016 - schubi@suse.de
 
 - Allowing AutoYaST to confirm licenses.

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.89
+Version:        3.1.90
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -32,8 +32,8 @@ BuildRequires:  yast2-storage
 BuildRequires:  yast2_theme
 BuildRequires:  rubygem(rspec)
 
-# HwDetection
-BuildRequires: yast2 >= 3.1.19
+# PackagesUI.show_update_messages
+BuildRequires: yast2 >= 3.1.175
 
 # Pkg::SourceRawURL() and Pkg:ExpandedUrl()
 BuildRequires:	yast2-pkg-bindings >= 3.1.30

--- a/src/modules/PackageInstallation.rb
+++ b/src/modules/PackageInstallation.rb
@@ -100,7 +100,7 @@ module Yast
 
 
     #  commitPackages marked for deletion or installation
-    #	Return: [ int successful, list failed, list remaining, list srcremaining ]
+    #	Return: [ int successful, list failed, list remaining, list srcremaining, list update_messages ]
     #
     #
     def Commit(config)
@@ -138,7 +138,6 @@ module Yast
 
       start_time = Builtins.time
 
-      commit_result = []
       # returns [ int successful, list failed, list remaining, list srcremaining ]
       Builtins.y2milestone("Calling Pkg::Commit (%1)", config)
       commit_result = Pkg.Commit(config)
@@ -188,6 +187,8 @@ module Yast
         )
       end
 
+      PackagesUI.show_update_messages(commit_result) unless Mode.installation || Mode.autoinst
+
       if Mode.normal
         # collect and set installation summary data
         summary = PackageSlideShow.GetPackageSummary
@@ -213,9 +214,8 @@ module Yast
       deep_copy(commit_result)
     end
 
-
     #  commitPackages marked for deletion or installation
-    #	Return: [ int successful, list failed, list remaining, list srcremaining ]
+    #	Return: [ int successful, list failed, list remaining, list srcremaining, list update_messages ]
     #
     #
     def CommitPackages(media_number, packages_installed)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 TESTS = \
   addon_product_test.rb \
+  package_installation_test.rb \
   packages_test.rb \
   source_dialogs_test.rb \
   space_calculation_test.rb

--- a/test/package_installation_test.rb
+++ b/test/package_installation_test.rb
@@ -1,0 +1,84 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+Yast.import "PackageInstallation"
+
+describe Yast::PackageInstallation do
+  subject { Yast::PackageInstallation }
+
+  describe "#Commit" do
+    let(:config) { {"medium_nr" => 0} }
+    let(:result) { [1, [], [], [], []] }
+
+    before do
+      allow(Yast::PackageSlideShow).to receive(:SetCurrentCdNo)
+      allow(Yast::Pkg).to receive(:Commit).with(config)
+        .and_return(result)
+      allow(Yast::PackagesUI).to receive(:show_update_messages)
+    end
+
+    context "when running in normal mode" do
+      it "shows a summary" do
+        expect(Yast::PackagesUI).to receive(:SetPackageSummary)
+        subject.Commit(config)
+      end
+
+      it "returns the commit result" do
+        allow(Yast::PackagesUI).to receive(:SetPackageSummary)
+        expect(subject.Commit(config)).to eq(result)
+      end
+    end
+
+    context "when update messages are received" do
+      let(:result) { [1, [], [], [], [message]] }
+      let(:message) do
+        {
+          "solvable"         => "dummy-package",
+          "text"             => "Some dummy text.",
+          "installationPath" => "/var/adm/update-message/dummy-package-1.0",
+          "currentPath"      => "/var/adm/update-message/dummy-package-1.0",
+        }
+      end
+
+      it "shows the update messages" do
+        expect(Yast::PackagesUI).to receive(:show_update_messages).with(result)
+        subject.Commit(config)
+      end
+
+      context "in installation mode" do
+        before do
+          allow(Yast::Mode).to receive(:installation).and_return(true)
+        end
+
+        it "does not show the update messages" do
+          expect(Yast::PackagesUI).to_not receive(:show_update_messages).with(result)
+          subject.Commit(config)
+        end
+      end
+
+      context "in autoinstallation mode" do
+        before do
+          allow(Yast::Mode).to receive(:autoinst).and_return(true)
+        end
+
+        it "does not show the update messages" do
+          expect(Yast::PackagesUI).to_not receive(:show_update_messages).with(result)
+          subject.Commit(config)
+        end
+      end
+    end
+
+    context "when installation fails" do
+      let(:result) { nil }
+
+      it "logs the error and returns []" do
+        expect(Yast::Pkg).to receive(:Commit).with(config)
+          .and_return(result)
+        allow(Yast::Pkg).to receive(:LastError).and_return("error")
+        expect(Yast::Builtins).to receive(:y2error).with(/Commit failed/, "error")
+        expect(subject.Commit(config)).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR uses the feature added to yast-yast2 in https://github.com/yast/yast-yast2/pull/442. It shows a popup showing packages notifications during normal and upgrade mode. This message is shown, for example, in `sw_single` or during a regular system upgrade.