### PR TITLE
Fix breakage introduced by previous PR

### DIFF
--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -530,7 +530,7 @@ module Yast
         ) ? "<BR>" : ""
         if Builtins.contains(
             @basic_dirs,
-            fs_mountpoint(failed_mount)
+            failed_mount.mountpoint
           )
           Ops.set(
             summary,
@@ -542,7 +542,7 @@ module Yast
                 _(
                   "Error: Cannot check free space in basic directory %1 (device %2), cannot start installation."
                 ),
-                fs_mountpoint(failed_mount),
+                failed_mount.mountpoint,
                 fs_dev_name(failed_mount)
               )
             )
@@ -562,7 +562,7 @@ module Yast
                 _(
                   "Warning: Cannot check free space in directory %1 (device %2)."
                 ),
-                fs_mountpoint(failed_mount),
+                failed_mount.mountpoint,
                 fs_dev_name(failed_mount)
               )
             )
@@ -2743,12 +2743,6 @@ module Yast
         # This is a fallback message for unknown types, normally it should not be displayed
         _("These items (%{type}) need to be selected to install: %{list}") % {type: type, list: list}
       end
-    end
-
-    # Mount point of the given filesystem, used to identify the filesystem in
-    # the log messages
-    def fs_mountpoint(filesystem)
-      filesystem.mountpoints[0] || ""
     end
 
     # Device name of the given filesystem, used to identify the filesystem in

--- a/src/modules/SpaceCalculation.rb
+++ b/src/modules/SpaceCalculation.rb
@@ -695,7 +695,7 @@ module Yast
                 # convert into KiB for TargetInitDU
                 free_size_kib = free_size / 1024
                 used_kib = used / 1024
-                mount_name = filesystem_mountpoint(filesystem)
+                mount_name = filesystem.mountpoint
                 log.info "partition: mount: #{mount_name}, free: #{free_size_kib}KiB, used: #{used_kib}KiB"
 
                 mount_name = mount_name[1..-1] if remove_slash && mount_name != "/"
@@ -1047,10 +1047,9 @@ module Yast
     # where unit can be one of: "" (none) or "B", "KiB", "MiB", "GiB", "TiB", "PiB"
     # @return [Integer] size in bytes
     def size_from_string(size_str)
-      classic_locale = true
       # Assume bytes by default
       size_str += "B" unless size_str =~ /[[:alpha:]]/
-      ::Storage.humanstring_to_byte(size_str, classic_locale)
+      Y2Storage::DiskSize.parse(size_str).to_i
     end
 
   private
@@ -1079,13 +1078,6 @@ module Yast
 
     def filesystem_dev_name(filesystem)
       filesystem.blk_devices[0].name
-    end
-
-    # storage-ng FIXME: revisit this after implementing subvolumes in btrfs. We
-    # are not sure whether 'mountpoints[0]' will be the right thing at that
-    # point in time.
-    def filesystem_mountpoint(filesystem)
-      filesystem.mountpoints[0] || ""
     end
   end
 

--- a/test/space_calculation_test.rb
+++ b/test/space_calculation_test.rb
@@ -214,7 +214,7 @@ Metadata: total=8.00MiB, used=0.00B
 EOF
       expect(Yast::SCR).to receive(:Execute).with(SCR_BASH_OUTPUT_PATH,
         "LC_ALL=C btrfs filesystem df #{dir}").and_return("stdout" => stdout, "exit" => 0)
-      expect(Yast::SpaceCalculation.btrfs_used_size(dir)).to eq(999_695_482)
+      expect(Yast::SpaceCalculation.btrfs_used_size(dir)).to eq(999_695_483)
     end
 
     it "raises an exception when btrfs tool fails" do
@@ -235,7 +235,7 @@ Metadata: total=8.00MiB
 EOF
       expect(Yast::SCR).to receive(:Execute).with(SCR_BASH_OUTPUT_PATH,
         "LC_ALL=C btrfs filesystem df #{dir}").and_return("stdout" => stdout, "exit" => 0)
-      expect(Yast::SpaceCalculation.btrfs_used_size(dir)).to eq(999_695_482)
+      expect(Yast::SpaceCalculation.btrfs_used_size(dir)).to eq(999_695_483)
     end
   end
 


### PR DESCRIPTION
#247 broke openQA. I hope this will fix it.

The first commit adjust the sizes in the test because the tests were failing in OBS (and also locally for me `rake test:unit` or ' rake osc:build`). Not sure how they managed to work before and even to pass travis recently.

The second test should fix the breakage in openQA. Verified locally. 