### PR TITLE
Do not abort installation when no add-on product is selected 

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 12 08:55:58 UTC 2017 - lslezak@suse.cz
+
+- Do not abort installation when no add-on product is selected from
+  a multi-repository medium (bsc#1062356)
+- 4.0.10
+
+-------------------------------------------------------------------
 Thu Sep 28 16:32:30 CEST 2017 - schubi@suse.de
 
 - Disable vpn, ssh,... and inform the user if the needed packages

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -106,8 +106,11 @@ module Yast
         ui = dialog.run
         found_products = dialog.selected_products
 
-        # nothing selected or pressed abort/cancel/close/back/...
-        return :cancel if found_products.empty? || ui != :next
+        # pressed abort/cancel/close/back/...
+        return ui if ui != :next
+
+        # nothing selected, just skip adding the repos and continue in the workflow
+        return :next if found_products.empty?
       end
 
       found_products.each do |product|

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -46,10 +46,11 @@ module Y2Packager
         finish_dialog(:next)
       end
 
-      # Handler for the :next action
-      # The default implementation asks for confirmation, here we abort only
-      # adding an addon-on, not the whole installation.
+      # Handler for the :abort action
+      # Confirm abort when running in the initial stage (inst-sys)
       def abort_handler
+        return if Yast::Stage.initial && !Yast::Popup.ConfirmAbort(:painless)
+
         finish_dialog(:abort)
       end
 

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -149,17 +149,20 @@ describe "PackagerRepositoriesIncludeInclude" do
         RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
       end
 
-      it "return :cancel if nothing is selected" do
+      it "returns :next if nothing is selected" do
         expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:selected_products)
           .and_return([])
-        RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:run)
+          .and_return(:next)
+        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        expect(ret).to eq(:next)
       end
 
-      it "return :cancel if product selection is aborted" do
+      it "returns :abort if product selection is aborted" do
         expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:run)
           .and_return(:abort)
         ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
-        expect(ret).to eq(:cancel)
+        expect(ret).to eq(:abort)
       end
     end
   end


### PR DESCRIPTION
- Do not abort installation when no add-on product is selected from a multi-repository medium
- See [bsc#1062356](https://bugzilla.suse.com/show_bug.cgi?id=1062356) for details
- Tested manually
- `Abort` in the selection dialog now asks for confirmation
- 4.0.10