### PR TITLE
Less strict low memory detection (bsc#1045915)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 20 06:44:42 UTC 2017 - lslezak@suse.cz
+
+- Less strict low memory detection, there might be some rounding
+  in the hwinfo memory size detection (bsc#1045915)
+- 3.3.0
+
+-------------------------------------------------------------------
 Tue Jul 11 14:41:58 UTC 2017 - lslezak@suse.cz
 
 - Properly handle multiple product renames (bsc#1048141)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.24
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_productsources.rb
+++ b/src/clients/inst_productsources.rb
@@ -1736,8 +1736,9 @@ module Yast
     # display a warning when online repositories are used on a system
     # with low memory (the installer may crash or freeze, see bnc#854755)
     def check_memory_size
-      # less than LOW_MEMORY_MIB RAM
-      if Mode.installation && Yast2::HwDetection.memory < (LOW_MEMORY_MIB << 20)
+      # less than LOW_MEMORY_MIB RAM, the 64MiB buffer is for possible
+      # rounding in hwinfo memory detection (bsc#1045915)
+      if Mode.installation && Yast2::HwDetection.memory < ((LOW_MEMORY_MIB - 64) << 20)
         Report.Warning(_("Low memory detected.\n\nUsing online repositories " +
               "during initial installation with less than\n" +
               "%dMiB system memory is not recommended.\n\n" +


### PR DESCRIPTION
- There might be some rounding in the hwinfo memory size detection, thus allow 64MiB less memory than the hardcoded limit (e.g. a VBox VM with 1024MiB RAM is reported as 960MiB by hwinfo, the popup saying that the system has less than 1024MiB might be confusing for users)
- See https://bugzilla.suse.com/show_bug.cgi?id=1045915#c4 for more details
- 3.3.0