### PR TITLE
Restored the InstURL#GetDevicesOption method (bsc#985593)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 20 08:04:22 UTC 2016 - lslezak@suse.cz
+
+- Restored back the InstURL#GetDevicesOption method which was
+  accidentaly removed in the previous update (bsc#985593)
+- 3.1.104
+
+-------------------------------------------------------------------
 Wed Jun 15 11:07:50 UTC 2016 - igonzalezsosa@suse.com
 
 - Allow installation via HTTPS using a self-signed certificate

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.103
+Version:        3.1.104
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
[bsc#985593](https://bugzilla.suse.com/show_bug.cgi?id=985593)

It was [accidentally removed](https://github.com/yast/yast-packager/pull/164/files#diff-2b522efd2e37c1915442a2eb12c7686dL37) in the previous update.

- 3.1.104

*Note: You do not have to verify the added code, it was just copy&past-ed from the old version.*