### PR TITLE
Multi-products licenses support

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,8 +2,9 @@
 Mon Aug 21 08:20:26 UTC 2017 - igonzalezsosa@suse.com
 
 - Moved repositories and product related classes to this module
-- Extended repositories and product related classes
-  (FATE#322276)
+- Extended repositories and product related API (FATE#322276)
+- Added clients and dialogs to handle products licenses using
+  the new yast2-pkg-bindings API
 - 3.3.6
 
 -------------------------------------------------------------------

--- a/src/clients/inst_product_license.rb
+++ b/src/clients/inst_product_license.rb
@@ -1,0 +1,3 @@
+require "y2packager/clients/inst_product_license"
+
+Y2Packager::Clients::InstProductLicense.new.main

--- a/src/clients/inst_repositories_initialization.rb
+++ b/src/clients/inst_repositories_initialization.rb
@@ -1,0 +1,3 @@
+require "y2packager/clients/inst_repositories_initialization"
+
+Y2Packager::Clients::InstRepositoriesInitialization.new.main

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2packager/dialogs/inst_product_license"
+require "y2packager/product"
+
+module Y2Packager
+  module Clients
+    class InstProductLicense
+      def main
+        dialog = Y2Packager::Dialogs::InstProductLicense.new(selected_product)
+        dialog.run
+      end
+
+      def selected_product
+        @selected_product ||= Y2Packager::Product.available_base_products.find(&:selected?)
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -29,6 +29,12 @@ module Y2Packager
         Y2Packager::Dialogs::InstProductLicense.new(selected_product).run
       end
 
+    private
+
+      # Return the selected base product
+      #
+      # @return [Y2Packager::Product]
+      # @see Y2Packager::Product.selected_base
       def selected_product
         @selected_product ||= Y2Packager::Product.selected_base
       end

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -20,6 +20,8 @@ module Y2Packager
     # This client shows a license confirmation dialog for the base selected product
     class InstProductLicense
       def main
+        textdomain "installation"
+
         if !selected_product.license?
           return Yast::GetInstArgs.going_back ? :back : :next
         end

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -13,13 +13,17 @@
 require "yast"
 require "y2packager/dialogs/inst_product_license"
 require "y2packager/product"
+Yast.import "GetInstArgs"
 
 module Y2Packager
   module Clients
     # This client shows a license confirmation dialog for the base selected product
     class InstProductLicense
       def main
-        return :next unless selected_product.license?
+        if !selected_product.license?
+          return Yast::GetInstArgs.going_back ? :back : :next
+        end
+
         Y2Packager::Dialogs::InstProductLicense.new(selected_product).run
       end
 

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -16,14 +16,15 @@ require "y2packager/product"
 
 module Y2Packager
   module Clients
+    # This client shows a license confirmation dialog for the base selected product
     class InstProductLicense
       def main
-        dialog = Y2Packager::Dialogs::InstProductLicense.new(selected_product)
-        dialog.run
+        return :next unless selected_product.license?
+        Y2Packager::Dialogs::InstProductLicense.new(selected_product).run
       end
 
       def selected_product
-        @selected_product ||= Y2Packager::Product.available_base_products.find(&:selected?)
+        @selected_product ||= Y2Packager::Product.selected_base
       end
     end
   end

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -13,7 +13,6 @@
 require "yast"
 require "y2packager/dialogs/inst_product_license"
 require "y2packager/product"
-Yast.import "GetInstArgs"
 
 module Y2Packager
   module Clients
@@ -23,11 +22,7 @@ module Y2Packager
 
       def main
         textdomain "installation"
-
-        if !selected_product.license?
-          return Yast::GetInstArgs.going_back ? :back : :next
-        end
-
+        return :auto unless selected_product.license?
         Y2Packager::Dialogs::InstProductLicense.new(selected_product).run
       end
 

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -19,6 +19,8 @@ module Y2Packager
   module Clients
     # This client shows a license confirmation dialog for the base selected product
     class InstProductLicense
+      include Yast::I18n
+
       def main
         textdomain "installation"
 

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -1,0 +1,79 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2packager/product"
+
+Yast.import "Packages"
+Yast.import "PackageCallbacks"
+Yast.import "Popup"
+
+module Y2Packager
+  module Clients
+    # Client to initialize software repositories
+    #
+    # It is intended to be used before the inst_complex_welcome client.
+    # If more than one product is available in the installation media, unselects
+    # all of them (the user should set a product later).
+    #
+    # @see adjust_base_product_selection
+    class InstRepositoriesInitialization
+      include Yast::Logger
+      include Yast::I18n
+
+      # Client main method
+      def main
+        textdomain "installation"
+
+        if init_installation_repositories
+          adjust_base_product_selection
+          :next
+        else
+          Yast::Popup.Message(
+            _("Failed to initialize the software repositories.\nAborting the installation.")
+          )
+          :abort
+        end
+      end
+
+    private
+
+      # Initialize installation repositories
+      def init_installation_repositories
+        Yast::PackageCallbacks.RegisterEmptyProgressCallbacks
+        Yast::Packages.InitializeCatalogs
+        return false if Yast::Packages.InitFailed
+        Yast::Packages.InitializeAddOnProducts
+
+        # bnc#886608: Adjusting product name (for &product; macro) right after we
+        # initialize libzypp and get the base product name (intentionally not translated)
+        # FIXME: UI.SetProductName(Product.name || "SUSE Linux")
+        Yast::PackageCallbacks.RestorePreviousProgressCallbacks
+        true
+      end
+
+      # Adjust product selection
+      #
+      # All products are selected by default. So if there is more than 1, we should unselect
+      # them all. The user will select one later.
+      #
+      # See https://github.com/yast/yast-packager/blob/7e1a0bbb90823b03c15d92f408036a560dca8aa3/src/modules/Packages.rb#L1876
+      def adjust_base_product_selection
+        products = Y2Packager::Product.available_base_products
+        products.each(&:restore) if products.size > 1
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -136,11 +136,7 @@ module Y2Packager
       # It will not update the status if it has not changed.
       def update_product_confirmation
         return if product.license_confirmed? == confirmed
-        if confirmed
-          product.confirm_license
-        else
-          product.unconfirm_license
-        end
+        product.license_confirmation = confirmed
       end
     end
   end

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -1,0 +1,65 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "ui/installation_dialog"
+
+module Y2Packager
+  module Dialogs
+    class InstProductLicense < ::UI::InstallationDialog
+      attr_reader :product
+
+      def initialize(product)
+        super()
+        @product = product
+      end
+
+      def dialog_content
+        VBox(
+          VSpacing(0.5),
+          ReplacePoint(
+            Id("license_replace_point"),
+            license_content
+          ),
+          confirmation_button
+        )
+      end
+
+      def dialog_title
+        format(_("%s License Agreement"), product.label)
+      end
+
+    private
+
+      def license_content
+        MinWidth(
+          80,
+          RichText(Id("license_content"), product.license_to_confirm)
+        )
+      end
+
+      def confirmation_button
+        VBox(
+          VSpacing(0.5),
+          Left(
+            CheckBox(
+              Id("license_#{product.name}"),
+              Opt(:notify),
+              # license agreement check box label
+              _("I &Agree to the License Terms.")
+            )
+          )
+        )
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -12,53 +12,135 @@
 
 require "yast"
 require "ui/installation_dialog"
+Yast.import "Language"
+Yast.import "UI"
+Yast.import "Report"
 
 module Y2Packager
   module Dialogs
+    # Dialog which shows the user a license and ask for confirmation
     class InstProductLicense < ::UI::InstallationDialog
+      # @return [Y2Packager::Product] Product
       attr_reader :product
 
+      # Constructor
+      #
+      # @param product [Y2Packager::Product] Product to ask for the license
       def initialize(product)
         super()
         @product = product
+        self.language = Yast::Language.language
+        self.confirmed = product.license_confirmed?
       end
 
-      def dialog_content
-        VBox(
-          VSpacing(0.5),
-          ReplacePoint(
-            Id("license_replace_point"),
-            license_content
-          ),
-          confirmation_button
-        )
+      # Handler for the :language action
+      #
+      # This happens when the user changes the license language
+      def language_handler
+        self.language = Yast::UI.QueryWidget(Id(:language), :Value)
+        Yast::UI.ReplaceWidget(Id(:license_replace_point), license_content)
       end
 
-      def dialog_title
-        format(_("%s License Agreement"), product.label)
+      # Handler for the :license_confirmation action
+      #
+      # This action happens when the user clicks the confirmation checkbox.
+      def license_confirmation_handler
+        @confirmed = Yast::UI.QueryWidget(Id(:license_confirmation), :Value)
+      end
+
+      # Handler for the :next action
+      #
+      # This action happens when the user clicks the 'Next' button
+      def next_handler
+        if confirmed
+          update_product_confirmation
+          finish_dialog(:next)
+        else
+          Yast::Report.Message(_("You must accept the license to install this product"))
+        end
+      end
+
+      # Handler for the :next action
+      #
+      # This action happens when the user clicks the 'Back' button
+      def back_handler
+        update_product_confirmation
+        finish_dialog(:back)
       end
 
     private
 
-      def license_content
-        MinWidth(
-          80,
-          RichText(Id("license_content"), product.license_to_confirm)
+      # @return [String] Language code (en_US, es_ES, etc.).
+      attr_accessor :language
+      # @return [Boolean] Determines whether the user confirmed the license
+      attr_accessor :confirmed
+
+      # Dialog content
+      #
+      # @see ::UI::Dialog
+      def dialog_content
+        VBox(
+          Left(language_selection),
+          VSpacing(0.5),
+          ReplacePoint(
+            Id(:license_replace_point),
+            license_content
+          ),
+          confirmation_checkbox
         )
       end
 
-      def confirmation_button
+      # Dialog title
+      #
+      # @see ::UI::Dialog
+      def dialog_title
+        format(_("%s License Agreement"), product.label)
+      end
+
+      # Return the UI for the language selector
+      def language_selection
+        ComboBox(
+          Id(:language),
+          Opt(:notify, :hstretch),
+          _("&Language"),
+          Yast::Language.GetLanguageItems(:primary)
+        )
+      end
+
+      # Return the UI for the license content
+      def license_content
+        MinWidth(
+          80,
+          RichText(Id(:license_content), product.license(language))
+        )
+      end
+
+      # Return the UI for the confirmation checkbox
+      def confirmation_checkbox
         VBox(
           VSpacing(0.5),
           Left(
             CheckBox(
-              Id("license_#{product.name}"),
+              Id(:license_confirmation),
               Opt(:notify),
               # license agreement check box label
-              _("I &Agree to the License Terms.")
+              _("I &Agree to the License Terms."),
+              confirmed
             )
           )
         )
+      end
+
+      # Update the product's license confirmation status
+      #
+      # It will not update the status if it has not changed.
+      def update_product_confirmation
+        return if product.license_confirmed? == confirmed
+        if confirmed
+          product.confirm_license
+        else
+          product.unconfirm_license
+        end
       end
     end
   end

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -158,14 +158,15 @@ module Y2Packager
       Yast::Pkg.PrdNeedToAcceptLicense(name)
     end
 
-    # Confirm the license for the product
-    def confirm_license
-      Yast::Pkg.PrdMarkLicenseConfirmed(name)
-    end
-
-    # Unconfirm the license for the product
-    def unconfirm_license
-      Yast::Pkg.PrdMarkLicenseUnconfirmed(name)
+    # Set license confirmation for the product
+    #
+    # @param [Boolean] determines whether the license should be accepted or not
+    def license_confirmation=(confirmed)
+      if confirmed
+        Yast::Pkg.PrdMarkLicenseConfirmed(name)
+      else
+        Yast::Pkg.PrdMarkLicenseUnconfirmed(name)
+      end
     end
 
     # Determine whether the license is confirmed

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -47,6 +47,15 @@ module Y2Packager
       Y2Packager::ProductReader.available_base_products
     end
 
+    # Returns the selected base product
+    #
+    # It assumes that at most 1 product could be selected.
+    #
+    # @return [Y2Packager::Product] Selected base product
+    def self.selected_base
+      available_base_products.find(&:selected?)
+    end
+
     # Constructor
     #
     # @param name                 [String]  Name

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -160,7 +160,7 @@ module Y2Packager
 
     # Set license confirmation for the product
     #
-    # @param [Boolean] determines whether the license should be accepted or not
+    # @param confirmed [Boolean] determines whether the license should be accepted or not
     def license_confirmation=(confirmed)
       if confirmed
         Yast::Pkg.PrdMarkLicenseConfirmed(name)

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -93,6 +93,21 @@ module Y2Packager
           name: repo_data["name"], autorefresh: repo_data["autorefresh"],
           url: URI(repo_data["url"]))
       end
+
+      # Add a repository
+      #
+      # @param name        [String]       Name
+      # @param enabled     [Boolean]      Is the repository enabled?
+      # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
+      # @param url         [URI::Generic] Repository URL
+      # @return [Y2Packager::Repository,nil] New repository or nil if creation failed
+      def create(name:, url:, enabled: true, autorefresh: true)
+        repo_id = Yast::Pkg.RepositoryAdd(
+          "name" => name, "base_urls" => [url], "enabled" => enabled, "autorefresh" => autorefresh
+        )
+        return nil unless repo_id
+        new(repo_id: repo_id, name: name, url: URI(url), enabled: enabled, autorefresh: autorefresh)
+      end
     end
 
     # Constructor

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -55,6 +55,16 @@ describe Y2Packager::Clients::InstProductLicense do
       it "returns :next" do
         expect(client.main).to eq(:next)
       end
+
+      context "and user was going back" do
+        before do
+          allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
+        end
+
+        it "returns :back" do
+          expect(client.main).to eq(:back)
+        end
+      end
     end
   end
 end

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -52,18 +52,8 @@ describe Y2Packager::Clients::InstProductLicense do
         client.main
       end
 
-      it "returns :next" do
-        expect(client.main).to eq(:next)
-      end
-
-      context "and user was going back" do
-        before do
-          allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
-        end
-
-        it "returns :back" do
-          expect(client.main).to eq(:back)
-        end
+      it "returns :auto" do
+        expect(client.main).to eq(:auto)
       end
     end
   end

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "y2packager/clients/inst_product_license"
+
+describe Y2Packager::Clients::InstProductLicense do
+  subject(:client) { described_class.new }
+
+  let(:dialog) { instance_double(Y2Packager::Dialogs::InstProductLicense, run: :next) }
+  let(:product) { instance_double(Y2Packager::Product, license?: license?) }
+  let(:license?) { true }
+
+  before do
+    allow(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
+      .and_return(dialog)
+    allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
+  end
+
+  describe "#main" do
+    it "opens the license dialog with the selected product" do
+      expect(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
+        .with(product)
+      client.main
+    end
+
+    context "when the user accepts the license" do
+      before do
+        allow(dialog).to receive(:run).and_return(:next)
+      end
+
+      it "returns :next" do
+        expect(client.main).to eq(:next)
+      end
+    end
+
+    context "when the user clicks the 'Back' button" do
+      before do
+        allow(dialog).to receive(:run).and_return(:back)
+      end
+
+      it "returns :back" do
+        expect(client.main).to eq(:back)
+      end
+    end
+
+    context "when no license is found for the selected base product" do
+      let(:license?) { false }
+
+      it "does not open the license dialog" do
+        expect(Y2Packager::Dialogs::InstProductLicense).to_not receive(:new)
+          .with(product)
+        client.main
+      end
+
+      it "returns :next" do
+        expect(client.main).to eq(:next)
+      end
+    end
+  end
+end

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "y2packager/clients/inst_repositories_initialization"
+
+describe Y2Packager::Clients::InstRepositoriesInitialization do
+  subject(:client) { described_class.new }
+
+  let(:success) { true }
+  let(:prod1) { instance_double(Y2Packager::Product) }
+  let(:prod2) { instance_double(Y2Packager::Product) }
+  let(:products) { [] }
+
+  describe "#main" do
+    before do
+      allow(Yast::Packages).to receive(:InitializeCatalogs)
+      allow(Yast::Packages).to receive(:InitializeAddOnProducts)
+      allow(Yast::Packages).to receive(:InitFailed).and_return(!success)
+      allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
+    end
+
+    it "initializes Packages subsystem" do
+      expect(Yast::Packages).to receive(:InitializeCatalogs)
+      client.main
+    end
+
+    it "returns :next" do
+      expect(client.main).to eq(:next)
+    end
+
+    context "when initialization fails" do
+      let(:success) { false }
+
+      it "returns :abort" do
+        expect(client.main).to eq(:abort)
+      end
+
+      it "shows an error" do
+        expect(Yast::Popup).to receive(:Message)
+        client.main
+      end
+    end
+
+    context "when only one product is available" do
+      let(:products) { [prod1] }
+
+      it "does not unselect the product for installation" do
+        expect(prod1).to_not receive(:restore)
+        client.main
+      end
+    end
+
+    context "when more than one product is available" do
+      let(:products) { [prod1, prod2] }
+
+      it "unselects all products" do
+        expect(prod1).to receive(:restore)
+        expect(prod2).to receive(:restore)
+        client.main
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/inst_product_license_test.rb
+++ b/test/lib/dialogs/inst_product_license_test.rb
@@ -7,11 +7,10 @@ describe Y2Packager::Dialogs::InstProductLicense do
   let(:product) do
     instance_double(
       Y2Packager::Product,
-      label:              "openSUSE",
-      license:            "content",
-      license_confirmed?: confirmed?,
-      confirm_license:    nil,
-      unconfirm_license:  nil
+      label:                   "openSUSE",
+      license:                 "content",
+      license_confirmed?:       confirmed?,
+      :license_confirmation= => nil
     )
   end
 
@@ -34,7 +33,7 @@ describe Y2Packager::Dialogs::InstProductLicense do
         let(:button) { :next }
 
         it "confirms the license" do
-          expect(product).to receive(:confirm_license)
+          expect(product).to receive(:license_confirmation=).with(true)
           dialog.run
         end
 
@@ -47,7 +46,7 @@ describe Y2Packager::Dialogs::InstProductLicense do
         let(:button) { :back }
 
         it "confirms the license" do
-          expect(product).to receive(:confirm_license)
+          expect(product).to receive(:license_confirmation=).with(true)
           dialog.run
         end
 
@@ -79,7 +78,7 @@ describe Y2Packager::Dialogs::InstProductLicense do
         end
 
         it "does not confirm the license" do
-          expect(product).to_not receive(:confirm_license)
+          expect(product).to_not receive(:license_confirmation=)
           dialog.run
         end
       end
@@ -99,7 +98,7 @@ describe Y2Packager::Dialogs::InstProductLicense do
         end
 
         it "confirms the license" do
-          expect(product).to receive(:unconfirm_license)
+          expect(product).to receive(:license_confirmation=).with(false)
           dialog.run
         end
 
@@ -117,7 +116,7 @@ describe Y2Packager::Dialogs::InstProductLicense do
         end
 
         it "unconfirms the license" do
-          expect(product).to receive(:unconfirm_license)
+          expect(product).to receive(:license_confirmation=).with(false)
           dialog.run
         end
 

--- a/test/lib/dialogs/inst_product_license_test.rb
+++ b/test/lib/dialogs/inst_product_license_test.rb
@@ -1,0 +1,130 @@
+require_relative "../../test_helper"
+require "y2packager/dialogs/inst_product_license"
+require "y2packager/product"
+
+describe Y2Packager::Dialogs::InstProductLicense do
+  subject(:dialog) { described_class.new(product) }
+  let(:product) do
+    instance_double(
+      Y2Packager::Product,
+      label:              "openSUSE",
+      license:            "content",
+      license_confirmed?: confirmed?,
+      confirm_license:    nil,
+      unconfirm_license:  nil
+    )
+  end
+
+  let(:language) { "en_US" }
+  let(:confirmed?) { false }
+
+  describe "#run" do
+    before do
+      allow(Yast::Language).to receive(:language).and_return(language)
+    end
+
+    context "when user accepts the license" do
+      before do
+        allow(Yast::UI).to receive(:QueryWidget).with(Id(:license_confirmation), :Value)
+          .and_return(true)
+        allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, button)
+      end
+
+      context "and clicks :next" do
+        let(:button) { :next }
+
+        it "confirms the license" do
+          expect(product).to receive(:confirm_license)
+          dialog.run
+        end
+
+        it "returns :next" do
+          expect(dialog.run).to eq(:next)
+        end
+      end
+
+      context "and clicks :back" do
+        let(:button) { :back }
+
+        it "confirms the license" do
+          expect(product).to receive(:confirm_license)
+          dialog.run
+        end
+
+        it "returns :back" do
+          expect(dialog.run).to eq(:back)
+        end
+      end
+    end
+
+    context "when user does not accept the license" do
+      context "and clicks :next" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:next, :back)
+        end
+
+        it "shows a message" do
+          expect(Yast::Report).to receive(:Message)
+          dialog.run
+        end
+      end
+
+      context "and clicks :back" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:back)
+        end
+
+        it "returns :back" do
+          expect(dialog.run).to eq(:back)
+        end
+
+        it "does not confirm the license" do
+          expect(product).to_not receive(:confirm_license)
+          dialog.run
+        end
+      end
+    end
+
+    context "when the user unconfirms a previously confirmed license" do
+      let(:confirmed?) { true }
+
+      before do
+        allow(Yast::UI).to receive(:QueryWidget).with(Id(:license_confirmation), :Value)
+          .and_return(false)
+      end
+
+      context "and clicks :next" do
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, :next, :back)
+        end
+
+        it "confirms the license" do
+          expect(product).to receive(:unconfirm_license)
+          dialog.run
+        end
+
+        it "shows a message" do
+          expect(Yast::Report).to receive(:Message)
+          dialog.run
+        end
+      end
+
+      context "and clicks :back" do
+        let(:button) { :back }
+
+        before do
+          allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, button)
+        end
+
+        it "unconfirms the license" do
+          expect(product).to receive(:unconfirm_license)
+          dialog.run
+        end
+
+        it "returns :back" do
+          expect(dialog.run).to eq(:back)
+        end
+      end
+    end
+  end
+end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -14,7 +14,19 @@ describe Y2Packager::Product do
     Y2Packager::Product.new(BASE_ATTRS)
   end
 
