### PR TITLE
Unify license handling

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,6 +3,8 @@ Tue Aug 23 11:17:36 UTC 2016 - jreidinger@suse.com
 
 - always enable next in license confirmation dialog, because even
   if not accepted, popup is shown to user (bnc#993530)
+- use same popup when license not confirmed for base product in
+  license confirmation dialog (bnc#993530)
 - 3.1.116
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 23 11:17:36 UTC 2016 - jreidinger@suse.com
+
+- always enable next in license confirmation dialog, because even
+  if not accepted, popup is shown to user (bnc#993530)
+- 3.1.116
+
+-------------------------------------------------------------------
 Thu Aug 18 10:55:06 CEST 2016 - schubi@suse.de
 
 - Do not raise an exception if no license is available (no licence

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,10 +1,11 @@
 -------------------------------------------------------------------
 Tue Aug 23 11:17:36 UTC 2016 - jreidinger@suse.com
 
-- always enable next in license confirmation dialog, because even
-  if not accepted, popup is shown to user (bnc#993530)
-- use same popup when license not confirmed for base product in
-  license confirmation dialog (bnc#993530)
+- Always enable "Next" button in license confirmation dialog,
+  because even if not accepted, popup is shown to user
+  (bnc#993530).
+- Use the same popup when license not confirmed for base product in
+  the license confirmation dialog (bnc#993530).
 - 3.1.116
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-packager
 #
-# Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -24,55 +24,56 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
 Url:            https://github.com/kobliha/yast-packager
-Group:	        System/YaST
-License:        GPL-2.0+
-BuildRequires:	yast2-country-data yast2-xml update-desktop-files yast2-testsuite
+BuildRequires:  update-desktop-files
+BuildRequires:  yast2-country-data
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  yast2-storage
+BuildRequires:  yast2-testsuite
+BuildRequires:  yast2-xml
 BuildRequires:  yast2_theme
 BuildRequires:  rubygem(rspec)
 
 # Packages::Repository and Packages::Product classes
-BuildRequires: yast2 >= 3.1.187
+BuildRequires:  yast2 >= 3.1.187
 
 # Pkg::SourceRawURL() and Pkg:ExpandedUrl()
-BuildRequires:	yast2-pkg-bindings >= 3.1.30
+BuildRequires:  yast2-pkg-bindings >= 3.1.30
 
 # Newly added RPM
-Requires:	yast2-country-data >= 2.16.3
+Requires:       yast2-country-data >= 2.16.3
 
 # Pkg::SourceRawURL() and Pkg:ExpandedUrl()
-Requires:	yast2-pkg-bindings >= 3.1.30
+Requires:       yast2-pkg-bindings >= 3.1.30
 
 # Packages::Repository and Packages::Product classes
-Requires: yast2 >= 3.1.187
+Requires:       yast2 >= 3.1.187
 
 # unzipping license file
-Requires:	unzip
+Requires:       unzip
 
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)
-Requires:	yast2-transfer
+Requires:       yast2-transfer
 
 # XML module (inst_productsources.ycp)
-Requires:	yast2-xml
+Requires:       yast2-xml
 
 # Bugzilla #305503 - storing/checking MD5 of licenses
-Requires:	/usr/bin/md5sum
+Requires:       /usr/bin/md5sum
 
 # .process agent
-Requires: 	yast2-core >= 2.16.35
+Requires:       yast2-core >= 2.16.35
 
 # setenv() builtin
-Conflicts:	yast2-core < 2.15.10
+Conflicts:      yast2-core < 2.15.10
 
 # NotEnoughMemory-related functions moved to misc.ycp import-file
-Conflicts:	yast2-add-on < 2.15.15
+Conflicts:      yast2-add-on < 2.15.15
 
 # One of libyui-qt-pkg, libyui-ncurses-pkg, libyui-gtk-pkg
-Requires:	libyui_pkg
+Requires:       libyui_pkg
 
 # ensure that 'checkmedia' is on the medium
-Recommends:	checkmedia
+Recommends:     checkmedia
 
 # for registering media add-ons on SLE
 # (openSUSE does not contain the registration module)
@@ -81,12 +82,13 @@ Recommends:     yast2-registration
 %endif
 
 # force *-webpin subpackage removal at upgrade
-Obsoletes:      yast2-packager-webpin < %version
 Obsoletes:      yast2-packager-devel-doc
+Obsoletes:      yast2-packager-webpin < %version
 
 Requires:       yast2-ruby-bindings >= 1.0.0
-Summary:	YaST2 - Package Library
-
+Summary:        YaST2 - Package Library
+License:        GPL-2.0+
+Group:          System/YaST
 
 %description
 This package contains the libraries and modules for software management.
@@ -108,7 +110,6 @@ This package contains the libraries and modules for software management.
 %postun
 %desktop_database_postun
 
-
 %files
 %defattr(-,root,root)
 %dir %{yast_yncludedir}/checkmedia
@@ -125,3 +126,5 @@ This package contains the libraries and modules for software management.
 %{yast_execcompdir}/servers_non_y2/ag_*
 %dir %{yast_docdir}
 %doc %{yast_docdir}/COPYING
+
+%changelog

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.115
+Version:        3.1.116
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1078,14 +1078,23 @@ module Yast
             break
           end
 
-          # text changed due to bug #162499
-          refuse_popup_text = base_product ?
-            # text asking whether to refuse a license (Yes-No popup)
-            _("Refusing the license agreement cancels the installation.\nReally refuse the agreement?")
-            :
-            # text asking whether to refuse a license (Yes-No popup)
-            _("Refusing the license agreement cancels the add-on\nproduct installation. Really refuse the agreement?")
-          next unless Popup.YesNo(refuse_popup_text)
+          if base_product
+            # TODO: refactor to use same widget as in inst_complex_welcome
+            # NOTE: keep in sync with inst_compex_welcome client, for grabing its translation
+            # mimic inst_complex_welcome behavior see bnc#993530
+            refuse_popup_text = Builtins.dgettext(
+                                  'installation',
+                                  'You must accept the license to install this product'
+                                )
+            Popup.Message(refuse_popup_text)
+            next
+          else
+            # text changed due to bug #162499
+            # TRANSLATORS: text asking whether to refuse a license (Yes-No popup)
+            refuse_popup_text = _("Refusing the license agreement cancels the add-on\n" \
+              'product installation. Really refuse the agreement?')
+            next unless Popup.YesNo(refuse_popup_text)
+          end
 
           log.info "License has been declined."
 

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -476,7 +476,8 @@ module Yast
         contents,
         GetLicenseDialogHelp(),
         back,
-        true # always allow next button, as if not accepted, it will raise popup (bnc#993530)
+        # always allow next button, as if not accepted, it will raise popup (bnc#993530)
+        true
       )
 
       # set the initial license download URL

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -471,16 +471,12 @@ module Yast
         _GetLicenseDialog_result
       )
 
-      # If acceptance is not needed, there's no need to disable the button
-      # by default
-      default_next_button_state = AcceptanceNeeded(id) ? false : true
-
       Wizard.SetContents(
         caption,
         contents,
         GetLicenseDialogHelp(),
         back,
-        default_next_button_state
+        true # always allow next button, as if not accepted, it will raise popup (bnc#993530)
       )
 
       # set the initial license download URL
@@ -1308,9 +1304,6 @@ module Yast
           VSpacing(0.5)
         ) : Empty()
       )
-      # If acceptance is not needed, there's no need to disable the button
-      # by default
-      default_next_button_state = true
 
       Builtins.foreach(dirs) do |dir|
         counter = Ops.add(counter, 1)
@@ -1360,7 +1353,6 @@ module Yast
         # Display info as a popup if exists
         InstShowInfo.show_info_txt(@info_file) if @info_file != nil
         Ops.set(licenses, counter, tmp_licenses)
-        default_next_button_state = false if AcceptanceNeeded(dir)
       end
 
       Wizard.SetContents(
@@ -1368,7 +1360,7 @@ module Yast
         contents,
         GetLicenseDialogHelp(),
         enable_back,
-        default_next_button_state
+        true # always enable next, as popup is raised if not accepted (bnc#993530)
       )
 
       Wizard.SetTitleIcon("yast-license")


### PR DESCRIPTION
YaST team get report that license agreement in automatic installation differs from common installation. So we look at it and unify it. We are in quite late phase of release, so it not done as unification of code, only with adapting one dialog to look like other. Also we are after string freeze due to translations, so we use trick to use translated text from different text domain to avoid new translatable string.

At first we unify enabled Next button, which is in autoinstallation disabled until clicked to checkbox that license is agreed ( but not disabled again when unchecked checkbox ).
![old_open](https://cloud.githubusercontent.com/assets/478871/17891417/fa406c9e-693b-11e6-92fd-f85fb88192ab.png)
disabled one have greyed out next button. And now how it looks now:
![new_open](https://cloud.githubusercontent.com/assets/478871/17891430/098db760-693c-11e6-917e-f5c7905741a3.png)

And how it looks when popup appear. At first old one:
![old_popup](https://cloud.githubusercontent.com/assets/478871/17891442/15d24090-693c-11e6-86df-3177ff0d357a.png)

and with new one:

![new_popup](https://cloud.githubusercontent.com/assets/478871/17891446/1c218406-693c-11e6-9c81-578b7ce30864.png)

and to compare how it looks with common installation, that now it is almost same ( except that common installation integrate also language and keyboard settings ):

![common](https://cloud.githubusercontent.com/assets/478871/17891457/30131592-693c-11e6-8d6a-4340445d6e7d.png)



