### PR TITLE
Add on product selection for multi-module media

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 18 14:02:10 UTC 2017 - lslezak@suse.cz
+
+- Display a product selection dialog when the add-on medium
+  contains multiple products (fate#323886)
+- 4.0.6
+
+-------------------------------------------------------------------
 Mon Sep 18 08:32:16 UTC 2017 - igonzalezsosa@suse.com
 
 - Add support to read release notes from an RPM in the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -201,7 +201,7 @@ module Yast
           URL.HidePassword(url)
         )
 
-        if Builtins.regexpmatch(url, "\\.iso$")
+        if url.end_with?(".iso")
           parsed_url = URL.Parse(url)
           scheme2 = Builtins.tolower(Ops.get_string(parsed_url, "scheme", ""))
 
@@ -223,10 +223,7 @@ module Yast
           _("Change the URL and try again?")
         )
 
-        tryagain = Popup.YesNo(msg)
-        return :again if tryagain
-
-        return :cancel
+        Popup.YesNo(msg) ? :again : :cancel
       else
         Progress.NextStage
         license_accepted = true
@@ -253,7 +250,7 @@ module Yast
         # relese (unmount) the medium
         Pkg.SourceReleaseAll
 
-        return license_accepted ? :ok : :abort
+        license_accepted ? :ok : :abort
       end
     end
 

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -1,3 +1,6 @@
+
+require "y2packager/product_location"
+
 # encoding: utf-8
 module Yast
   # Include file to be shared by yast2-packager and yast2-add-on
@@ -69,103 +72,24 @@ module Yast
           PackageSystem.CheckAndInstallPackages(["cifs-mount"])
         end
 
-        Progress.New(
-          # TRANSLATORS: dialog caption
-          _("Adding a New Repository"),
-          " ",
-          3,
-          [
-            _("Check Repository Type"),
-            _("Add Repository"),
-            _("Read Repository License")
-          ],
-          [
-            _("Checking Repository Type"),
-            _("Adding Repository"),
-            _("Reading Repository License")
-          ],
-          # TRANSLATORS: dialog help
-          _(
-            "<p>The repository manager is downloading repository details...</p>"
-          )
-        )
+        initialize_progress
 
         Progress.NextStage
         service_type = Pkg.ServiceProbe(expanded_url)
         Builtins.y2milestone("Probed service type: %1", service_type)
 
         if !service_type.nil? && service_type != "NONE"
-          Builtins.y2milestone("Adding a service of type %1...", service_type)
-          alias_name = "service"
-
-          # all current aliases
-          aliases = Builtins.maplist(@serviceStatesOut) do |s|
-            Ops.get_string(s, "alias", "")
-          end
-
-          # service alias must be unique
-          # if it already exists add "_<number>" suffix to it
-          idx = 1
-          while Builtins.contains(aliases, alias_name)
-            alias_name = Builtins.sformat("service_%1", idx)
-            idx = Ops.add(idx, 1)
-          end
-
-          # use alias as the name if it's missing
-          preffered_name = alias_name if preffered_name.nil? || preffered_name == ""
-
-          new_service = {
-            "alias"       => alias_name,
-            "autorefresh" => autorefresh_for?(url),
-            "enabled"     => true,
-            "name"        => preffered_name,
-            "url"         => url
-          }
-
-          Builtins.y2milestone("Added new service: %1", new_service)
-
-          @serviceStatesOut = Builtins.add(@serviceStatesOut, new_service)
-
+          add_service()
           return :ok
         end
 
-        new_repos = Pkg.RepositoryScan(expanded_url)
-        Builtins.y2milestone("new_repos: %1", new_repos)
-
-        # add at least one product if the scan result is empty (no product info available)
-        if Builtins.size(new_repos).zero?
-          url_path = Ops.get_string(URL.Parse(url), "path", "")
-          p_elems = Builtins.splitstring(url_path, "/")
-          fallback = _("Repository")
-
-          if Ops.greater_than(Builtins.size(p_elems), 1)
-            url_path = Ops.get(
-              p_elems,
-              Ops.subtract(Builtins.size(p_elems), 1),
-              fallback
-            )
-
-            if url_path.nil? || url_path == ""
-              url_path = Ops.get(
-                p_elems,
-                Ops.subtract(Builtins.size(p_elems), 2),
-                fallback
-              )
-
-              url_path = fallback if url_path.nil? || url_path == ""
-            end
-          end
-
-          new_repos = [[url_path, "/"]]
-        end
-
+        found_products = scan_products(expanded_url)
         newSources = []
 
         enter_again = false
 
         # more products on the medium, let the user choose the products to install
         if !Mode.auto && new_repos.size > 1
