### PR TITLE
Fixed required acceptance of license in installation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Aug 16 08:31:23 CEST 2016 - locilka@suse.com
+
+- Added lazy loading of licenses into AcceptanceNeeded in case of
+  base product in the initial installation to fix a problem when
+  explicit acceptance of the product license was always required
+  (bnc#993285)
+- 3.1.113
+
+-------------------------------------------------------------------
 Mon Aug 15 13:59:58 CEST 2016 - schubi@suse.de
 
 - Fixed parameter error while logging errors. It belongs to

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.112
+Version:        3.1.113
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -163,8 +163,8 @@ describe Yast::ProductLicense do
     context "when called in the initial stage of installation" do
       before do
         # Initial installation
-        allow(Yast::Stage).to receive(:stage).and_return("initial")
-        allow(Yast::Mode).to receive(:mode).and_return("installation")
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Yast::Mode).to receive(:installation).and_return(true)
 
         # Tarball with licenses exists
         allow(Yast::FileUtils).to receive(:Exists).with(/license.tar.gz/).and_return(true)
@@ -206,10 +206,10 @@ describe Yast::ProductLicense do
       end
     end
 
-    context "when called on a running system" do
+    context "when not called in initial installation" do
       before do
-        allow(Yast::Stage).to receive(:stage).and_return("normal")
-        allow(Yast::Mode).to receive(:mode).and_return("normal")
+        allow(Yast::Stage).to receive(:initial).and_return(false)
+        allow(Yast::Mode).to receive(:installation).and_return(false)
       end
 
       context "when called for base-product" do


### PR DESCRIPTION
- When tarball with licenses contains no-acceptance-needed file, explicit acceptance of that license is not required. This did not work after refactoring of inst_complex_welcome as the installer called AcceptanceNeeded, but data were not loaded yet (bnc#993285)
- The fix adds lazy loading into AcceptanceNeeded function, but keeps it also on the old place
- This only applies for the base product license in the initial installation