### PR TITLE
Better handle disabled add-ons check box (bsc#955186)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 10 14:07:57 UTC 2016 - lslezak@suse.cz
+
+- Do not ask for a CD when the add-on check box is unchecked
+  (bsc#955186)
+- 3.2.2
+
+-------------------------------------------------------------------
 Thu Oct  6 08:01:38 UTC 2016 - lslezak@suse.cz
 
 - Disable autorefresh for newly added local repositories ("cd",

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -67,6 +67,9 @@ module Yast
     VALID_URL_SCHEMES = ["ftp", "tftp", "http", "https", "nfs",
       "nfs4", "cifs", "smb", "cd", "dvd", "iso", "dir", "file", "hd"]
 
+    # repository types which need special handling
+    SPECIAL_TYPES = [:slp, :cd, :dvd, :comm_repos, :sccrepos]
+
     def main
       Yast.import "Pkg"
       Yast.import "UI"
@@ -2220,7 +2223,7 @@ module Yast
     # @param [String] key widget key
     # @param [Hash] event event description
     # @return [Symbol]
-    def SelectHandle(key, event)
+    def SelectHandle(_key, event)
       case event["ID"]
       when :back
         # reset the preselected URL when going back
@@ -2238,8 +2241,7 @@ module Yast
       #  TODO: disable "download" option when CD or DVD source is selected
 
       selected = UI.QueryWidget(Id(:type), :CurrentButton)
-      special_repo = [:slp, :cd, :dvd, :comm_repos, :sccrepos].include?(selected)
-      return :finish if special_repo && !global_disable
+      return :finish if SPECIAL_TYPES.include?(selected) && !global_disable
 
       nil
     end
@@ -2251,8 +2253,7 @@ module Yast
       UI.WidgetExists(:add_addon) && !UI.QueryWidget(:add_addon, :Value)
     end
 
-    def SelectStore(key, event)
-      event = deep_copy(event)
+    def SelectStore(_key, _event)
       @_url = ""
       @_plaindir = false
       @_repo_name = ""

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -2177,7 +2177,9 @@ module Yast
     end
 
     def SelectValidate(key, event)
-      event = deep_copy(event)
+      # skip validation if disabled by the global checkbox
+      return true if global_disable
+
       selected = Convert.to_symbol(UI.QueryWidget(Id(:type), :CurrentButton))
       if selected == nil
         # error popup
@@ -2236,9 +2238,17 @@ module Yast
       #  TODO: disable "download" option when CD or DVD source is selected
 
       selected = UI.QueryWidget(Id(:type), :CurrentButton)
-      return :finish if [:slp, :cd, :dvd, :comm_repos, :sccrepos].include?(selected)
+      special_repo = [:slp, :cd, :dvd, :comm_repos, :sccrepos].include?(selected)
+      return :finish if special_repo && !global_disable
 
       nil
+    end
+
+    # Get the status of the global checkbox.
+    # @return [Boolean] true if the global checkbox is displayed and is unchecked,
+    #   false otherwise
+    def global_disable
+      UI.WidgetExists(:add_addon) && !UI.QueryWidget(:add_addon, :Value)
     end
 
     def SelectStore(key, event)
@@ -2246,7 +2256,9 @@ module Yast
       @_url = ""
       @_plaindir = false
       @_repo_name = ""
-      @addon_enabled = UI.WidgetExists(:add_addon) ?  UI.QueryWidget(:add_addon, :Value) : nil
+      @addon_enabled = !global_disable
+
+      return nil if global_disable
 
       selected = Convert.to_symbol(UI.QueryWidget(Id(:type), :CurrentButton))
 


### PR DESCRIPTION
Do not ask for a CD when the add-on check box is unchecked, fixes [bug 955186](https://bugzilla.suse.com/show_bug.cgi?id=955186)

- 3.2.2

### The Original Problem

See the screenshot:

- Check the *I would like to install...* check box
- Select the *CD* repository
- Uncheck the add-on check box back
- The radiobuttons are correctly disabled
- But after pressing *Next* the user is still asked for a CD medium!

![add-on-disabled](https://cloud.githubusercontent.com/assets/907998/19239187/314c8d14-8f05-11e6-8948-b36c8659afe8.png)


### Fix

With this fix the user is not asked for a CD after unchecking the check box. The next installation dialog is displayed. Moreover adding a CD when the checkbox is enabled still works :wink: .