-          require "y2packager/product_location"
           require "y2packager/dialogs/addon_selector"
           products = new_repos.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
 
@@ -175,28 +99,22 @@ module Yast
           # abort/cancel/back/... => do not continue
           return :cancel unless ui == :next
 
-          new_repos = dialog.selected_products.map { |p| [p.name, p.dir] }
-
+          found_products = dialog.selected_products
           # nothing selected
-          return :cancel if new_repos.empty?
+          return :cancel if found_products.empty?
         end
 
-        Builtins.foreach(new_repos) do |repo|
+        found_products.each do |product|
           next if enter_again
-          prod_dir = Ops.get(repo, 1, "/")
-          name = Ops.get(repo, 0, "")
+          name = product.name
           if !preffered_name.nil? && preffered_name != ""
             name = preffered_name
-            name += " (#{prod_dir})" if ![nil, "", "/"].include?(prod_dir)
+            name += " (#{product.dir})" if ![nil, "", "/"].include?(product.dir)
           end
           # probe repository type (do not probe plaindir repo)
-          repo_type = plaindir ? @plaindir_type : Pkg.RepositoryProbe(expanded_url, prod_dir)
-          Builtins.y2milestone(
-            "Repository type (%1,%2): %3",
-            URL.HidePassword(url),
-            prod_dir,
-            repo_type
-          )
+          repo_type = plaindir ? @plaindir_type : Pkg.RepositoryProbe(expanded_url, product.dir)
+          log.info("Repository type (#{URL.HidePassword(url)},#{repo.dir}): #{repo_type}")
+
           # the probing has failed
           if repo_type.nil? || repo_type == "NONE"
             if scheme == "dir"
@@ -226,53 +144,34 @@ module Yast
 
             next
           end
-          alias_name = ""
-          if force_alias == ""
-            # replace " " -> "_" (avoid spaces in .repo file name) and remove shell unfriendly chars
-            alias_name = name.tr(" ", "_").delete(SHELL_UNFRIENDLY)
-            alias_orig = alias_name
 
-            # all current aliases
-            aliases = Builtins.maplist(Pkg.SourceGetCurrent(false)) do |i|
-              info = Pkg.SourceGeneralData(i)
-              Ops.get_string(info, "alias", "")
-            end
+          alias_name = (force_alias == "") ? propose_alias(product.name) : force_alias
 
-            # repository alias must be unique
-            # if it already exists add "_<number>" suffix to it
-            idx = 1
-            while Builtins.contains(aliases, alias_name)
-              alias_name = Builtins.sformat("%1_%2", alias_orig, idx)
-              idx = Ops.add(idx, 1)
-            end
-          else
-            alias_name = force_alias
-          end
           # map with repository parameters: $[ "enabled" : boolean,
           # "autorefresh" : boolean, "name" : string, "alias" : string,
           # "base_urls" : list<string>, "prod_dir" : string, "type" : string ]
-          repo_prop = {}
-          Ops.set(repo_prop, "enabled", true)
-          Ops.set(repo_prop, "autorefresh", autorefresh_for?(url))
-          Ops.set(repo_prop, "name", name)
-          Ops.set(repo_prop, "prod_dir", Ops.get(repo, 1, "/"))
-          Ops.set(repo_prop, "alias", alias_name)
-          Ops.set(repo_prop, "base_urls", [url])
-          Ops.set(repo_prop, "type", repo_type)
+          repo_prop = {
+            "enabled" => true,
+            "autorefresh" => autorefresh_for?(url),
+            "name" => name,
+            "prod_dir" => product.dir,
+            "alias" => alias_name,
+            "base_urls" => [url],
+            "type" => repo_type
+          }
           if force_alias != ""
             # don't check uniqueness of the alias, force the alias
-            Ops.set(repo_prop, "check_alias", false)
+            repo_prop["check_alias"] = false
           end
           Progress.NextStage
           new_repo_id = Pkg.RepositoryAdd(repo_prop)
+
+          # hide the URL password in the log
           repo_prop_log = deep_copy(repo_prop)
