### PR TITLE
Fix spaces encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-pkg-bindings yast2-country-data yast2-storage" -g "rspec:3.3.0 yast-rake simplecov coveralls"
+    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-pkg-bindings yast2-country-data yast2-storage" -g "rspec:3.3.0 yast-rake coveralls"
 script:
     - make -f Makefile.cvs
     - make

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  1 16:03:24 UTC 2017 - jreidinger@suse.com
+
+- Fix escaping spaces ( yast uses web form escaping to "+" but
+  libzypp expects percentage escaping to "%20" ) (bsc#954813)
+- 3.1.121
+
+-------------------------------------------------------------------
 Mon Jan 30 10:57:14 UTC 2017 - igonzalezsosa@suse.com
 
 - Packages module is able to perform a package selection proposal

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.120
+Version:        3.1.121
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -343,7 +343,9 @@ module Yast
       params["url"] = URI.unescape(new_url.to_s)
 
       processed = URI("")
-      processed.query = URI.encode_www_form(params)
+      # libzypp do not use web encoding as in https://www.w3.org/TR/html5/forms.html#url-encoded-form-data
+      # but percentage enconding only. For more details see (bsc#954813#c20)
+      processed.query = URI.encode_www_form(params).gsub(/\+/, "%20")
 
       ret = "iso:///" + processed.to_s
       log.info "Updated URL: #{URL.HidePassword(ret)}"

--- a/test/source_dialogs_test.rb
+++ b/test/source_dialogs_test.rb
@@ -68,7 +68,7 @@ describe Yast::SourceDialogs do
 
     it "prevents double escaping if get already escaped string" do
       converted = "iso:///install/Duomenys%20600%20GB/openSUSE-13.2-DVD-x86_64.iso"
-      url = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall%2FDuomenys+600+GB"
+      url = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall%2FDuomenys%20600%20GB"
 
       expect(subject.PostprocessISOURL(converted)).to eq(url)
     end


### PR DESCRIPTION
tested manually. It works properly and even can show licence for opensuse Leap.
see screenshot 
![iso_with_space](https://cloud.githubusercontent.com/assets/478871/22514823/d6ba73fc-e8a0-11e6-885a-ef0ba0c64b43.png)
