### PR TITLE
Fixed list of skipped packages (boo#971759)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 18 11:46:53 UTC 2016 - lslezak@suse.cz
+
+- Fixed list of skipped packages in the installation summary
+  dialog (boo#971759)
+- 3.1.91
+
+-------------------------------------------------------------------
 Mon Feb 22 11:13:20 UTC 2016 - igonzalezsosa@suse.com
 
 - Show messages coming from libzypp except during installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.90
+Version:        3.1.91
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/PackageInstallation.rb
+++ b/src/modules/PackageInstallation.rb
@@ -195,7 +195,7 @@ module Yast
 
         Ops.set(summary, "time_seconds", installation_time)
         Ops.set(summary, "success", Builtins.size(errpacks) == 0)
-        Ops.set(summary, "remaining", Ops.get_list(commit_result, 2, []))
+        Ops.set(summary, "remaining", package_names(commit_result[2] || []))
         Ops.set(summary, "install_log", SlideShow.inst_log)
 
         if Ops.greater_than(Builtins.size(errpacks), 0)
@@ -296,6 +296,15 @@ module Yast
     publish :function => :FakePackager, :type => "any (list <list>, string, boolean)"
     publish :function => :Commit, :type => "list (map <string, any>)"
     publish :function => :CommitPackages, :type => "list (integer, integer)"
+
+    private
+
+    # Get a human readable list of installed packages
+    # @param [Array<Hash>] packages list of package data
+    # @return [Array<String>] list of package names
+    def package_names(packages)
+      packages.map{ |p| p["name"] }
+    end
   end
 
   PackageInstallation = PackageInstallationClass.new


### PR DESCRIPTION
I was playing with the package callbacks and found out that after enabling *dry-run* mode in libzypp the skipped packages were displayed wrongly. YaST displayed the internal data structure instead of a human readable list.

- 3.1.91

# Bug

![not_installed_summary](https://cloud.githubusercontent.com/assets/907998/13876970/1bd8e486-ed08-11e5-9231-66678975b13c.png)

# Fix

![not_installed_summary_fixed](https://cloud.githubusercontent.com/assets/907998/13876981/2b45efae-ed08-11e5-8e3b-b443bb58bce4.png)

