### PR TITLE
Select the new default patterns when adding a media add-on (FATE#320199)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 12 11:24:25 UTC 2016 - lslezak@suse.cz
+
+- Select the new default product patterns also when adding an
+  add-on from media in installed system (FATE#320199)
+- 3.1.100
+
+-------------------------------------------------------------------
 Wed May 11 15:49:26 CEST 2016 - schubi@suse.de
 
 - Showing location of installed licenses.

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.99
+Version:        3.1.100
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/product_factory.rb
+++ b/test/product_factory.rb
@@ -36,6 +36,7 @@ class ProductFactory
     product["description"] = attrs["description"] || "SUSE Linux Enterprise #{product_name}."
     product["display_name"] = attrs["display_name"] || "SUSE Linux Enterprise #{product_name}"
     product["download_size"] = attrs["download_size"] || 0
+    # default: 2024-10-31
     product["eol"] = attrs["eol"] || 1730332800
     product["flags"] = attrs["flags"] || []
     product["flavor"] = attrs["flavor"] || "POOL"
@@ -69,5 +70,23 @@ class ProductFactory
     product["deps"] = attrs["deps"] if attrs.key?("deps")
 
     product
+  end
+
+  # create product packages for testing
+  # @param [String] product_name name of the product_line
+  # @param [Fixnum,nil] src repository ID providing the product
+  # @return [Array] created product data: the default pattern name,
+  #   the release package name, the release package status,
+  #   the product status
+  def self.create_product_packages(product_name: "product", src: nil)
+    pattern_name = "#{product_name}_pattern"
+    package_name = "#{product_name}-release"
+    package = { "name" => package_name, "status" => :selected,
+       "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
+                  { "provides" => "defaultpattern(#{pattern_name})" }] }
+    product = ProductFactory.create_product("status" => :selected,
+      "source" => src, "product_package" => package_name)
+
+    [ pattern_name, package_name,  package, product ]
   end
 end

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -84,6 +84,44 @@ describe Yast::ProductPatterns do
 
       expect(subject.names.sort).to eq([default_pattern1, default_pattern2].sort)
     end
+
+    context "repository parameter has been set" do
+      # get the default patterns only from the repository with id 2
+      subject { Yast::ProductPatterns.new(src: 2) }
+
+      it "returns the default patterns only from the selected repository" do
+        default_pattern1 = "def_pattern1"
+        product_package_name1 = "product-release1"
+        product_package1 = { "name" => product_package_name1, "status" => :selected,
+           "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
+                      { "provides" => "defaultpattern(#{default_pattern1})" }]}
+        product1 = ProductFactory.create_product("status"          => :selected,
+                                                 "source" => 1,
+                                                 "product_package" => product_package_name1)
+
+        default_pattern2 = "def_pattern2"
+        product_package_name2 = "product-release2"
+        product_package2 = { "name" => product_package_name2, "status" => :selected,
+           "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
+                      { "provides" => "defaultpattern(#{default_pattern2})" }] }
+        product2 = ProductFactory.create_product("status"          => :selected,
+                                                 "source" => 2,
+                                                 "product_package" => product_package_name2)
+
+        expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+          .and_return([product1, product2])
+        expect(Yast::Pkg).to receive(:ResolvableProperties).with(product1["name"], :product, "")
+          .and_return([product1])
+        expect(Yast::Pkg).to receive(:ResolvableProperties).with(product2["name"], :product, "")
+          .and_return([product2])
+        # the product1 package should not be checked, it's in different repo
+        expect(Yast::Pkg).to_not receive(:ResolvableDependencies).with(product_package_name1, :package, "")
+        expect(Yast::Pkg).to receive(:ResolvableDependencies).with(product_package_name2, :package, "")
+          .and_return([product_package2])
+
+        expect(subject.names).to eq([default_pattern2])
+      end
+    end
   end
 
   describe "#select" do

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -36,40 +36,25 @@ describe Yast::ProductPatterns do
     end
 
     it "returns the default pattern name from the release package" do