-          Ops.set(repo_prop_log, "base_urls", [URL.HidePassword(url)])
-          Builtins.y2milestone(
-            "Added repository: %1: %2",
-            new_repo_id,
-            repo_prop_log
-          )
-          newSources = Builtins.add(newSources, new_repo_id)
+          repo_prop_log["base_urls"] = [URL.HidePassword(url)]
+          log.info("Added repository: #{new_repo_id}: #{repo_prop_log}")
+
+          newSources << new_repo_id
 
           # for local repositories (e.g. CD/DVD) which have autorefresh disabled
           # download the metadata immediately, the medium is in the drive right
@@ -291,7 +190,7 @@ module Yast
 
         Builtins.y2milestone("New sources: %1", newSources)
 
-        if Builtins.size(newSources).zero?
+        if newSources.empty?
           Builtins.y2error("Cannot add the repository")
 
           # popup message part 1
@@ -487,5 +386,125 @@ module Yast
       log.info "Autorefresh flag for '#{protocol}' URL protocol: #{autorefresh}"
       autorefresh
     end
+
+    private
+
+    # scan the repository URL and return the available products
+    # @return [Array<Y2Packager::ProductLocation>] Found products
+    def scan_products(expanded_url)
+      new_repos = Pkg.RepositoryScan(expanded_url)
+      found_products = new_repos.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
+      log.info("Found products: #{found_products}")
+
+      # add at least one product if the scan result is empty (no product info available)
+      # to try adding the repository at the root (/) of the medium
+      if found_products.empty?
+        url_path = URL.Parse(url)["path"]
+        p_elems = url_path.split("/")
+
+        fallback = _("Repository")
+
+        if p_elems.size > 1
+          url_path = Ops.get(
+            p_elems,
+            Ops.subtract(Builtins.size(p_elems), 1),
+            fallback
+          )
+
+          if url_path.nil? || url_path == ""
+            url_path = Ops.get(
+              p_elems,
+              Ops.subtract(Builtins.size(p_elems), 2),
+              fallback
+            )
+
+            url_path = fallback if url_path.nil? || url_path == ""
+          end
+        end
+
+        found_products << Y2Packager::ProductLocation.new(url_path, "/")
+      end
+
+      found_products
+    end
+
+    # propose the repository alias (based on the product name)
+    # @return [String] an unique alias
+    def propose_alias(product_name)
+      # replace " " -> "_" (avoid spaces in .repo file name) and remove shell unfriendly chars
+      alias_name = product_name.tr(" ", "_").delete(SHELL_UNFRIENDLY)
+      alias_orig = alias_name
+
+      # all current aliases
+      aliases = Pkg.SourceGetCurrent(false).map do |i|
+        Pkg.SourceGeneralData(i)["alias"]
+      end
+
+      # repository alias must be unique
+      # if it already exists add "_<number>" suffix to it
+      idx = 1
+      while aliases.include?(alias_name)
+        alias_name = "#{alias_orig}_#{idx}"
+        idx += 1
+      end
+
+      alias_name
+    end
+
+    # initialize the progress for adding new add-on repository
+    def initialize_progress
+      Progress.New(
+        # TRANSLATORS: dialog caption
+        _("Adding a New Repository"),
+        " ",
+        3,
+        [
+          _("Check Repository Type"),
+          _("Add Repository"),
+          _("Read Repository License")
+        ],
+        [
+          _("Checking Repository Type"),
+          _("Adding Repository"),
+          _("Reading Repository License")
+        ],
+        # TRANSLATORS: dialog help
+        _(
+          "<p>The repository manager is downloading repository details...</p>"
+        )
+      )
+    end
+
+    def add_service(url, type, preffered_name)
+      Builtins.y2milestone("Adding a service of type %1...", service_type)
+
+      # all current aliases
+      aliases = @serviceStatesOut.map { |s| s["alias"] }
+
+      # service alias must be unique
+      # if it already exists add "_<number>" suffix to it
+      idx = 1
+      alias_name = "service"
+      while aliases.include?(alias_name)
+        alias_name = "service_#{idx}"
+        idx += 1
+      end
+
+      # use alias as the name if it's missing
+      preffered_name = alias_name if preffered_name.nil? || preffered_name == ""
+
+      new_service = {
+        "alias"       => alias_name,
+        "autorefresh" => autorefresh_for?(url),
+        "enabled"     => true,
+        "name"        => preffered_name,
+        "url"         => url
+      }
+
+      log.info("Added new service: #{new_service}")
+
+      @serviceStatesOut << new_service
+    end
+
   end
 end

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -163,6 +163,24 @@ module Yast
 
         enter_again = false
 
