### PR TITLE
Add widgets for product licenses

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 31 15:45:38 UTC 2017 - igonzalezsosa@suse.com
+
+- Add widgets to show/confirm product licenses (fate#322276)
+- 3.3.8 
+
+-------------------------------------------------------------------
 Tue Aug 22 14:09:50 UTC 2017 - igonzalezsosa@suse.com
 
 - Moved repositories and product related classes to this module

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.3.7
+Version:        3.3.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -19,11 +19,12 @@ module Y2Packager
     # This client shows a license confirmation dialog for the base selected product
     class InstProductLicense
       include Yast::I18n
+      include Yast::Logger
 
       def main
         textdomain "installation"
-        return :auto unless selected_product && selected_product.license?
-        Y2Packager::Dialogs::InstProductLicense.new(selected_product).run
+        return :auto unless show_license?
+        Y2Packager::Dialogs::InstProductLicense.new(product).run
       end
 
     private
@@ -32,8 +33,36 @@ module Y2Packager
       #
       # @return [Y2Packager::Product]
       # @see Y2Packager::Product.selected_base
-      def selected_product
-        @selected_product ||= Y2Packager::Product.selected_base
+      def product
+        @product ||= Y2Packager::Product.selected_base
+      end
+
+      # Determines whether the license should be shown
+      #
+      # @return [Boolean]
+      def show_license?
+        multi_product_media? && available_license?
+      end
+
+      # Determines whether a multi-product media is being used
+      #
+      # This client only makes sense when using a multi-product media.
+      #
+      # @return [Boolean]
+      def multi_product_media?
+        Y2Packager::Product.available_base_products.size > 1
+      end
+
+      # Determine whether the product's license should be shown
+      #
+      # @return [Boolean] true if the license is available; false otherwise.
+      def available_license?
+        return false unless product
+        if !product.license?
+          log.warn "No license for product '#{product.label}' was found"
+          return false
+        end
+        true
       end
     end
   end

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -23,7 +23,7 @@ module Y2Packager
 
       def main
         textdomain "installation"
-        return :auto unless show_license?
+        return :auto unless available_license?
         Y2Packager::Dialogs::InstProductLicense.new(product).run
       end
 
@@ -35,13 +35,6 @@ module Y2Packager
       # @see Y2Packager::Product.selected_base
       def product
         @product ||= Y2Packager::Product.selected_base
-      end
-
-      # Determines whether the license should be shown
-      #
-      # @return [Boolean]
-      def show_license?
-        multi_product_media? && available_license?
       end
 
       # Determines whether a multi-product media is being used
@@ -57,12 +50,12 @@ module Y2Packager
       #
       # @return [Boolean] true if the license is available; false otherwise.
       def available_license?
-        return false unless product
-        if !product.license?
+        return true if product && product.license?
+        log.warn "No base product is selected for installation" unless product
+        if product && !product.license?
           log.warn "No license for product '#{product.label}' was found"
-          return false
         end
-        true
+        false
       end
     end
   end

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -103,7 +103,7 @@ module Y2Packager
         ComboBox(
           Id(:language),
           Opt(:notify, :hstretch),
-          _("&Language"),
+          _("&License Language"),
           Yast::Language.GetLanguageItems(:primary)
         )
       end

--- a/src/lib/y2packager/widgets/product_license.rb
+++ b/src/lib/y2packager/widgets/product_license.rb
@@ -46,6 +46,7 @@ module Y2Packager
       # @see CWM::CustomWidget#contents
       def contents
         VBox(
+          Left(Label(_("License Agreement"))),
           license_content,
           confirmation_checkbox
         )

--- a/src/lib/y2packager/widgets/product_license.rb
+++ b/src/lib/y2packager/widgets/product_license.rb
@@ -1,0 +1,105 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+require "y2packager/widgets/product_license_confirmation"
+
+module Y2Packager
+  module Widgets
+    # Widget to show a product's license
+    #
+    # This widget relies on Y2Packager::Widgets::ProductLicenseConfirmation to
+    # show the license confirmation checkbox.
+    class ProductLicense < CWM::CustomWidget
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+
+      # Constructor
+      #
+      # @param product [Y2Packager::Product] Product to ask for the license
+      def initialize(product, language = nil)
+        textdomain "packager"
+        @product = product
+        @language = language || Yast::Language.language
+      end
+
+      # Widget label
+      #
+      # @return [String] Translated label
+      # @see CWM::AbstractWidget#label
+      def label
+        _("License Agreement")
+      end
+
+      # Widget content
+      #
+      # @see CWM::CustomWidget#contents
+      def contents
+        VBox(
+          license_content,
+          confirmation_checkbox
+        )
+      end
+
+    private
+
+      # @return [String] Language code (en_US, es_ES, etc.).
+      attr_accessor :language
+
+      # Return the UI for the license content
+      #
+      # @return [Yast::Term] UI for the license content
+      def license_content
+        MinWidth(
+          80,
+          RichText(Id(:license_content), formatted_license_text)
+        )
+      end
+
+      # Regexp to determine whether the text is formatted as richtext
+      RICHTEXT_REGEXP = /<\/.*>/
+
+      # Return the license text
+      #
+      # It detects whether license text is richtext or not and format it
+      # accordingly.
+      #
+      # @return [String] Formatted license text
+      def formatted_license_text
+        text = product.license(language)
+        if RICHTEXT_REGEXP =~ text
+          text
+        else
+          "<pre>#{CGI.escapeHTML(text)}</pre>"
+        end
+      end
+
+      # Return the UI for the confirmation checkbox
+      #
+      # It returns Empty() if confirmation is not needed.
+      #
+      # @return [Yast::Term] Product confirmation license widget or Empty() if
+      #   confirmation is not needed.
+      def confirmation_checkbox
+        return Empty() unless product.license_confirmation_required?
+
+        VBox(
+          VSpacing(0.5),
+          Left(
+            ::Y2Packager::Widgets::ProductLicenseConfirmation.new(product)
+          )
+        )
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/widgets/product_license_confirmation.rb
+++ b/src/lib/y2packager/widgets/product_license_confirmation.rb
@@ -13,6 +13,8 @@
 require "yast"
 require "cwm"
 
+Yast.import "Report"
+
 module Y2Packager
   module Widgets
     # Widget for product license confirmation
@@ -54,6 +56,14 @@ module Y2Packager
         product.license_confirmed? ? check : uncheck
       end
 
+      # Handle value changes
+      #
+      # @see CWM::AbstractWidget#handle
+      # @see #store
+      def handle
+        store
+      end
+
       # Update product license confirmation status
       #
       # @see CWM::AbstractWidget#store
@@ -62,6 +72,20 @@ module Y2Packager
         return if product.license_confirmed? == value
         product.license_confirmation = value
         nil
+      end
+
+      # Validate value
+      #
+      # The value is not valid if license is required but not confirmed.
+      # This method shows an error if validation fails.
+      #
+      # @return [Boolean] true if the value is valid; false otherwise
+      # @see CWM::AbstractWidget#validate
+      def validate
+        return true if !product.license_confirmation_required? || product.license_confirmed?
+
+        Yast::Report.Message(_("You must accept the license to install this product"))
+        false
       end
     end
   end

--- a/src/lib/y2packager/widgets/product_license_confirmation.rb
+++ b/src/lib/y2packager/widgets/product_license_confirmation.rb
@@ -1,0 +1,68 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+
+module Y2Packager
+  module Widgets
+    # Widget for product license confirmation
+    #
+    # Presents a checkbox to confirm product's license. This widget will update
+    # the product's license confirmation status
+    class ProductLicenseConfirmation < CWM::CheckBox
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+
+      # Constructor
+      #
+      # @param product [Y2Packager::Product] Product to confirm license
+      def initialize(product)
+        textdomain "packager"
+        @product = product
+      end
+
+      # Widget label
+      #
+      # @return [String] Translated label
+      # @see CWM::AbstractWidget#label
+      def label
+        # license agreement check box label
+        _("I &Agree to the License Terms.")
+      end
+
+      # Widget options
+      #
+      # @see CWM::AbstractWidget#opt
+      def opt
+        [:notify]
+      end
+
+      # Widget value initializer
+      #
+      # @see CWM::AbstractWidget#init
+      def init
+        product.license_confirmed? ? check : uncheck
+      end
+
+      # Update product license confirmation status
+      #
+      # @see CWM::AbstractWidget#store
+      # @see Y2Packager::Product#license_confirmation
+      def store
+        return if product.license_confirmed? == value
+        product.license_confirmation = value
+        nil
+      end
+    end
+  end
+end

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -84,13 +84,5 @@ describe Y2Packager::Clients::InstProductLicense do
         expect(client.main).to eq(:auto)
       end
     end
-
-    context "when only 1 product is available" do
-      let(:products) { [product] }
-
-      it "returns :auto" do
-        expect(client.main).to eq(:auto)
-      end
-    end
   end
 end

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -7,13 +7,27 @@ describe Y2Packager::Clients::InstProductLicense do
   subject(:client) { described_class.new }
 
   let(:dialog) { instance_double(Y2Packager::Dialogs::InstProductLicense, run: :next) }
-  let(:product) { instance_double(Y2Packager::Product, license?: license?) }
+  let(:product) do
+    instance_double(
+      Y2Packager::Product,
+      label:                          "SLES",
+      license?:                       license?,
+      license_confirmation_required?: confirmation_required?,
+      license_confirmed?:             license_confirmed?
+    )
+  end
+  let(:other_product) { instance_double(Y2Packager::Product) }
+  let(:products) { [product, other_product] }
+
   let(:license?) { true }
+  let(:confirmation_required?) { true }
+  let(:license_confirmed?) { false }
 
   before do
     allow(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
       .and_return(dialog)
     allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
+    allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
   end
 
   describe "#main" do
@@ -65,6 +79,14 @@ describe Y2Packager::Clients::InstProductLicense do
           .with(product)
         client.main
       end
+
+      it "returns :auto" do
+        expect(client.main).to eq(:auto)
+      end
+    end
+
+    context "when only 1 product is available" do
+      let(:products) { [product] }
 
       it "returns :auto" do
         expect(client.main).to eq(:auto)

--- a/test/lib/widgets/product_license_confirmation_test.rb
+++ b/test/lib/widgets/product_license_confirmation_test.rb
@@ -11,14 +11,23 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
 
   subject(:widget) { described_class.new(product) }
 
-  let(:license_confirmed) { false }
+  let(:license_confirmed?) { false }
+  let(:confirmation_required?) { false }
   let(:product) do
-    instance_double(Y2Packager::Product, license_confirmed?: license_confirmed)
+    instance_double(
+      Y2Packager::Product,
+      license_confirmed?:             license_confirmed?,
+      license_confirmation_required?: confirmation_required?
+    )
+  end
+
+  before do
+    allow(product).to receive(:license_confirmation=)
   end
 
   describe "#init" do
     context "when product license is unconfirmed" do
-      let(:license_confirmed) { false }
+      let(:license_confirmed?) { false }
 
       it "sets value to false" do
         expect(widget).to receive(:uncheck)
@@ -27,7 +36,7 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
     end
 
     context "when product license is confirmed" do
-      let(:license_confirmed) { true }
+      let(:license_confirmed?) { true }
 
       it "sets value to true" do
         expect(widget).to receive(:check)
@@ -45,7 +54,7 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       let(:value) { true }
 
       context "and product license is unconfirmed" do
-        let(:license_confirmed) { false }
+        let(:license_confirmed?) { false }
 
         it "sets the license as confirmed" do
           expect(product).to receive(:license_confirmation=).with(true)
@@ -54,7 +63,7 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       end
 
       context "and product license is confirmed" do
-        let(:license_confirmed) { true }
+        let(:license_confirmed?) { true }
 
         it "does not modify product's license confirmation" do
           expect(product).to_not receive(:license_confirmation=)
@@ -67,7 +76,7 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       let(:value) { false }
 
       context "and product license is unconfirmed" do
-        let(:license_confirmed) { false }
+        let(:license_confirmed?) { false }
 
         it "does not modify product's license confirmation" do
           expect(product).to_not receive(:license_confirmation=)
@@ -76,11 +85,48 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       end
 
       context "and product license is confirmed" do
-        let(:license_confirmed) { true }
+        let(:license_confirmed?) { true }
 
         it "sets the license as unconfirmed" do
           expect(product).to receive(:license_confirmation=).with(false)
           widget.store
+        end
+      end
+    end
+  end
+
+  describe "#handle" do
+    it "calls #store" do
+      expect(widget).to receive(:store)
+      widget.handle
+    end
+  end
+
+  describe "#validate" do
+    context "when license confirmation is not needed" do
+      let(:confirmation_required?) { false }
+
+      it "returns true" do
+        expect(widget.validate).to eq(true)
+      end
+    end
+
+    context "when license confirmation is required" do
+      let(:confirmation_required?) { true }
+
+      context "and license is confirmed" do
+        let(:license_confirmed?) { true }
+
+        it "returns true" do
+          expect(widget.validate).to eq(true)
+        end
+      end
+
+      context "and license is still unconfirmed" do
+        let(:license_confirmed?) { false }
+
+        it "returns false" do
+          expect(widget.validate).to eq(false)
         end
       end
     end

--- a/test/lib/widgets/product_license_confirmation_test.rb
+++ b/test/lib/widgets/product_license_confirmation_test.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "cwm/abstract_widget"
+require "cwm/rspec"
+require "y2packager/widgets/product_license_confirmation"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::ProductLicenseConfirmation do
+  include_examples "CWM::AbstractWidget"
+
+  subject(:widget) { described_class.new(product) }
+
+  let(:license_confirmed) { false }
+  let(:product) do
+    instance_double(Y2Packager::Product, license_confirmed?: license_confirmed)
+  end
+
+  describe "#init" do
+    context "when product license is unconfirmed" do
+      let(:license_confirmed) { false }
+
+      it "sets value to false" do
+        expect(widget).to receive(:uncheck)
+        widget.init
+      end
+    end
+
+    context "when product license is confirmed" do
+      let(:license_confirmed) { true }
+
+      it "sets value to true" do
+        expect(widget).to receive(:check)
+        widget.init
+      end
+    end
+  end
+
+  describe "#store" do
+    before do
+      allow(widget).to receive(:value).and_return(value)
+    end
+
+    context "when widget's value is true" do
+      let(:value) { true }
+
+      context "and product license is unconfirmed" do
+        let(:license_confirmed) { false }
+
+        it "sets the license as confirmed" do
+          expect(product).to receive(:license_confirmation=).with(true)
+          widget.store
+        end
+      end
+
+      context "and product license is confirmed" do
+        let(:license_confirmed) { true }
+
+        it "does not modify product's license confirmation" do
+          expect(product).to_not receive(:license_confirmation=)
+          widget.store
+        end
+      end
+    end
+
+    context "when widget's value is false" do
+      let(:value) { false }
+
+      context "and product license is unconfirmed" do
+        let(:license_confirmed) { false }
+
+        it "does not modify product's license confirmation" do
+          expect(product).to_not receive(:license_confirmation=)
+          widget.store
+        end
+      end
+
+      context "and product license is confirmed" do
+        let(:license_confirmed) { true }
+
+        it "sets the license as unconfirmed" do
+          expect(product).to receive(:license_confirmation=).with(false)
+          widget.store
+        end
+      end
+    end
+  end
+end

--- a/test/lib/widgets/product_license_test.rb
+++ b/test/lib/widgets/product_license_test.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "cwm/abstract_widget"
+require "cwm/rspec"
+require "y2packager/widgets/product_license"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::ProductLicense do
+  include_examples "CWM::CustomWidget"
+
+  before do
+    allow(Yast::Language).to receive(:language).and_return(language)
+  end
+
+  subject(:widget) { described_class.new(product) }
+
+  let(:language) { "de_DE" }
+  let(:license_confirmation_required?) { true }
+  let(:product) do
+    instance_double(
+      Y2Packager::Product,
+      license:                        "license_content",
+      license_confirmation_required?: license_confirmation_required?
+    )
+  end
+
+  describe "#contents" do
+    let(:confirmation_widget) { Yast::Term.new(:confirmation_widget) }
+
+    before do
+      allow(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new)
+        .and_return(confirmation_widget)
+    end
+
+    it "shows the license in the given language" do
+      expect(product).to receive(:license).with(language).and_return("de_DE license")
+      expect(widget.contents.to_s).to include("de_DE license")
+    end
+
+    it "includes a confirmation checkbox" do
+      expect(widget.contents.to_s).to include("confirmation_widget")
+    end
+
+    context "when license confirmation is not needed" do
+      let(:license_confirmation_required?) { false }
+
+      it "does includes a confirmation checkbox" do
+        expect(widget.contents.to_s).to_not include("confirmation_widget")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `ProductLicense` and `ProductLicenseConfirmation` as widgets to show/confirm product licenses.