-      default_pattern = "def_pattern"
-      product_package_name = "product-release"
-      product_package = { "name" => product_package_name, "status" => :selected,
-         "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                    { "provides" => "defaultpattern(#{default_pattern})" }] }
-      product = ProductFactory.create_product("status"          => :selected,
-                                              "product_package" => product_package_name)
+      pattern_name, package_name, package, product =
+        ProductFactory.create_product_packages(product_name: "product1")
 
       expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
         .and_return([product])
       expect(Yast::Pkg).to receive(:ResolvableProperties).with(product["name"], :product, "")
         .and_return([product])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(product_package_name, :package, "")
-        .and_return([product_package])
+      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name, :package, "")
+        .and_return([package])
 
-      expect(subject.names).to eq([default_pattern])
+      expect(subject.names).to eq([pattern_name])
     end
 
     it "returns the default patterns from all products" do
-      default_pattern1 = "def_pattern1"
-      product_package_name1 = "product-release1"
-      product_package1 = { "name" => product_package_name1, "status" => :selected,
-         "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                    { "provides" => "defaultpattern(#{default_pattern1})" }] }
-      product1 = ProductFactory.create_product("status"          => :selected,
-                                               "product_package" => product_package_name1)
+      pattern_name1, package_name1, package1, product1 =
+        ProductFactory.create_product_packages(product_name: "product1")
 
-      default_pattern2 = "def_pattern2"
-      product_package_name2 = "product-release2"
-      product_package2 = { "name" => product_package_name2, "status" => :selected,
-         "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                    { "provides" => "defaultpattern(#{default_pattern2})" }] }
-      product2 = ProductFactory.create_product("status"          => :selected,
-                                               "product_package" => product_package_name2)
+      pattern_name2, package_name2, package2, product2 =
+        ProductFactory.create_product_packages(product_name: "product2")
 
       expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
         .and_return([product1, product2])
@@ -77,12 +62,12 @@ describe Yast::ProductPatterns do
         .and_return([product1])
       expect(Yast::Pkg).to receive(:ResolvableProperties).with(product2["name"], :product, "")
         .and_return([product2])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(product_package_name1, :package, "")
-        .and_return([product_package1])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(product_package_name2, :package, "")
-        .and_return([product_package2])
+      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name1, :package, "")
+        .and_return([package1])
+      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name2, :package, "")
+        .and_return([package2])
 
-      expect(subject.names.sort).to eq([default_pattern1, default_pattern2].sort)
+      expect(subject.names.sort).to eq([pattern_name1, pattern_name2].sort)
     end
 
     context "repository parameter has been set" do
@@ -90,23 +75,11 @@ describe Yast::ProductPatterns do
       subject { Yast::ProductPatterns.new(src: 2) }
 
       it "returns the default patterns only from the selected repository" do
-        default_pattern1 = "def_pattern1"
-        product_package_name1 = "product-release1"
-        product_package1 = { "name" => product_package_name1, "status" => :selected,
-           "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                      { "provides" => "defaultpattern(#{default_pattern1})" }]}
-        product1 = ProductFactory.create_product("status"          => :selected,
-                                                 "source" => 1,
-                                                 "product_package" => product_package_name1)
+        pattern_name1, package_name1, package1, product1 =
+          ProductFactory.create_product_packages(product_name: "product1", src: 1)
 
-        default_pattern2 = "def_pattern2"
-        product_package_name2 = "product-release2"
-        product_package2 = { "name" => product_package_name2, "status" => :selected,
-           "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                      { "provides" => "defaultpattern(#{default_pattern2})" }] }
-        product2 = ProductFactory.create_product("status"          => :selected,
-                                                 "source" => 2,
-                                                 "product_package" => product_package_name2)
+        pattern_name2, package_name2, package2, product2 =
+          ProductFactory.create_product_packages(product_name: "product2", src: 2)
 
         expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
           .and_return([product1, product2])
@@ -115,11 +88,11 @@ describe Yast::ProductPatterns do
         expect(Yast::Pkg).to receive(:ResolvableProperties).with(product2["name"], :product, "")
           .and_return([product2])
         # the product1 package should not be checked, it's in different repo
-        expect(Yast::Pkg).to_not receive(:ResolvableDependencies).with(product_package_name1, :package, "")
-        expect(Yast::Pkg).to receive(:ResolvableDependencies).with(product_package_name2, :package, "")
-          .and_return([product_package2])
+        expect(Yast::Pkg).to_not receive(:ResolvableDependencies).with(package_name1, :package, "")
+        expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name2, :package, "")
+          .and_return([package2])
 
-        expect(subject.names).to eq([default_pattern2])
+        expect(subject.names).to eq([pattern_name2])
       end
     end
   end


### PR DESCRIPTION
... in installed system.

Additionally be less strict about missing pattern specification in the `content` file, the default patterns should be specified using the new method. The `content` file handling is kept just for the backward compatibility.

- 3.1.99

### Testing

Tested in a SP2 system with the SLE-HA addon which already supports the the `defaultpattern()` provides. A snippet from `y2log` showing that the SLES-HA pattern was selected:

```
packager/product_patterns.rb:150 Found default pattern provide: defaultpattern(ha_sles)
packager/product_patterns.rb:155 Found default patterns: ["ha_sles"]
packager/product_patterns.rb:63 Default patterns for the selected products: ["ha_sles"]
modules/AddOnProduct.rb:1029 Found default product patterns: ["ha_sles"]
modules/AddOnProduct.rb:1033 Add-On requires these patterns: ["ha_sles"]
modules/PackagesProposal.rb:199 Adjusting resolvables ["ha_sles"] type `pattern for Add-On-Product-ID:1
```