### PR TITLE
Added yast2-sw_single-wrapper to handle rpms in Plasma

### DIFF
--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Name=Install/Remove Software
 GenericName=Install/Remove Software
-Exec=xdg-su -c "/sbin/yast2 sw_single %F"
+Exec=/usr/bin/yast2-sw_single-wrapper %F
 Icon=yast-sw_single
 Terminal=false
 Type=Application
@@ -11,3 +11,6 @@ MimeType=application/x-rpm;application/x-redhat-package-manager;
 NotShowIn=GNOME;MATE;
 StartupNotify=true
 
+# KDE specific (does not affect the other desktop environments)
+# https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#kde-items
+InitialPreference=10

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Oct 11 10:28:59 UTC 2016 - ancor@suse.com
+
+- Enhanced opening of rpm packages with YaST in Dolphin (Plasma)
+  (bug#954143, bug#1002417, fate#319376).
+- Fixes contributed by marceloatie@gmail.com and
+  opensuse.lietuviu.kalba@gmail.com
+- 3.1.119
+
+-------------------------------------------------------------------
 Mon Oct  3 16:38:36 UTC 2016 - jreidinger@suse.com
 
 - prevent double URL encoding for ISO (bsc#954813)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -22,6 +22,7 @@ Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
+Source1:        yast2-sw_single-wrapper
 
 Url:            https://github.com/kobliha/yast-packager
 BuildRequires:  update-desktop-files
@@ -63,6 +64,9 @@ Requires:       /usr/bin/md5sum
 # .process agent
 Requires:       yast2-core >= 2.16.35
 
+# yast2-sw_single-wrapper requires xdg-su
+Requires:       /usr/bin/xdg-su
+
 # setenv() builtin
 Conflicts:      yast2-core < 2.15.10
 
@@ -101,6 +105,8 @@ This package contains the libraries and modules for software management.
 
 %install
 %yast_install
+mkdir -p %{buildroot}%{_bindir}
+install -m 755 %{SOURCE1} %{buildroot}%{_bindir}/yast2-sw_single-wrapper
 
 %suse_update_desktop_file yast2-packager
 
@@ -124,6 +130,7 @@ This package contains the libraries and modules for software management.
 %{_datadir}/applications/*.desktop
 %{yast_scrconfdir}/*
 %{yast_execcompdir}/servers_non_y2/ag_*
+%{_bindir}/yast2-sw_single-wrapper
 %dir %{yast_docdir}
 %doc %{yast_docdir}/COPYING
 

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.118
+Version:        3.1.119
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-sw_single-wrapper
+++ b/package/yast2-sw_single-wrapper
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# This script helps to correctly pass RPM packages including spaces in the path
+# (and/or multiple RPM packages) to YaST2 via desktop file
+# See https://bugzilla.suse.com/show_bug.cgi?id=1002417
+
+# Originally created by http://en.opensuse.org/User:Mvidner for
+# https://bugzilla.novell.com/show_bug.cgi?id=222757
+
+# This stripped /usr/bin/package-manager function 
+# (from libzypp (<=13.9) shipped with openSUSE 13.1 and earler)
+# to pass RPM packages to true package manager
+
+# quoted concatenation of arguments
+function quote() {
+  # formerly used 'printf %q' breaks UTF-8 strings
+  echo -n "$@" | sed 's/\([]|&;<>()$`\" \t*?#~=%[]\)/\\\1/g'
+}
+
+function mkCmd() {
+  quote "$1"
+  shift
+  for ARG in "$@"; do
+    echo -n " $(quote "$ARG")"
+  done
+}
+
+xsu() {
+    xdg-su -c "$(mkCmd "$@")"
+}
+
+xsu /sbin/yast2 sw_single "$@"


### PR DESCRIPTION
Replaces #190 

See
https://bugzilla.suse.com/show_bug.cgi?id=954143
https://bugzilla.suse.com/show_bug.cgi?id=1002417
https://features.opensuse.org/319376

BTW, something to fix in the future (maybe when merging to master). `desktop/yast2-packager.desktop` seems to be in the wrong location (should be `src/desktop`) and is redundant with `src/desktop/sw_single.desktop`.
