### PR TITLE
Move the default pattern selection to a different place (FATE#320199)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 22 16:23:17 UTC 2016 - lslezak@suse.cz
+
+- Move the default pattern selection to a different place to not
+  conflict with the pattern selection in the system upgrade mode
+  (FATE#320199)
+- 3.1.97
+
+-------------------------------------------------------------------
 Fri Apr 22 11:48:52 UTC 2016 - knut.anderssen@suse.com
 
 - Added public methods to modify and know info about files read,

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.96
+Version:        3.1.97
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1111,13 +1111,6 @@ module Yast
         end
       end
 
-      # preselect the default product patterns (FATE#320199)
-      # note: must be called *after* selecting the products
-      require "packager/product_patterns"
-      product_patterns = ProductPatterns.new
-      log.info "Found default product patterns: #{product_patterns.names}"
-      pattern_list.concat(product_patterns.names)
-
       # FATE #302116
       # BNC #431580
       required_patterns = PackagesProposal.GetAllResolvables(:pattern)
@@ -2614,6 +2607,13 @@ module Yast
       if !Mode.autoinst
         (default_patterns | optional_default_patterns).inject(patterns, :<<)
       end
+
+      # preselect the default product patterns (FATE#320199)
+      # note: must be called *after* selecting the products
+      require "packager/product_patterns"
+      product_patterns = ProductPatterns.new
+      log.info "Found default product patterns: #{product_patterns.names}"
+      patterns.concat(product_patterns.names)
 
       patterns
     end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -255,6 +255,20 @@ describe Yast::Packages do
 
       expect(logged_errors).to eq 4
     end
+
+    it "selects the default product patterns" do
+      allow(Yast::Packages).to receive(:ComputeSystemPatternList).and_return([])
+      allow(Yast::Packages).to receive(:default_patterns).and_return([])
+      allow(Yast::Packages).to receive(:optional_default_patterns).and_return([])
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return([{}])
+
+      product_patterns = [ "default_pattern_1", "default_pattern_2"]
+      expect_any_instance_of(Yast::ProductPatterns).to receive(:names).at_least(:once).and_return(product_patterns)
+      expect(Yast::Pkg).to receive(:ResolvableInstall).with(product_patterns[0], :pattern)
+      expect(Yast::Pkg).to receive(:ResolvableInstall).with(product_patterns[1], :pattern)
+
+      Yast::Packages.SelectSystemPatterns(false)
+    end
   end
 
   describe "#log_software_selection" do
@@ -424,12 +438,6 @@ describe Yast::Packages do
         expect(Yast::Linuxrc).to receive(:InstallInf).with("Cmdline").and_return("foo bar")
         expect(Yast::Packages.ComputeSystemPatternList).to_not include("fips")
       end
-    end
-
-    it "includes the default product patterns in the result" do
-      default_patterns = [ "default_pattern_1", "default_pattern_2"]
-      expect_any_instance_of(Yast::ProductPatterns).to receive(:names).at_least(:once).and_return(default_patterns)
-      expect(Yast::Packages.ComputeSystemPatternList).to include(*default_patterns)
     end
   end
 


### PR DESCRIPTION
...to not conflict with the pattern selection in the system upgrade mode

`ComputeSystemPatternList` is called also in the upgrade mode, but in upgrade mode we need to select the default product patterns only in the *pattern based* upgrade.

In the *packages based* upgrade the default patterns must not be selected to avoid adding new packages into the system.

The `patterns_to_install` method is called only in the installation mode.

- 3.1.96