### PR TITLE
Optimize installation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 28 14:15:15 UTC 2016 - jreidinger@suse.com
+
+- optimize slide show size computing to improve installation
+  performance (bnc#986649)
+- 3.1.105
+
+-------------------------------------------------------------------
 Mon Jun 20 08:04:22 UTC 2016 - lslezak@suse.cz
 
 - Restored back the InstURL#GetDevicesOption method which was

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.104
+Version:        3.1.105
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -129,12 +129,10 @@ module Yast
     # Sum up all list items
     #
     def ListSum(sizes)
-      sizes = deep_copy(sizes)
-      sum = 0
-
-      Builtins.foreach(sizes) { |item| sum = Ops.add(sum, item) if item != -1 }
-
-      sum
+      sizes.each_with_object(0) do |i, r|
+        next if i == -1
+        r += i
+      end
     end
 
     # Sum up all positive list items, but cut off individual items at a maximum value.


### PR DESCRIPTION
Found by profiller, that common manual installation call this method around 25k times, so lets try to improve its performance:

Measured by code at
https://gist.githubusercontent.com/jreidinger/917d5681c87b7645bcf6/raw/7bf458830dacbf40a48f6b6a5e89c808ad3cc14f/list_sum_benchmark.rb

result was ( used alternative 1 )

user     system      total        real
old code    17.310000   0.000000  17.310000 (17.309706)
new code     1.710000   0.000000   1.710000 (1.709686)
new code2    2.440000   0.010000   2.450000 (2.450233)