### PR TITLE
Handle correctly multiple product renames (bsc#1048141)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 11 14:41:58 UTC 2017 - lslezak@suse.cz
+
+- Properly handle multiple product renames (bsc#1048141)
+- 3.2.24
+
+-------------------------------------------------------------------
 Fri Apr 28 08:45:31 UTC 2017 - jreidinger@suse.com
 
 - Escape backslashes in installation repo URL (bsc#1032506)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.23
+Version:        3.2.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2335,8 +2335,8 @@ module Yast
     def add_rename_to_hash(renames, old_name, new_name)
       return renames if old_name == new_name || renamed_at?(renames, old_name, new_name)
       log.info "Adding product rename: '#{old_name}' => '#{new_name}'"
-      renames.merge(old_name => new_name) do |key, old_val, new_val|
-        old_val.nil? ? [new_val] : old_val + [new_val]
+      renames.merge(old_name => [new_name]) do |key, old_val, new_val|
+        old_val.nil? ? [new_val] : old_val + new_val
       end
     end
 

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -80,14 +80,17 @@ describe Yast::AddOnProduct do
       expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES")).to eq(true)
     end
 
-    # bsc#1048141
-    it "supports multiple renames" do
+    # handle correctly multiple renames (bsc#1048141)
+    it "handles multiple renames" do
+      # add several renames
       Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES")
       Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_SAP")
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_NEW")
       
-      # both renames are known
+      # all renames are known
       expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(true)
       expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(true)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_NEW")).to eq(true)
     end
   end
 

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -65,6 +65,11 @@ describe Yast::AddOnProduct do
   end
 
   describe "#add_rename" do
+    before do
+      # reset the known renames for each test
+      subject.main
+    end
+
     it "adds a new product rename" do
       expect(Yast::AddOnProduct.renamed?("FOO", "BAR")).to eq(false)
       Yast::AddOnProduct.add_rename("FOO", "BAR")
@@ -80,13 +85,48 @@ describe Yast::AddOnProduct do
       expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES")).to eq(true)
     end
 
-    # handle correctly multiple renames (bsc#1048141)
+    it "handles single rename" do
+      # not known yet
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(false)
+      # add a single rename
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES")
+
+      # the rename is known
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(true)
+      # the rest is unknown
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(false)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_NEW")).to eq(false)
+    end
+
+    # handle correctly double renames (bsc#1048141)
+    it "handles double rename" do
+      # not known yet
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(false)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(false)
+
+      # add several renames
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES")
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_SAP")
+
+      # the renames are known
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(true)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(true)
+      # the rest is unknown
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_NEW")).to eq(false)
+    end
+
+    # handle correctly multiple renames
     it "handles multiple renames" do
+      # not known yet
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(false)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(false)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_NEW")).to eq(false)
+
       # add several renames
       Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES")
       Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_SAP")
       Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_NEW")
-      
+
       # all renames are known
       expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(true)
       expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(true)

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -79,6 +79,16 @@ describe Yast::AddOnProduct do
       # check the already known rename
       expect(Yast::AddOnProduct.renamed?("SUSE_SLES", "SLES")).to eq(true)
     end
+
+    # bsc#1048141
+    it "supports multiple renames" do
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES")
+      Yast::AddOnProduct.add_rename("SUSE_SLE", "SLES_SAP")
+      
+      # both renames are known
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES")).to eq(true)
+      expect(Yast::AddOnProduct.renamed?("SUSE_SLE", "SLES_SAP")).to eq(true)
+    end
   end
 
   describe "#SetRepoUrlAlias" do


### PR DESCRIPTION
Fix for P1 https://bugzilla.suse.com/show_bug.cgi?id=1048141

## Details

The code actually created a wrong mapping, for the very first item it created `"old_name" => "new_name"` mapping instead of the expected `"old_name" => [ "new_name" ]` structure.

Later, when adding `new_name2`, it failed because it expected an `Array` as the value, not a `String`.

This bug was not found earlier because when checking the renames it uses the `.include?` method (see [here](https://github.com/yast/yast-packager/blob/cf216e301a9d044d3267800fb084469bfee855b4/src/modules/AddOnProduct.rb#L2290)) which works for both `String` and `Array`:

```
irb(main):001:0> ["SLES"].include?("SLES")
=> true
irb(main):002:0> "SLES".include?("SLES")
=> true
```

So the bug in the internal structure was hidden until another rename was added.