### PR TITLE
Sorted addons below product base (part of bsc#992304)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 10 16:39:10 UTC 2016 - kanderssen@suse.com
+
+- List addons below base product in Software proposal during
+  installation. (bsc#992304)
+- 3.1.110
+
+-------------------------------------------------------------------
 Thu Jul 28 10:40:32 UTC 2016 - jreidinger@suse.com
 
 - allow KDE to use packager for opening rpms (boo#954143)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.109
+Version:        3.1.110
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2580,9 +2580,6 @@ module Yast
 
     # Prepares a list of formatted selected resolvables
     #
-    # :pattern resolvables are sorted by "order"
-    # :product resolvables are sorted by "source"
-    #
     # @param [Array<Hash>] list of selected resolvables to format
     # @param [String] string format to use
     def formatted_resolvables(selected, format)
@@ -2601,6 +2598,7 @@ module Yast
     #
     # @param [Array<Hash>] list of selected resolvables to sort
     # @param [Symbol] what symbol specifying the type of resolvables to select
+    # @see RESOLVABLE_SORT_ORDER
     def sort_resolvable!(selected, what)
       order = RESOLVABLE_SORT_ORDER[what]
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -921,7 +921,7 @@ describe Yast::Packages do
       ]
     end
 
-    let(:unordered_packages) do
+    let(:unordered_patterns) do
       [
         pattern("name" => "p3", "status" => :selected, "order" => "3", "user_visible" => true),
         pattern("name" => "p1", "status" => :selected, "order" => "1", "user_visible" => false),
@@ -929,7 +929,7 @@ describe Yast::Packages do
       ]
     end
 
-    let(:filtered_packages) do
+    let(:filtered_patterns) do
       [
         pattern("name" => "p3", "status" => :selected, "order" => "3", "user_visible" => true)
       ]
@@ -955,14 +955,14 @@ describe Yast::Packages do
 
     it "filters not user visible resolvables from the list for type pattern" do
       expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :pattern, "")
-        .and_return(unordered_packages)
+        .and_return(unordered_patterns)
       expect(subject).to receive(:sort_resolvable!)
-        .with(filtered_packages, :pattern)
+        .with(filtered_patterns, :pattern)
 
       subject.ListSelected(:pattern, "")
     end
 
-    it "sorts resultant list depending on resortable type" do
+    it "sorts resultant list depending on resolvable type" do
       expect(subject).to receive(:formatted_resolvables).with(ordered_products, "")
 
       subject.ListSelected(:product, "")


### PR DESCRIPTION
### Changes
-  Addons are sorted based on "source" key, that basically represent the order in which the repositories where added to the system, so the base product will be the one with the lower "source" and for that the first one listed.
- 3.1.110

### Test
- Added unit tests and tested manually in a SLE 12 - SP2 - Server,  build 2050.

#### Original State

Addons are listed unordered and product base is not the first one listed.

![beforefix](https://cloud.githubusercontent.com/assets/7056681/17579205/622de14e-5f8a-11e6-965e-1d76deab1e4e.png)

Addons are listed ordered being the product base the first one of the list.

![fixed](https://cloud.githubusercontent.com/assets/7056681/17579206/64f78d30-5f8a-11e6-8fa1-a2e86ec13de5.png)



