### PR TITLE
Generic solution for the YaST needed packages (bsc#885496)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 14 11:40:56 UTC 2016 - lslezak@suse.cz
+
+- Software proposal: display an error when a package or a pattern
+  required by YaST has been deselected by user, implement a generic
+  solution for bsc#885496
+- 3.2.6
+
+-------------------------------------------------------------------
 Mon Oct 24 14:54:59 CEST 2016 - schubi@suse.de
 
 - Faking /etc/mtab on target system for post RPM installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.5
+Version:        3.2.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -630,8 +630,11 @@ module Yast
       # Check the YaST required packages.
       missing_resolvables = check_missing_resolvables
       if !missing_resolvables.empty?
-        texts = missing_resolvables.map{ |type, list| format_missing_resolvables(type,list) }
+        texts = missing_resolvables.map{ |type, list| format_missing_resolvables(type, list) }
         texts << _("Please manually select the needed items to install.")
+
+        # include the existing warning if defined
+        texts.unshift(ret["warning"]) if ret["warning"]
 
         ret["warning"] = texts.join("<br>")
         ret["warning_level"] = :blocker
@@ -2819,7 +2822,7 @@ module Yast
         _("These patterns need to be selected to install: %s") % list_str
       else
         # TRANSLATORS: %{type} is a resolvable type, %{list} is a list of names
-        # This is a fallback message for unsupported types, normally it should not be displayed
+        # This is a fallback message for unknown types, normally it should not be displayed
         _("These items (%{type}) need to be selected to install: %{list}") % {type: type, list: list}
       end
     end


### PR DESCRIPTION
# Description

This is a generic solution for checking the packages/patterns required by YaST itself. See the [original bug report](https://bugzilla.suse.com/show_bug.cgi?id=885496) for the bootloader module.

Currently only the bootloader module checks for unselected packages, this is a generic solution for all YaST modules. (The bootloader specific part will be removed after merging this PR.)

## Screenshots

The proposal contains an error message with list of missing packages or patterns if user deselects some needed items:

![packages_proposal](https://cloud.githubusercontent.com/assets/907998/20259897/8813a41c-aa57-11e6-87fe-64a260fb5a51.png)


After clicking the `Install` button the installation is blocked, user must resolve the problem either by selecting the packages back or by adjusting the respective YaST configuration (e.g. do not install any bootloader and disable the firewall).

![packages_proposal2](https://cloud.githubusercontent.com/assets/907998/20259906/8f74fab2-aa57-11e6-8e86-fc35c212c942.png)
