### PR TITLE
Add a test to Yast::AddOnProduct.AddRepo

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,8 @@ require "pathname"
 
 TESTS_PATH = Pathname.new(File.dirname(__FILE__))
 FIXTURES_PATH = TESTS_PATH.join("data")
+
+RSpec.configure do |config|
+  config.extend Yast::I18n  # available in context/describe
+  config.include Yast::I18n # available in it/let/before/...
+end


### PR DESCRIPTION
Although it was not the real cause of the bug, a nasty error was discovered through bug [bsc#993690](https://bugzilla.suse.com/show_bug.cgi?id=993690). The problem was that `AddRepo` got some refactoring but I didn't write a unit test for it. The problem was solved in #181 and here is the unit test.

I'm not releasing a new version as the fix was already shipped and this PR does not contain any change to the code included in the package.