### PR TITLE
Disable autorefresh by default for local media (DVD, USB Flash,...) (bsc#948982)

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--color --format doc

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,9 +1,9 @@
 -------------------------------------------------------------------
 Thu Oct  6 08:01:38 UTC 2016 - lslezak@suse.cz
 
-- Disable autorefresh for new added local repositories (cd/dvd,
-  dir, hd (including USB flash), iso and file URL protocols)
-  (bsc#948982)
+- Disable autorefresh for newly added local repositories ("cd",
+  "dvd", "dir", "hd" (including USB flash), "iso" and "file" URL
+  protocols) (bsc#948982)
 - 3.2.1
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  6 08:01:38 UTC 2016 - lslezak@suse.cz
+
+- Disable autorefresh for new added local repositories (cd/dvd,
+  dir, hd (including USB flash), iso and file URL protocols)
+  (bsc#948982)
+- 3.2.1
+
+-------------------------------------------------------------------
 Wed Oct  5 14:35:07 UTC 2016 - jreidinger@suse.com
 
 - remove workaround that creates fake mtab to prevent collision

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -38,15 +38,14 @@ BuildRequires:  yast2 >= 3.1.187
 # needed for icon for desktop file, it is verified at the end of build
 BuildRequires:       yast2_theme
 
-
-# Pkg::SourceRawURL() and Pkg:ExpandedUrl()
-BuildRequires:  yast2-pkg-bindings >= 3.1.30
+# Pkg::UrlSchemeIs*()
+BuildRequires:  yast2-pkg-bindings >= 3.2.0
 
 # Newly added RPM
 Requires:       yast2-country-data >= 2.16.3
 
-# Pkg::SourceRawURL() and Pkg:ExpandedUrl()
-Requires:       yast2-pkg-bindings >= 3.1.30
+# Pkg::UrlSchemeIs*()
+Requires:       yast2-pkg-bindings >= 3.2.0
 
 # Packages::Repository and Packages::Product classes
 Requires:       yast2 >= 3.1.187

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -1,14 +1,12 @@
 # encoding: utf-8
 
-# File:	packager/repositories_include.ycp
+# File:	packager/repositories_include.rb
 #
 # Author:	Cornelius Schumacher <cschum@suse.de>
 #		Ladislav Slezak <lslezak@suse.cz>
 #		Lukas Ocilka <locilka@suse.cz>
 #
 # Purpose:	Include file to be shared by yast2-packager and yast2-add-on
-#
-# $Id$
 #
 module Yast
   module PackagerRepositoriesIncludeInclude
@@ -118,14 +116,6 @@ module Yast
             idx = Ops.add(idx, 1)
           end
 
-          autorefresh = true
-          schema = Builtins.tolower(Builtins.substring(url, 0, 3))
-
-          if schema == "cd:" || schema == "dvd"
-            autorefresh = false
-            Builtins.y2milestone("Disabling autorefresh for a CD/DVD service")
-          end
-
           # use alias as the name if it's missing
           if preffered_name == nil || preffered_name == ""
             preffered_name = _alias
@@ -133,7 +123,7 @@ module Yast
 
           new_service = {
             "alias"       => _alias,
-            "autorefresh" => autorefresh,
+            "autorefresh" => autorefresh(url),
             "enabled"     => true,
             "name"        => preffered_name,
             "url"         => url
@@ -177,30 +167,6 @@ module Yast
         end
 
         newSources = []
-        auto_refresh = true
-
-        # disable autorefresh for ISO images
-        iso_prefix = "iso:"
-        if Builtins.substring(url, 0, Builtins.size(iso_prefix)) == iso_prefix
-          Builtins.y2milestone(
-            "ISO image detected, disabling autorefresh (%1)",
-            URL.HidePassword(url)
-          )
-          auto_refresh = false
-        end
-
-        # CD or DVD repository?
-        cd_scheme = Builtins.contains(
-          ["cd", "dvd"],
-          Builtins.tolower(Ops.get_string(URL.Parse(url), "scheme", ""))
-        )
-        if cd_scheme
-          Builtins.y2milestone(
-            "CD/DVD repository detected, disabling autorefresh (%1)",
-            URL.HidePassword(url)
-          )
-          auto_refresh = false
-        end
 
         enter_again = false
 
@@ -275,7 +241,7 @@ module Yast
           # "base_urls" : list<string>, "prod_dir" : string, "type" : string ]
           repo_prop = {}
           Ops.set(repo_prop, "enabled", true)
-          Ops.set(repo_prop, "autorefresh", auto_refresh)
+          Ops.set(repo_prop, "autorefresh", autorefresh(url))
           Ops.set(repo_prop, "name", name)
           Ops.set(repo_prop, "prod_dir", Ops.get(repo, 1, "/"))
           Ops.set(repo_prop, "alias", _alias)
@@ -295,17 +261,15 @@ module Yast
             repo_prop_log
           )
           newSources = Builtins.add(newSources, new_repo_id)
-          if cd_scheme
-            # for CD/DVD repo download the metadata immediately,
-            # the medium is in the drive right now, it can be changed later
-            # and accidentaly added a different repository
-            Builtins.y2milestone(
-              "Adding a CD or DVD repository, refreshing now..."
-            )
+
+          # for local repositories (e.g. CD/DVD) which have autorefresh disabled
+          # download the metadata immediately, the medium is in the drive right
+          # now, it can be changed later and accidentaly added a different repository
+          if !autorefresh(url)
+            log.info "Adding a local repository, refreshing it now..."
             Pkg.SourceRefreshNow(new_repo_id)
           end
-        end 
-
+        end
 
         # broken repository or wrong URL - enter the URL again
         if enter_again
@@ -426,7 +390,7 @@ module Yast
               )
             )
             Builtins.y2warning("Not searching for SLP repositories")
-            return :back 
+            return :back
             # New .slp agent has been added
             # FIXME: lazy loading of agents will make this obsolete
           else
@@ -465,7 +429,7 @@ module Yast
       ret = createSource(url, plaindir, @download_meta, name)
 
       case ret
-      when :again 
+      when :again
         :back
       when :abort, :cancel
         :abort
@@ -496,6 +460,23 @@ module Yast
     def EditDialog
       ret = SourceDialogs.EditDialog
       ret
+    end
+
+    # Evaluate the default autorefresh flag for the given repository URL.
+    # @param url [String] Repository URL
+    # @return [Boolean] The default autorefresh flag for the URL
+    def autorefresh(url)
+      log.info "Evaluating autorefresh flag for #{URL.HidePassword(url)}"
+      protocol = URL.Parse(url)["scheme"].downcase
+
+      # disable autorefresh for local repositories ,
+      # see https://github.com/openSUSE/libzypp/blob/master/zypp/Url.cc#L458
+      # for the local URL protocols defined by libzypp
+      local_protocols = [ "cd", "dvd", "dir", "hd", "iso", "file" ]
+      autorefresh = !local_protocols.include?(protocol)
+
+      log.info "Autorefresh flag for '#{protocol}' URL protocol: #{autorefresh}"
+      autorefresh
     end
   end
 end

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -9,12 +9,12 @@ class RepositoryIncludeTester
 end
 
 describe "PackagerRepositoriesIncludeInclude" do
-  describe ".autorefresh" do
+  describe ".autorefresh_for?" do
     # local protocols
     [ "cd", "dvd", "dir", "hd", "iso", "file" ].each do |protocol|
       url = "#{protocol}://foo/bar"
       it "returns false for local '#{url}' URL" do
-        expect(RepositoryIncludeTester.autorefresh(url)).to eq(false)
+        expect(RepositoryIncludeTester.autorefresh_for?(url)).to eq(false)
       end
     end
 
@@ -23,13 +23,13 @@ describe "PackagerRepositoriesIncludeInclude" do
     [ "http", "https", "nfs", "nfs4", "smb", "cifs", "ftp", "sftp", "tftp" ].each do |protocol|
       url = "#{protocol}://foo/bar"
       it "returns true for remote '#{url}' URL" do
-        expect(RepositoryIncludeTester.autorefresh(url)).to eq(true)
+        expect(RepositoryIncludeTester.autorefresh_for?(url)).to eq(true)
       end
     end
     
     it "handles uppercase URLs correctly" do
-      expect(RepositoryIncludeTester.autorefresh("FTP://FOO/BAR")).to eq(true)
-      expect(RepositoryIncludeTester.autorefresh("DVD://FOO/BAR")).to eq(false)
+      expect(RepositoryIncludeTester.autorefresh_for?("FTP://FOO/BAR")).to eq(true)
+      expect(RepositoryIncludeTester.autorefresh_for?("DVD://FOO/BAR")).to eq(false)
     end
   end
 end

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -1,0 +1,35 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+# just a wrapper class for the repositories_include.rb
+class RepositoryIncludeTester
+  extend Yast::I18n
+  Yast.include self, "packager/repositories_include.rb"
+end
+
+describe "PackagerRepositoriesIncludeInclude" do
+  describe ".autorefresh" do
+    # local protocols
+    [ "cd", "dvd", "dir", "hd", "iso", "file" ].each do |protocol|
+      url = "#{protocol}://foo/bar"
+      it "returns false for local '#{url}' URL" do
+        expect(RepositoryIncludeTester.autorefresh(url)).to eq(false)
+      end
+    end
+
+    # remote protocols
+    # see https://github.com/openSUSE/libzypp/blob/master/zypp/Url.cc#L464
+    [ "http", "https", "nfs", "nfs4", "smb", "cifs", "ftp", "sftp", "tftp" ].each do |protocol|
+      url = "#{protocol}://foo/bar"
+      it "returns true for remote '#{url}' URL" do
+        expect(RepositoryIncludeTester.autorefresh(url)).to eq(true)
+      end
+    end
+    
+    it "handles uppercase URLs correctly" do
+      expect(RepositoryIncludeTester.autorefresh("FTP://FOO/BAR")).to eq(true)
+      expect(RepositoryIncludeTester.autorefresh("DVD://FOO/BAR")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Evaluate the default autorefresh flag depending on the repository URL protocol.

Fixes [bsc#948982](https://bugzilla.suse.com/show_bug.cgi?id=948982)

Tested in both `add-on` and `repositories` YaST clients.

# Screenshots

Adding a repository on an USB Flash:

![yast2-adding_usb](https://cloud.githubusercontent.com/assets/907998/19145356/e582b646-8bae-11e6-818c-e4bbc1edf339.png)

When added the autorefresh flag is disabled:

![yast2-added_usb](https://cloud.githubusercontent.com/assets/907998/19145395/095ce0c8-8baf-11e6-9d39-8aec4a53e7bd.png)