+        # more products on the medium, let the user choose the products to install
+        if !Mode.auto && new_repos.size > 1
+          require "y2packager/product_location"
+          require "y2packager/dialogs/addon_selector"
+          products = new_repos.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
+
+          dialog = Y2Packager::Dialogs::AddonSelector.new(products)
+          ui = dialog.run
+
+          # abort/cancel/back/... => do not continue
+          return :cancel unless ui == :next
+
+          new_repos = dialog.selected_products.map { |p| [p.name, p.dir] }
+
+          # nothing selected
+          return :cancel if new_repos.empty?
+        end
+
         Builtins.foreach(new_repos) do |repo|
           next if enter_again
           prod_dir = Ops.get(repo, 1, "/")

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -81,7 +81,7 @@ module Yast
       Builtins.y2milestone("Probed service type: %1", service_type)
 
       # create a new service if a service is detected at the URL
-      if !service_type.nil? && service_type != "NONE"
+      if ![nil, "NONE"].include?(service_type)
         add_service(url, preffered_name)
         return :ok
       end
@@ -164,10 +164,7 @@ module Yast
       end
 
       # broken repository or wrong URL - enter the URL again
-      if enter_again
-        Pkg.SourceReleaseAll
-        return :again
-      end
+      return :again if enter_again
 
       log.info("New sources: #{newSources}")
 
@@ -197,11 +194,11 @@ module Yast
           end
         end
 
-        # relese (unmount) the medium
-        Pkg.SourceReleaseAll
-
         license_accepted ? :ok : :abort
       end
+    ensure
+      # relese (unmount) the medium
+      Pkg.SourceReleaseAll
     end
 
     # start createSource() function in extra wizard dialog
@@ -334,7 +331,7 @@ module Yast
     # @return [Array<Y2Packager::ProductLocation>] Found products
     def scan_products(expanded_url, original_url)
       new_repos = Pkg.RepositoryScan(expanded_url)
-      found_products = new_repos.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
+      found_products = new_repos.map { |(name, dir)| Y2Packager::ProductLocation.new(name, dir) }
       log.info("Found products: #{found_products}")
 
       # add at least one product if the scan result is empty (no product info available)

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -10,6 +10,9 @@ module Yast
     # constant Plaindir
     PLAINDIR_TYPE = "Plaindir".freeze
 
+    # shell unfriendly characters we want to remove from alias, so it is easier to use with zypper
+    SHELL_UNFRIENDLY = "()/!'\"*?;&|<>{}$#`".freeze
+
     def initialize_packager_repositories_include(_include_target)
       Yast.import "Pkg"
       Yast.import "Stage"
@@ -37,9 +40,6 @@ module Yast
     def LicenseAccepted(id)
       AddOnProduct.AcceptedLicenseAndInfoFile(id)
     end
-
-    # shell unfriendly characters we want to remove from alias, so it is easier to use with zypper
-    SHELL_UNFRIENDLY = "()/!'\"*?;&|<>{}$#`".freeze
 
     # Create a new repository or service.
     # @param url [String] repository or service URL
@@ -206,10 +206,7 @@ module Yast
 
     # start createSource() function in extra wizard dialog
     def createSource(url, plaindir, download, preffered_name)
-      Wizard.CreateDialog
-      ret = createSourceImpl(url, plaindir, download, preffered_name, "")
-      Wizard.CloseDialog
-      ret
+      createSourceWithAlias(url, plaindir, download, preffered_name, "")
     end
 
     # create source with alias
@@ -364,6 +361,8 @@ module Yast
 
             url_path = fallback if url_path.nil? || url_path == ""
           end
