### PR TITLE
Do not allow changing the plugin services (bsc#1021117)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 30 15:01:19 UTC 2017 - lslezak@suse.cz
+
+- Do not allow changing services of type "plugin" and its
+  repositories, they cannot be changed (related to bsc#1021117)
+- 3.2.15
+
+-------------------------------------------------------------------
 Wed Feb  1 16:03:24 UTC 2017 - jreidinger@suse.com
 
 - Fix escaping spaces ( yast uses web form escaping to "+" but

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Mon Jan 30 15:01:19 UTC 2017 - lslezak@suse.cz
+Mon Feb  6 14:00:13 UTC 2017 - lslezak@suse.cz
 
 - Do not allow changing services of type "plugin" and its
   repositories, they cannot be changed (related to bsc#1021117)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.14
+Version:        3.2.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/repositories.rb
+++ b/src/clients/repositories.rb
@@ -1172,7 +1172,7 @@ module Yast
 
           if input == :replace
             if @repository_view
-              repo_replace_handler(id, sourceState, global_current)
+              repo_replace_handler(sourceState, global_current)
             else
               service_replace_handler(current)
             end
@@ -1598,6 +1598,7 @@ module Yast
     end
 
     # Handle the "Delete" button in the service view
+    # @param [Integer] current index of the selected item in the table
     def service_delete_handler(current)
       selected_service = @serviceStatesOut[current] || {}
 
@@ -1624,6 +1625,7 @@ module Yast
     end
 
     # Handle the "Delete" button in the repository view
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
     def repo_delete_handler(global_current)
       repo = @sourceStatesOut[global_current] || {}
 
@@ -1639,6 +1641,9 @@ module Yast
     end
 
     # Handle the "Enable" checkbox in the repository view
+    # @param [Hash] sourceState the current state of the repository or service
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
+    # @param [Integer] current index of the selected item in the table
     def repo_enable_handler(sourceState, global_current, current)
       repo = @sourceStatesOut[global_current] || {}
       return if !repo["service"].to_s.empty? && !plugin_service_check(repo["service"], repo_change_msg)
@@ -1652,6 +1657,7 @@ module Yast
     end
 
     # Handle the "Enable" checkbox in the service view
+    # @param [Integer] current index of the selected item in the table
     def service_enable_handler(current)
       srv = @serviceStatesOut[current]
       return if !srv
@@ -1675,6 +1681,9 @@ module Yast
     end
 
     # Handle the "Autorefresh" checkbox in the repository view
+    # @param [Hash] sourceState the current state of the repository or service
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
+    # @param [Integer] current index of the selected item in the table
     def repo_autorefresh_handler(sourceState, global_current, current)
       source_id = sourceState["SrcId"]
       src_data = Pkg.SourceGeneralData(source_id)
@@ -1697,6 +1706,7 @@ module Yast
     end
 
     # Handle the "Autorefresh" checkbox in the service view
+    # @param [Integer] current index of the selected item in the table
     def service_autorefresh_handler(current)
       srv = @serviceStatesOut[current]
       log.info("Selected service: #{srv}")
@@ -1715,6 +1725,9 @@ module Yast
     end
 
     # Handle the "Priority" field in the repository view
+    # @param [Hash] sourceState the current state of the repository or service
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
+    # @param [Integer] current index of the selected item in the table
     def repo_priority_handler(sourceState, global_current, current)
       return if !plugin_service_check(sourceState["service"], repo_change_msg)
 
@@ -1732,6 +1745,8 @@ module Yast
     end
 
     # Handle the "Keep packages" check box in the repository view
+    # @param [Hash] sourceState the current state of the repository or service
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
     def repo_keeppackages_handler(sourceState, global_current)
       return if !plugin_service_check(sourceState["service"], repo_change_msg)
 
@@ -1744,7 +1759,10 @@ module Yast
     end
 
     # Handle the "Edit" button in the repository view
-    def repo_replace_handler(id, sourceState, global_current)
+    # @param [Hash] sourceState the current state of the repository or service
+    # @param [Integer] global_current index of the repository in the @sourceStatesOut
+    def repo_replace_handler(sourceState, global_current)
+      id = sourceState["SrcId"]
       generalData = Pkg.SourceGeneralData(id)
 
       return if !plugin_service_check(generalData["service"], repo_change_msg)
@@ -1913,6 +1931,7 @@ module Yast
     end
 
     # Handle the "Edit" button in the service view
+    # @param [Integer] current index of the selected item in the table
     def service_replace_handler(current)
       service_info = Ops.get(@serviceStatesOut, current, {})
 


### PR DESCRIPTION
- This is an improvement for the fix for bug [bsc#1021117](https://bugzilla.suse.com/show_bug.cgi?id=1021117) in pkg-bindings (proposal: https://github.com/yast/yast-pkg-bindings/pull/64) which just avoids a hard error at save
- This change prevents from modifying any libzypp plugin service and its repositories. They cannot be modified because there is no file where the changes could be saved, the repository metadata are dynamically generated by a script (see example in the https://github.com/yast/yast-pkg-bindings/pull/64 pull request)
- See more details at https://doc.opensuse.org/projects/libzypp/SLE12SP2/zypp-plugins.html#plugin-services and https://doc.opensuse.org/projects/libzypp/SLE12SP2/zypp-services.html
- The change is big because I have split a 900 (!) lines long method into smaller parts. Each method checks at the beginning whether the edited service or repository is of the `plugin` type. If yes a message is displayed and the change is not allowed.
- That means you do not have to check the complete diff, just the added checks.
- Tested manually
- No unit tests as the code is in a client and it is UI related, making it testable would require a major rewrite... :grimacing:
- The code would need even more refactoring, but that is out of scope for an L3 bug fix enhancement...