### PR TITLE
Allow KDE to use packager for opening rpms

### DIFF
--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -8,6 +8,7 @@ Terminal=false
 Type=Application
 Categories=System;PackageManager;X-SuSE-ControlCenter-System;
 MimeType=application/x-rpm;application/x-redhat-package-manager;
-NotShowIn=KDE;GNOME;MATE;
+InitialPreference=10
+NotShowIn=GNOME;MATE;
 StartupNotify=true
 

--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -8,7 +8,9 @@ Terminal=false
 Type=Application
 Categories=System;PackageManager;X-SuSE-ControlCenter-System;
 MimeType=application/x-rpm;application/x-redhat-package-manager;
-InitialPreference=10
 NotShowIn=GNOME;MATE;
 StartupNotify=true
 
+# KDE specific (does not affect the other desktop environments)
+# https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#kde-items
+InitialPreference=10

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Jul 31 22:12:54 UTC 2016 - marceloatie@gmail.com
+
+- Allow KDE to use packager for opening rpms and
+  prioritize over other options. (boo#954143)
+- 3.1.84.2
+
+-------------------------------------------------------------------
 Wed Jan 27 12:16:51 UTC 2016 - lslezak@suse.cz
 
 - Fixed selecting additional products during system installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.84.1
+Version:        3.1.84.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Allow KDE to use packager for opening rpms and prioritize over other options.