+        elsif url_path == "/"
+          url_path = fallback
         end
 
         found_products << Y2Packager::ProductLocation.new(url_path, "/")

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "ui/installation_dialog"
+
+Yast.import "UI"
+Yast.import "Report"
+
+module Y2Packager
+  module Dialogs
+    # Dialog which shows the user available products on the medium
+    class AddonSelector < ::UI::InstallationDialog
+      include Yast::Logger
+
+      # @return [Array<Y2Packager::ProductLocation>] Products on the medium
+      attr_reader :products
+      # @return [Array<Y2Packager::ProductLocation>] User selected products
+      attr_reader :selected_products
+
+      # Constructor
+      #
+      # @param product [Array<Y2Packager::ProductLocation>] Products on the medium
+      def initialize(products)
+        super()
+        textdomain "packager"
+
+        @products = products
+        @selected_products = []
+      end
+
+      # Handler for the :next action
+      #
+      # This action happens when the user clicks the 'Next' button
+      def next_handler
+        read_user_selection
+        finish_dialog(:next)
+      end
+
+      # Handler for the :next action
+      # The default implementation asks for confirmation, here we abort only
+      # adding an addon-on, not the whole installation.
+      def abort_handler
+        finish_dialog(:abort)
+      end
+
+      # Text to display when the help button is pressed
+      #
+      # @return [String]
+      def help_text
+        # TRANSLATORS: help text (1/2)
+        _("<p>The selected repository contains several products in independent " \
+        "subdirectories. Select which products you want to install.</p>") +
+          # TRANSLATORS: help text (2/2)
+          _("<p>Note: If there are dependencies between the products you have " \
+          "to manually select the dependent products. The product dependencies "\
+          "cannot be automatically detected and checked.</p>")
+      end
+
+    private
+
+      attr_writer :selected_products
+
+      def selection_content
+        products.map(&:name)
+      end
+
+      # Dialog content
+      #
+      # @see ::UI::Dialog
+      def dialog_content
+        # do not stretch the MultiSelectionBox widget over the entire screen,
+        # squash it to as small as possible size...
+        HVSquash(
+          # ...and then set a resonable minimum size
+          MinSize(60, 16,
+            MultiSelectionBox(
+              Id("addon_repos"),
+
+              # TRANSLATORS: Product selection label (multi-selection box)
+              _("&Select Products to Install"),
+              selection_content
+            ))
+        )
+      end
+
+      def read_user_selection
+        selected_items = Yast::UI.QueryWidget(Id("addon_repos"), :SelectedItems)
+
+        self.selected_products = selected_items.map do |s|
+          products.find { |p| p.name == s }
+        end
+
+        log.info("Selected products: #{selected_products.inspect}")
+      end
+
+      # Dialog title
+      #
+      # @see ::UI::Dialog
+      def dialog_title
+        # TODO: does it make sense also for the 3rd party addons?
+        _("Extension and Module Selection")
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -96,9 +96,7 @@ module Y2Packager
       def read_user_selection
         selected_items = Yast::UI.QueryWidget(Id("addon_repos"), :SelectedItems)
 
-        self.selected_products = selected_items.map do |s|
-          products.find { |p| p.name == s }
-        end
+        self.selected_products = products.select { |p| selected_items.include?(p.name) }
 
         log.info("Selected products: #{selected_products.inspect}")
       end

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -61,7 +61,7 @@ module Y2Packager
         end
       end
 
-      # Handler for the :next action
+      # Handler for the :back action
       #
       # This action happens when the user clicks the 'Back' button
       def back_handler

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -1,0 +1,32 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+module Y2Packager
+  # This class represents a product located on a multi-repository medium,
+  # libzypp reads the available products from /medium.1/products file.
+  class ProductLocation
+    # @return [String] Products on the medium
+    attr_reader :name
+    # @return [String] User selected products
+    attr_reader :dir
+
+    # Constructor
+    #
+    # @param name [String] Product name
+    # @param dir [String] Location (path starting at the media root)
+    def initialize(name, dir)
+      super()
+      @name = name
+      @dir = dir
+    end
+  end
+end

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -24,7 +24,6 @@ module Y2Packager
     # @param name [String] Product name
     # @param dir [String] Location (path starting at the media root)
     def initialize(name, dir)
-      super()
       @name = name
       @dir = dir
     end

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -8,18 +8,15 @@ require "y2packager/dialogs/addon_selector"
 module Yast
   class RepositoryIncludeTesterClass < Module
     extend Yast::I18n
-  end
 
-  def main
-    Yast.include self, "packager/repositories_include.rb"
+    def main
+      Yast.include self, "packager/repositories_include.rb"
+    end
   end
 end
 
 RepositoryIncludeTester = Yast::RepositoryIncludeTesterClass.new
 RepositoryIncludeTester.main
-
-# require "byebug"
-# byebug
 
 describe "PackagerRepositoriesIncludeInclude" do
   describe ".autorefresh_for?" do

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -3,10 +3,21 @@
 require_relative "./test_helper"
 
 # just a wrapper class for the repositories_include.rb
