### PR TITLE
Display a confirmation popup when no add-on is selected (bsc#1062356)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 16 07:41:53 UTC 2017 - lslezak@suse.cz
+
+- Display a confirmation popup when no add-on is selected from
+  a multi-repository medium (bsc#1062356)
+- 4.0.11
+
+-------------------------------------------------------------------
 Thu Oct 12 08:55:58 UTC 2017 - lslezak@suse.cz
 
 - Do not abort installation when no add-on product is selected from

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,13 +17,13 @@
 
 
 Name:           yast2-packager
-Version:        4.0.10
+Version:        4.0.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
-Url:            https://github.com/kobliha/yast-packager
+Url:            https://github.com/yast/yast-packager
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(rspec)

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -43,6 +43,9 @@ module Y2Packager
       # This action happens when the user clicks the 'Next' button
       def next_handler
         read_user_selection
+
+        return if selected_products.empty? && !Yast::Popup.ContinueCancel(continue_msg)
+
         finish_dialog(:next)
       end
 
@@ -108,6 +111,15 @@ module Y2Packager
       def dialog_title
         # TODO: does it make sense also for the 3rd party addons?
         _("Extension and Module Selection")
+      end
+
+      # A message for asking the user whether to continue without adding any addon.
+      #
+      # @return [String] translated message
+      def continue_msg
+        # TRANSLATORS: Popup with [Continue] [Cancel] buttons
+        _("No product has been selected.\n\n" \
+          "Do you really want to continue without adding any product?")
       end
     end
   end

--- a/test/addon_selector_test.rb
+++ b/test/addon_selector_test.rb
@@ -1,0 +1,90 @@
+#! /usr/bin/env rspec
+
+require_relative "./test_helper"
+
+require "y2packager/product_location"
+require "y2packager/dialogs/addon_selector"
+
+describe Y2Packager::Dialogs::AddonSelector do
+  let(:media_products) do
+    prods = [["SLE-15-Module-Basesystem 15.0-0", "/Basesystem"],
+             ["SLE-15-Module-Legacy 15.0-0", "/Legacy"]]
+    prods.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
+  end
+
+  subject { described_class.new(media_products) }
+
+  describe "#help_text" do
+    it "returns a String" do
+      expect(subject.help_text).to be_a(String)
+    end
+  end
+
+  describe "#abort_handler" do
+    it "returns :abort" do
+      allow(Yast::Stage).to receive(:initial).and_return(false)
+      expect(subject.abort_handler).to eq(:abort)
+    end
+
+    context "in installation" do
+      before do
+        expect(Yast::Stage).to receive(:initial).and_return(true)
+      end
+
+      it "asks for confirmation" do
+        expect(Yast::Popup).to receive(:ConfirmAbort).and_return(true)
+        subject.abort_handler
+      end
+
+      it "returns :abort when confirmed" do
+        expect(Yast::Popup).to receive(:ConfirmAbort).and_return(true)
+        expect(subject.abort_handler).to eq(:abort)
+      end
+
+      it "returns nil when not confirmed" do
+        expect(Yast::Popup).to receive(:ConfirmAbort).and_return(false)
+        expect(subject.abort_handler).to be_nil
+      end
+    end
+  end
+
+  describe "#next_handler" do
+    context "an addon is selected" do
+      before do
+        expect(Yast::UI).to receive(:QueryWidget).with(Id("addon_repos"), :SelectedItems)
+          .and_return(["SLE-15-Module-Basesystem 15.0-0"])
+      end
+
+      it "returns :next if an addon is selected" do
+        expect(subject.next_handler).to eq(:next)
+      end
+
+      it "does not display any popup" do
+        expect(Yast::Popup).to_not receive(:anything)
+        subject.next_handler
+      end
+    end
+
+    context "no addon is selected" do
+      before do
+        expect(Yast::UI).to receive(:QueryWidget).with(Id("addon_repos"), :SelectedItems)
+          .and_return([])
+      end
+
+      it "displays a popup asking for confirmation" do
+        expect(Yast::Popup).to receive(:ContinueCancel).with(/no product/i)
+        subject.next_handler
+      end
+
+      it "returns :next if the popup is confirmed" do
+        expect(Yast::Popup).to receive(:ContinueCancel).with(/no product/i).and_return(true)
+        expect(subject.next_handler).to eq(:next)
+      end
+
+      it "returns nil if the popup is not confirmed" do
+        expect(Yast::Popup).to receive(:ContinueCancel).with(/no product/i).and_return(false)
+        expect(subject.next_handler).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Display a confirmation popup when no add-on is selected from a multi-repository medium.

Requested by @fcrozat 

- 4.0.11

![no_product_selected](https://user-images.githubusercontent.com/907998/31609170-5b6d3f52-b273-11e7-971c-d2b7711412ef.png)
