### PR TITLE
Create the /etc/products.d/baseproduct symlink in inst-sys (bsc#972046)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr  7 13:40:59 UTC 2017 - lslezak@suse.cz
+
+- Create the /etc/products.d/baseproduct symlink in inst-sys when
+  it is missing to allow expanding variables in the add-on
+  repositories URL (bsc#972046)
+- 3.2.22
+
+-------------------------------------------------------------------
 Tue Mar 28 08:31:49 UTC 2017 - igonzalezsosa@suse.com
 
 - Do not crash when changing the priority of a just created

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.21
+Version:        3.2.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
...when it is missing to allow expanding variables in the add-on repositories URL.

- 3.2.22

This is a followup patch for https://github.com/yast/yast-add-on/pull/28 which did not work in SLES but worked in openSUSE. The difference was tracked down to the missing /etc/products.d/baseproduct file in SLES.

Tested manually in patched SP3, the URL expansion then works as expected.