### PR TITLE
Remove the icon in the add-on selection popup (bsc#875201)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 16 14:16:01 UTC 2016 - lslezak@suse.cz
+
+- Remove the icon from the add-on selection popup (bsc#875201)
+- 3.1.114
+
+-------------------------------------------------------------------
 Tue Aug 16 08:31:23 CEST 2016 - locilka@suse.com
 
 - Added lazy loading of licenses into AcceptanceNeeded in case of

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.113
+Version:        3.1.114
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -1370,11 +1370,8 @@ module Yast
 
       UI.OpenDialog(
         VBox(
-          HBox(
-            HSquash(MarginBox(0.5, 0.2, Icon.Simple("yast-addon"))),
-            # TRANSLATORS: popup heading
-            Left(Heading(Id(:search_heading), _("Additional Products")))
-          ),
+          # TRANSLATORS: popup heading
+          Left(Heading(Id(:search_heading), _("Additional Products"))),
           VSpacing(0.5),
           # TRANSLATORS: additional dialog information
           Left(


### PR DESCRIPTION
- All icons in all popups should be removed, see https://bugzilla.suse.com/show_bug.cgi?id=875201#c1
- 3.1.114


## Test

Tested manually with this simple `add_on_products.xml` file:

```xml
<?xml version="1.0"?>
<add_on_products xmlns="http://www.suse.com/1.0/yast2ns"
    xmlns:config="http://www.suse.com/1.0/configns">
    <product_items config:type="list">
        <product_item>
            <name>Driver Update Add On</name>
            <url>cd:///?alias=dud</url>
            <path>/dud</path>
            <priority config:type="integer">50</priority>
            <ask_user config:type="boolean">true</ask_user>
        </product_item>
    </product_items>
</add_on_products>
```

using this simple Ruby script:

```ruby
require "yast"
Yast.import "AddOnProduct"
Yast::AddOnProduct.ParseXMLBasedAddOnProductsFile("add_on_products.xml", "cd:/")
```

### Screenshots

*(Taken in an installed system, the colors will be of course different in a real SLE12 installation...)*

#### The Original State

![yast2-addon_selection_orig](https://cloud.githubusercontent.com/assets/907998/17702859/f3e39770-63cf-11e6-810a-0542a59411ae.png)

#### After Icon Removal

![yast2-addon_selection_fixed](https://cloud.githubusercontent.com/assets/907998/17702875/fd413534-63cf-11e6-91e7-65df0ab6fb00.png)
