### PR TITLE
Warn no products && disable license confirmation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Sep  5 10:24:26 UTC 2017 - igonzalezsosa@suse.com
+
+- Report an error when no available base products are found
+- Add support to skip validations in the product license widget
+  (fate#322276)
+- 3.3.10
+
+-------------------------------------------------------------------
 Thu Aug 31 15:45:38 UTC 2017 - igonzalezsosa@suse.com
 
 - Add widgets to show/confirm product licenses (fate#322276)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.3.9
+Version:        3.3.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/product_reader.rb
+++ b/src/lib/y2packager/product_reader.rb
@@ -77,6 +77,7 @@ module Y2Packager
 
     def self.installation_package_mapping
       installation_packages = Yast::Pkg.PkgQueryProvides("system-installation()")
+      log.info "Installation packages: #{installation_packages.inspect}"
 
       mapping = {}
       installation_packages.each do |list|

--- a/src/lib/y2packager/widgets/product_license.rb
+++ b/src/lib/y2packager/widgets/product_license.rb
@@ -23,14 +23,17 @@ module Y2Packager
     class ProductLicense < CWM::CustomWidget
       # @return [Y2Packager::Product] Product
       attr_reader :product
+      # @param skip_validation [Boolean] Skip value validation
+      attr_reader :skip_validation
 
       # Constructor
       #
       # @param product [Y2Packager::Product] Product to ask for the license
-      def initialize(product, language = nil)
+      def initialize(product, language: nil, skip_validation: false)
         textdomain "packager"
         @product = product
         @language = language || Yast::Language.language
+        @skip_validation = skip_validation
       end
 
       # Widget label
@@ -97,7 +100,7 @@ module Y2Packager
         VBox(
           VSpacing(0.5),
           Left(
-            ::Y2Packager::Widgets::ProductLicenseConfirmation.new(product)
+            ProductLicenseConfirmation.new(product, skip_validation: skip_validation)
           )
         )
       end

--- a/src/lib/y2packager/widgets/product_license_confirmation.rb
+++ b/src/lib/y2packager/widgets/product_license_confirmation.rb
@@ -24,13 +24,16 @@ module Y2Packager
     class ProductLicenseConfirmation < CWM::CheckBox
       # @return [Y2Packager::Product] Product
       attr_reader :product
+      # @param skip_validation [Boolean] Skip value validation
+      attr_reader :skip_validation
 
       # Constructor
       #
       # @param product [Y2Packager::Product] Product to confirm license
-      def initialize(product)
+      def initialize(product, skip_validation: false)
         textdomain "packager"
         @product = product
+        @skip_validation = skip_validation
       end
 
       # Widget label
@@ -82,7 +85,9 @@ module Y2Packager
       # @return [Boolean] true if the value is valid; false otherwise
       # @see CWM::AbstractWidget#validate
       def validate
-        return true if !product.license_confirmation_required? || product.license_confirmed?
+        if skip_validation || !product.license_confirmation_required? || product.license_confirmed?
+          return true
+        end
 
         Yast::Report.Message(_("You must accept the license to install this product"))
         false

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -9,7 +9,7 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
   let(:success) { true }
   let(:prod1) { instance_double(Y2Packager::Product) }
   let(:prod2) { instance_double(Y2Packager::Product) }
-  let(:products) { [] }
+  let(:products) { [prod1] }
 
   describe "#main" do
     before do
@@ -36,7 +36,7 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       end
 
       it "shows an error" do
-        expect(Yast::Popup).to receive(:Message)
+        expect(Yast::Popup).to receive(:Error)
         client.main
       end
     end
@@ -56,6 +56,19 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       it "unselects all products" do
         expect(prod1).to receive(:restore)
         expect(prod2).to receive(:restore)
+        client.main
+      end
+    end
+
+    context "when no products are found" do
+      let(:products) { [] }
+
+      it "returns :abort" do
+        expect(client.main).to eq(:abort)
+      end
+
+      it "shows an error" do
+        expect(Yast::Popup).to receive(:Error)
         client.main
       end
     end

--- a/test/lib/widgets/product_license_confirmation_test.rb
+++ b/test/lib/widgets/product_license_confirmation_test.rb
@@ -130,5 +130,16 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
         end
       end
     end
+
+    context "when validation is disabled" do
+      let(:confirmation_required?) { true }
+      let(:license_confirmed?) { false }
+
+      subject(:widget) { described_class.new(product, skip_validation: true) }
+
+      it "returns true" do
+        expect(widget.validate).to eq(true)
+      end
+    end
   end
 end

--- a/test/lib/widgets/product_license_test.rb
+++ b/test/lib/widgets/product_license_test.rb
@@ -39,7 +39,19 @@ describe Y2Packager::Widgets::ProductLicense do
     end
 
     it "includes a confirmation checkbox" do
+      expect(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new)
+        .with(product, skip_validation: false)
       expect(widget.contents.to_s).to include("confirmation_widget")
+    end
+
+    context "when validation is disabled" do
+      subject(:widget) { described_class.new(product, skip_validation: true) }
+
+      it "disables confirmation widget validation" do
+        expect(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new)
+          .with(product, skip_validation: true)
+        expect(widget.contents.to_s).to include("confirmation_widget")
+      end
     end
 
     context "when license confirmation is not needed" do


### PR DESCRIPTION
* Allow to disable confirmation for `ProductLicenseConfirmation` widget (needed by complex welcome).
* Show an error when no installable products are found.