-  describe "==" do
+  describe ".selected_base" do
+    let(:not_selected) { instance_double(Y2Packager::Product, selected?: false) }
+    let(:selected) { instance_double(Y2Packager::Product, selected?: true) }
+
+    it "returns base selected packages" do
+      allow(described_class).to receive(:available_base_products)
+        .and_return([not_selected, selected])
+
+      expect(described_class.selected_base).to eq(selected)
+    end
+  end
+
+  describe "#==" do
     context "when name, arch, version and vendor match" do
       let(:other) { Y2Packager::Product.new(BASE_ATTRS) }
 

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -228,17 +228,19 @@ describe Y2Packager::Product do
     end
   end
 
-  describe "#confirm_license" do
-    it "confirms the license" do
-      expect(Yast::Pkg).to receive(:PrdMarkLicenseConfirmed).with(product.name)
-      product.confirm_license
+  describe "#license_confirmation=" do
+    context "when 'true' is given" do
+      it "confirms the license" do
+        expect(Yast::Pkg).to receive(:PrdMarkLicenseConfirmed).with(product.name)
+        product.license_confirmation = true
+      end
     end
-  end
 
-  describe "#unconfirm_license" do
-    it "unconfirms the license" do
-      expect(Yast::Pkg).to receive(:PrdMarkLicenseUnconfirmed).with(product.name)
-      product.unconfirm_license
+    context "when 'false' is given" do
+      it "unconfirms the license" do
+        expect(Yast::Pkg).to receive(:PrdMarkLicenseUnconfirmed).with(product.name)
+        product.license_confirmation = false
+      end
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,14 +14,6 @@ RSpec.configure do |config|
   config.include Yast::I18n # available in it/let/before/...
 end
 
-# stub module to prevent its Import
-# Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set name.to_sym, Class.new { def self.fake_method; end }
-end
-
-stub_module("Language")
-
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.start do


### PR DESCRIPTION
This PR, which is built on top of #263, adds clients and dialogs to handle products licenses.

* `Y2Packager::Dialogs::InstProductLicense` offers a dialog to ask for license confirmation. It is used in a `Y2Packager::Clients::InstProductLicense` client.
* `Y2Packager::Clients::InstRepositoriesInitialization` initializes the packaging system. It is supposed to be used before `inst_complex_welcome` and it will set the base product if only one is available (for instance, in `openSUSE`).