-class RepositoryIncludeTester
-  extend Yast::I18n
-  Yast.include self, "packager/repositories_include.rb"
+module Yast
+  class RepositoryIncludeTesterClass < Module
+    extend Yast::I18n
+  end
+
+  def main
+    Yast.include self, "packager/repositories_include.rb"
+  end
 end
+
+RepositoryIncludeTester = Yast::RepositoryIncludeTesterClass.new
+RepositoryIncludeTester.main
+
+# require "byebug"
+# byebug
 
 describe "PackagerRepositoriesIncludeInclude" do
   describe ".autorefresh_for?" do
@@ -30,6 +41,67 @@ describe "PackagerRepositoriesIncludeInclude" do
     it "handles uppercase URLs correctly" do
       expect(RepositoryIncludeTester.autorefresh_for?("FTP://FOO/BAR")).to eq(true)
       expect(RepositoryIncludeTester.autorefresh_for?("DVD://FOO/BAR")).to eq(false)
+    end
+  end
+
+  describe ".createSource" do
+    let(:url) { "https://example.com/repository" }
+    let(:plaindir) { false }
+    let(:download) { false }
+    let(:preffered_name) { "" }
+    let(:repo_id) { 42 }
+
+    before do
+      allow(Yast::Wizard).to receive(:CreateDialog)
+      allow(Yast::Wizard).to receive(:CloseDialog)
+      allow(Yast::Progress).to receive(:New)
+      allow(Yast::Progress).to receive(:NextStep)
+      allow(Yast::Progress).to receive(:NextStage)
+      allow(Yast::Pkg).to receive(:ExpandedUrl).with(url).and_return(url)
+      allow(Yast::Pkg).to receive(:ServiceProbe).with(url).and_return("NONE")
+      allow(Yast::Pkg).to receive(:RepositoryAdd).and_return(repo_id)
+      allow(Yast::Pkg).to receive(:SourceReleaseAll)
+      allow(Yast::Pkg).to receive(:SourceRefreshNow)
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([])
+      allow(Yast::Mode).to receive(:auto).and_return(false)
+      allow(Yast::Pkg).to receive(:RepositoryScan).and_return([])
+      allow(Yast::Pkg).to receive(:RepositoryProbe).and_return("YUM")
+      allow(Yast::AddOnProduct).to receive(:AcceptedLicenseAndInfoFile).and_return(true)
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(repo_id).and_return({})
+    end
+
+    it "returns :again symbol when URL is empty" do
+      ret = RepositoryIncludeTester.createSource("", plaindir, download, preffered_name)
+      expect(ret).to eq(:again)
+    end
+
+    it "creates the repository" do
+      repo_props = { "enabled"     => true,
+                     "autorefresh" => true,
+                     "name"        => "repository",
+                     "prod_dir"    => "/",
+                     "alias"       => "repository",
+                     "base_urls"   => ["https://example.com/repository"],
+                     "type"        => "YUM" }
+
+      expect(Yast::Pkg).to receive(:RepositoryAdd).with(repo_props).and_return(repo_id)
+      expect(Yast::Pkg).to_not receive(:SourceDelete)
+
+      RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+    end
+
+    it "returns :ok symbol on success" do
+      ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+      expect(ret).to eq(:ok)
+    end
+
+    it "returns :abort and removes the repository if license is rejected" do
+      expect(Yast::AddOnProduct).to receive(:AcceptedLicenseAndInfoFile)
+        .with(repo_id).and_return(false)
+      expect(Yast::Pkg).to receive(:SourceDelete).with(repo_id)
+
+      ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+      expect(ret).to eq(:abort)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@ srcdir = File.expand_path("../../src", __FILE__)
 y2dirs = ENV.fetch("Y2DIR", "").split(":")
 ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 
+# force English locale to avoid failing tests due to translations
+# when running in non-English environment
+ENV["LC_ALL"] = "en_US.UTF-8"
+
 require "yast"
 require "yast/rspec"
 require "pathname"


### PR DESCRIPTION
- Display a selection dialog to choose the products to install when using a multi-module medium
- See https://trello.com/c/Hg8HZTYm for details (e.g. a testing repository)
- Note: Maybe reviewing per commits is better as there is some cleanup and refactoring which makes reading the change more difficult...
- Note: The coverage increase of +0.8% does not sound that much but actually the changed `repositories_include.rb` file improved from 17.1% to 60.5%

[TODO: add screenshot]