### PR TITLE
eula acceptence moved to add-on procuct client

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Jul 27 11:12:01 CEST 2017 - schubi@suse.de
 
-- AutoYaST: Configuring EULA acception of add-on products has
+- AutoYaST: Configuring EULA acceptance of add-on products has
   not worked if the add-on product is on the medium of the base
   product too. (bnc#1032523).
   Now the add-on product has to be defined in the AutoYaST

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Jul 27 11:12:01 CEST 2017 - schubi@suse.de
+
+- AutoYaST: Configuring EULA acception of add-on products has
+  not worked if the add-on product is on the medium of the base
+  product too. (bnc#1032523).
+  Now the add-on product has to be defined in the AutoYaST
+  configuration file explicit.
+- 3.1.123
+
+-------------------------------------------------------------------
 Tue Mar  7 09:37:15 CET 2017 - schubi@suse.de
 
 - Product selection: Do not reinstall already installed products

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.1.122
+Version:        3.1.123
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -41,6 +41,7 @@ module Yast
     def main
       Yast.import "UI"
       Yast.import "Pkg"
+      Yast.import "Mode"
 
       textdomain "packager"
 
@@ -820,7 +821,13 @@ module Yast
           "Found list of add-on products to preselect: %1",
           @add_on_products_list
         )
-        AddOnProduct.AddPreselectedAddOnProducts(@add_on_products_list)
+        if Mode.auto
+          Builtins.y2warning( "This is an AutoYaST installation. "\
+            "Only Add-on products will be added which have been defined "\
+            "in the add-on section of the AutoYaST configuration file." )
+        else
+          AddOnProduct.AddPreselectedAddOnProducts(@add_on_products_list)
+        end
         @add_on_products_list = [] # do not select them any more
       end
 


### PR DESCRIPTION
It is possible to put add-on products on the same medium as the base product. In that case the EULA acceptance and adding process of the add-on-product will be made in a very early installation stage (before AutoYaST has been initialized). Now in case of an AutoYaST installation this will be done later in the general add-on YaST module which is configured by the AutoYaST configuration file. So the customer has to add it  in order to handle the EULA acceptance.:
`
  <add-on>

    <add_on_products config:type="list">

      <listentry>

       <media_url><![CDATA[cd:///oes]]></media_url>

       <product>Open_Enterprise_Server</product>

       <alias>oes</alias>

       <product_dir>/</product_dir>

       <confirm_license config:type="boolean">false</confirm_license>

      </listentry>

    </add_on_products>

  </add-on>
`