### PR TITLE
The boot option to allow self-signed certs is ssl_certs=0.

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -9,7 +9,7 @@ Mon Jun 20 08:04:22 UTC 2016 - lslezak@suse.cz
 Wed Jun 15 11:07:50 UTC 2016 - igonzalezsosa@suse.com
 
 - Allow installation via HTTPS using a self-signed certificate
-  when "ssl_verify=no" boot option is used (bsc#982727)
+  when "ssl_certs=0" boot option is used (bsc#982727)
 - Drop "is_network" method from InstURL module
 - 3.1.103
 


### PR DESCRIPTION
If ssl_certs=0 appears on the command line, ssl_verify=no appears in install.inf.

With this, I have tested that the #164 fix actually works, and in the process found a one-liner for an HTTPS server: 
```
ruby -r webrick/https -e 'WEBrick::HTTPServer.new(Port:8000,DocumentRoot:".",SSLEnable:true,SSLCertName:[%w[CN localhost]]).start'
```