### PR TITLE
Fix remaining packages count during installation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul  6 10:46:54 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix remaining packages count during installation (bsc#987791)
+- 3.1.106
+
+-------------------------------------------------------------------
 Tue Jun 28 14:15:15 UTC 2016 - jreidinger@suse.com
 
 - optimize slide show size computing to improve installation

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Wed Jul  6 10:46:54 UTC 2016 - igonzalezsosa@suse.com
 
-- Fix remaining packages count during installation (bsc#987791)
+- Fix remaining packages count during installation (bsc#987791 and
+  bsc#987604)
 - 3.1.106
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.105
+Version:        3.1.106
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -128,11 +128,10 @@ module Yast
 
     # Sum up all list items
     #
+    # @param sizes [Array<Fixnum>] Sizes to sum
+    # @return [Fixnum] Sizes sum
     def ListSum(sizes)
-      sizes.each_with_object(0) do |i, r|
-        next if i == -1
-        r += i
-      end
+      sizes.reduce(0) { |s, i| i == -1 ? s : s + i }
     end
 
     # Sum up all positive list items, but cut off individual items at a maximum value.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,6 +3,7 @@ TESTS = \
   inst_url_test.rb \
   product_patterns_test.rb \
   package_installation_test.rb \
+  package_slide_show_test.rb \
   packages_test.rb \
   pkg_finish_test.rb \
   source_dialogs_test.rb \

--- a/test/package_slide_show_test.rb
+++ b/test/package_slide_show_test.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "PackageSlideShow"
+
+describe Yast::PackageSlideShow do
+  subject(:package_slide_show) { Yast::PackageSlideShow }
+
+  describe "#ListSum" do
+    it "returns the sum skipping '-1' values" do
+      expect(package_slide_show.ListSum([1, 2, 3, -1, 4])).to eq(10)
+    end
+  end
+end


### PR DESCRIPTION
Fixes [bsc#987604](https://bugzilla.suse.com/show_bug.cgi?id=987604) and [bsc#987791](https://bugzilla.suse.com/show_bug.cgi?id=987791).

`Enumerable#each_with_object` won't work with inmutable objects:

```ruby
[1, 2, 3].each_with_object(0) { |i, a| a += i } # => 0
```