### PR TITLE
Update the priority for the loaded packages (bsc#498266)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 17 07:41:00 UTC 2016 - lslezak@suse.cz
+
+- Update the priority for the loaded packages when starting the
+  repository manager from the package manager (bsc#498266)
+- 3.2.4
+
+-------------------------------------------------------------------
 Fri Oct 14 11:03:49 UTC 2016 - jreidinger@suse.com
 
 - allow SLES for SAP upgrade from 11 to 12 as it is renamed

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.3
+Version:        3.2.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -38,14 +38,14 @@ BuildRequires:  yast2 >= 3.1.187
 # needed for icon for desktop file, it is verified at the end of build
 BuildRequires:       yast2_theme
 
-# Pkg::UrlSchemeIs*()
-BuildRequires:  yast2-pkg-bindings >= 3.2.0
+# Pkg::SourceSetPriority()
+BuildRequires:  yast2-pkg-bindings >= 3.2.1
 
 # Newly added RPM
 Requires:       yast2-country-data >= 2.16.3
 
-# Pkg::UrlSchemeIs*()
-Requires:       yast2-pkg-bindings >= 3.2.0
+# Pkg::SourceSetPriority()
+Requires:       yast2-pkg-bindings >= 3.2.1
 
 # Packages::Repository and Packages::Product classes
 Requires:       yast2 >= 3.1.187

--- a/src/clients/repositories.rb
+++ b/src/clients/repositories.rb
@@ -1683,6 +1683,9 @@ module Yast
               Ops.set(sourceState, "priority", new_priority)
               Ops.set(@sourceStatesOut, global_current, sourceState)
 
+              # update the priority for the already loaded packages
+              Pkg.SourceSetPriority(sourceState["SrcId"], new_priority)
+
               # do not refresh the item in the table
               current = -1
             else


### PR DESCRIPTION
... when starting the repository manager from the package manager

- 3.2.4

When the repository manager was started from the package management the changed repository priority was not applied on the pool. You had to restart YaST.