### PR TITLE
Added yast2-sw_single-wrapper to handle rpms in KDE

### DIFF
--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=Install/Remove Software
 GenericName=Install/Remove Software
-Exec=xdg-su -c "/sbin/yast2 sw_single %F"
+Exec=/usr/bin/yast2-sw_single-wrapper %F
 Icon=yast-sw_single
 Terminal=false
 Type=Application
@@ -11,3 +11,6 @@ MimeType=application/x-rpm;application/x-redhat-package-manager;
 NotShowIn=GNOME;MATE;
 StartupNotify=true
 
+# KDE specific (does not affect the other desktop environments)
+# https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#kde-items
+InitialPreference=10

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Oct  4 08:02:04 UTC 2016 - ancor@suse.com
+
+- Enhanced opening of rpm packages with YaST in Dolphin (Plasma)
+  (bug#954143, bug#1002417, fate#319376).
+- Fixes contributed by marceloatie@gmail.com and
+  opensuse.lietuviu.kalba@gmail.com
+- 3.1.117.1
+
+-------------------------------------------------------------------
 Wed Aug 31 14:25:19 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix URLs handling when retrying to load an add-on from a CD/DVD

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,11 +17,12 @@
 
 
 Name:           yast2-packager
-Version:        3.1.117
+Version:        3.1.117.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
+Source1:        yast2-sw_single-wrapper
 
 Url:            https://github.com/kobliha/yast-packager
 BuildRequires:  update-desktop-files
@@ -101,6 +102,8 @@ This package contains the libraries and modules for software management.
 
 %install
 %yast_install
+mkdir -p %{buildroot}%{_bindir}
+install -m 755 %{SOURCE1} %{buildroot}%{_bindir}/yast2-sw_single-wrapper
 
 %suse_update_desktop_file yast2-packager
 
@@ -124,6 +127,7 @@ This package contains the libraries and modules for software management.
 %{_datadir}/applications/*.desktop
 %{yast_scrconfdir}/*
 %{yast_execcompdir}/servers_non_y2/ag_*
+%{_bindir}/yast2-sw_single-wrapper
 %dir %{yast_docdir}
 %doc %{yast_docdir}/COPYING
 

--- a/package/yast2-sw_single-wrapper
+++ b/package/yast2-sw_single-wrapper
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# This script helps to correctly pass RPM packages including spaces in the path
+# (and/or multiple RPM packages) to YaST2 via desktop file
+# See https://bugzilla.suse.com/show_bug.cgi?id=1002417
+
+# Originally created by http://en.opensuse.org/User:Mvidner for
+# https://bugzilla.novell.com/show_bug.cgi?id=222757
+
+# This stripped /usr/bin/package-manager function 
+# (from libzypp (<=13.9) shipped with openSUSE 13.1 and earler)
+# to pass RPM packages to true package manager
+
+# quoted concatenation of arguments
+function quote() {
+  # formerly used 'printf %q' breaks UTF-8 strings
+  echo -n "$@" | sed 's/\([]|&;<>()$`\" \t*?#~=%[]\)/\\\1/g'
+}
+
+function mkCmd() {
+  quote "$1"
+  shift
+  for ARG in "$@"; do
+    echo -n " $(quote "$ARG")"
+  done
+}
+
+xsu() {
+    xdg-su -c "$(mkCmd "$@")"
+}
+
+xsu /sbin/yast2 sw_single "$@"


### PR DESCRIPTION
This should fix https://bugzilla.suse.com/show_bug.cgi?id=954143 and https://bugzilla.suse.com/show_bug.cgi?id=1002417 for Leap 42.2 and SLE-12-SP2. Since both are in beta phase, waiting for release managers approval, see comments in first bug report.
