### PR TITLE
Use a Docker image at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-language: cpp
-compiler:
-    - gcc
+sudo: required
+language: ruby
+services:
+  - docker
+
 before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-pkg-bindings yast2-storage" -g "rspec:3.3.0 yast-rake simplecov coveralls cheetah"
+  - docker build -t yast-test-image .
 script:
-    - sudo rake install
-    - COVERAGE=1 rake test:unit
+  # the "yast-travis" script is included in the base yastdevel/ruby-tw image
+  # see https://github.com/yast/docker-yast-ruby-tw/blob/master/yast-travis
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-test-image yast-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby-tw
+COPY . /tmp/sources
+

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -82,9 +82,16 @@ describe Yast::Packages do
     end
 
     context "when no /proc/cmdline is defined" do
-      it "returns empty list" do
+      it "returns empty list when a Dell system is not detected" do
         expect(Yast::SCR).to receive(:Read).with(SCR_PROC_CMDLINE_PATH).and_return(nil)
+        expect(Yast::Packages).to receive(:DellSystem).and_return(false)
         expect(Yast::Packages.kernelCmdLinePackages).to eq([])
+      end
+
+      it "returns biosdevname package when a Dell system is detected" do
+        expect(Yast::SCR).to receive(:Read).with(SCR_PROC_CMDLINE_PATH).and_return(nil)
+        expect(Yast::Packages).to receive(:DellSystem).and_return(true)
+        expect(Yast::Packages.kernelCmdLinePackages).to eq(["biosdevname"])
       end
     end
 


### PR DESCRIPTION
- Use the prebuilt Docker image at Travis
- Additionally a test has been fixed - the Dell system detection code was not mocked and the test used a real BIOS detection which caused a test failure on my Dell system :wink:
Fixed and improved the test to test both scenarios.

