### PR TITLE
Fix URL when retrying to load an add-on from a DVD

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 31 14:25:19 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix URLs handling when retrying to load an add-on from a CD/DVD
+  through the add_on_products.xml (related to bsc#991935).
+- 3.1.117
+
+-------------------------------------------------------------------
 Tue Aug 23 11:17:36 UTC 2016 - jreidinger@suse.com
 
 - Always enable "Next" button in license confirmation dialog,

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.116
+Version:        3.1.117
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2235,7 +2235,7 @@ module Yast
         end
 
         # ask for a different medium
-        current_url = AskForCD(current_url, prodname)
+        current_url = AskForCD(url, prodname)
         return nil if current_url.nil?
       end
     end

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -211,6 +211,7 @@ describe Yast::AddOnProduct do
         let(:matching_product) { { "label" => repo["name"] } }
         let(:other_product) { { "label" => "other" } }
         let(:other_repo_id) { 2 }
+        let(:other_cd_url) { "cd:///?device=/dev/sr1" }
 
         context "and the product is found in the CD/DVD" do
           before do
@@ -257,6 +258,24 @@ describe Yast::AddOnProduct do
             expect(subject).to receive(:Integrate).with(repo_id)
             subject.AddPreselectedAddOnProducts(filelist)
             expect(subject.add_on_products).to_not be_empty
+          end
+
+          it "does not break the URL when retrying" do
+            allow(subject).to receive(:AddRepo).with(repo["url"], repo["path"], repo["priority"])
+              .and_return(nil)
+            allow(subject).to receive(:AddRepo).with(other_cd_url, repo["path"], repo["priority"])
+              .and_return(other_repo_id)
+            allow(subject).to receive(:AddRepo).with(cd_url, repo["path"], repo["priority"])
+              .and_return(repo_id)
+
+            # AskForCD receives always
+            expect(subject).to receive(:AskForCD).with(repo["url"], repo["name"])
+              .and_return(other_cd_url, nil)
+
+            expect(Yast::Pkg).to receive(:SourceDelete).with(other_repo_id)
+            expect(subject).to_not receive(:Integrate).with(other_repo_id)
+            subject.AddPreselectedAddOnProducts(filelist)
+            expect(subject.add_on_products).to be_empty
           end
 
           context "and check_name option is disabled" do

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -310,6 +310,12 @@ describe Yast::AddOnProduct do
     context "when the repo is added successfully" do
       let(:repo_id) { 1 }
 
+      before do
+        allow(Yast::Pkg).to receive(:SourceSaveAll)
+        allow(Yast::Pkg).to receive(:SourceRefreshNow)
+        allow(Yast::Pkg).to receive(:SourceLoad)
+      end
+
       it "returns the new repository id" do
         expect(Yast::Pkg).to receive(:RepositoryAdd)
           .with("enabled" => true, "base_urls" => [url], "prod_dir" => pth, "priority" => prio)


### PR DESCRIPTION
**This behavior is also present in SLE 12 SP1, so I would like to check if it's intended.**

While retrying to load an add-on from a CD/DVD with this dialog:

![ask-for-cd](https://cloud.githubusercontent.com/assets/15836/18133057/05d663e6-6f91-11e6-96e4-df45a3ea59d7.png)

The URL gets screwed (note the duplicated `devices=/dev/sr0`):

![broken-url](https://cloud.githubusercontent.com/assets/15836/18132950/9f70a4a4-6f90-11e6-929a-187530c2ebd6.png)

This patch fix this issue.