### PR TITLE
SLE 12 SP2 merge

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle12sp2
+
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle12sp2
+Yast::Tasks.submit_to ENV["YAST_SUBMIT"] || :sle12sp2
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to ENV["YAST_SUBMIT"] || :sle12sp2
+Yast::Tasks.submit_to(ENV["YAST_SUBMIT"] ? ENV["YAST_SUBMIT"].to_sym : :sle12sp2)
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 31 14:25:19 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix URLs handling when retrying to load an add-on from a CD/DVD
+  through the add_on_products.xml (related to bsc#991935).
+- 3.1.117
+
+-------------------------------------------------------------------
 Tue Aug 23 11:17:36 UTC 2016 - jreidinger@suse.com
 
 - Always enable "Next" button in license confirmation dialog,

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,15 +1,20 @@
 -------------------------------------------------------------------
+Wed Nov  9 16:31:50 UTC 2016 - igonzalezsosa@suse.com
+
+- Synchronize Leap 42.2 and SLES 12 SP2 versions
+- 3.1.119
+
+-------------------------------------------------------------------
 Fri Oct 14 11:03:49 UTC 2016 - jreidinger@suse.com
 
 - allow SLES for SAP upgrade from 11 to 12 as it is renamed
   (bsc#1004665)
-- 3.1.119
+- 3.1.117.1
 
 -------------------------------------------------------------------
 Mon Oct  3 16:38:36 UTC 2016 - jreidinger@suse.com
 
 - prevent double URL encoding for ISO (bsc#954813)
-- 3.1.118
 
 -------------------------------------------------------------------
 Wed Aug 31 14:25:19 UTC 2016 - igonzalezsosa@suse.com

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.116
+Version:        3.1.117
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2235,7 +2235,7 @@ module Yast
         end
 
         # ask for a different medium
-        current_url = AskForCD(current_url, prodname)
+        current_url = AskForCD(url, prodname)
         return nil if current_url.nil?
       end
     end


### PR DESCRIPTION
Merge `merge_after_SP2_release` branch into `SLE-12-SP2`. It uses `3.1.119` because `3.1.118` existed at some point in `master` branch (now it uses `3.2.x`).