### PR TITLE
Adapt to cleaned Y2Storage::StorageManager API

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul 25 10:54:48 UTC 2017 - ancor@suse.com
+
+- storage-ng: adapted to the new Y2Storage::StorageManager API
+
+-------------------------------------------------------------------
 Wed Jul  5 14:50:19 CEST 2017 - shundhammer@suse.de
 
 - Merged master to storage-ng branch

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -30,8 +30,8 @@ BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(yast-rake)
 BuildRequires:  rubygem(cfa) >= 0.5.0
 
-# Y2Storage::StorageManager#staging_revision
-BuildRequires:  yast2-storage-ng >= 0.1.8
+# New Y2Storage::StorageManager API
+BuildRequires:  yast2-storage-ng >= 0.1.32
 
 # Optional resolvables support in PackagesProposal
 BuildRequires:  yast2 >= 3.2.7

--- a/test/space_calculation_test.rb
+++ b/test/space_calculation_test.rb
@@ -16,8 +16,7 @@ SCR_BASH_OUTPUT_PATH = Yast::Path.new(".target.bash_output")
 
 def stub_devicegraph(name)
   path = File.join(DATA_PATH, "#{name}_devicegraph.yml")
-  storage = Y2Storage::StorageManager.fake_from_yaml(path)
-  storage.probed.copy(storage.staging)
+  Y2Storage::StorageManager.instance.probe_from_yaml(path)
 end
 
 def expect_to_execute(command)


### PR DESCRIPTION
To be merged right after merging yast2-storage-ng 0.1.32.

Breakage in tests is expected until the new API is merged in storage-ng