### PR TITLE
Added Network Configuration button to Source Dialogs (Fate#319716)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  1 12:37:51 UTC 2016 - knut.anderssen@suse.com
+
+- Added [Network Configuration] button to Source Dialog for
+  installation or upgrade modes. (fate#319716)
+- 3.1.92
+
+-------------------------------------------------------------------
 Fri Mar 18 11:46:53 UTC 2016 - lslezak@suse.cz
 
 - Fixed list of skipped packages in the installation summary

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.91
+Version:        3.1.92
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -87,6 +87,7 @@ module Yast
       Yast.import "ProductControl"
       Yast.import "ProductFeatures"
       Yast.import "Stage"
+      Yast.import "WFM"
 
       # common functions / data
 
@@ -470,6 +471,7 @@ module Yast
       end
       true
     end
+
     # Get widget description map
     # @return widget description map
     def RepoNameWidget
@@ -2013,6 +2015,14 @@ module Yast
       display_scc ? Left(RadioButton(Id(:sccrepos), _(WIDGET_LABELS[:sccrepos]))) : Empty()
     end
 
+    def network_button
+      if Mode.installation || Mode.live_installation || Mode.update
+        Right(PushButton(Id(:network), _("Network Configuration...")))
+      else
+        Empty()
+      end
+    end
+
     # FIXME: two almost same definitions in the same function smell bad
     def SelectRadioWidgetOpt(download_widget)
       contents = HBox(
@@ -2215,6 +2225,8 @@ module Yast
       when :add_addon
         RefreshTypeWidgets()
         return nil
+      when :network
+        Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
       end
 
       return nil if event["ID"] != :next && event["ID"] != :ok
@@ -2625,7 +2637,7 @@ module Yast
         {
           "widget_names"       => ["select"],
           "widget_descr"       => Widgets(),
-          "contents"           => VBox("select"),
+          "contents"           => VBox(network_button, "select"),
           "caption"            => caption,
           "back_button"        => Label.BackButton,
           "next_button"        => Label.NextButton,
@@ -2649,7 +2661,7 @@ module Yast
         {
           "widget_names"       => ["select_dl"],
           "widget_descr"       => Widgets(),
-          "contents"           => VBox("select_dl"),
+          "contents"           => VBox(network_button, "select_dl"),
           "caption"            => caption,
           "back_button"        => Label.BackButton,
           "next_button"        => Label.NextButton,


### PR DESCRIPTION
The button added should be available only during installation as in a running system you should have network configured and doesn't make sense in auto_installation