### PR TITLE
Use `nil` for the default "display_addon_checkbox" value (FATE#323163)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct 19 10:39:38 UTC 2017 - lslezak@suse.cz
+
+- Use `nil` for the default "display_addon_checkbox" value
+  to distinguish between the default and a changed value
+  to possibly hide the "I would like to install an additional Add On
+  Product" check box from the external code (FATE#323163)
+- 4.0.13
+
+-------------------------------------------------------------------
 Mon Oct 16 15:13:58 UTC 2017 - jreidinger@suse.com
 
 - Cleaning up DefaultDesktop as its usage is now reduced even for

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.12
+Version:        4.0.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -99,7 +99,8 @@ module Yast
       @_allow_https = true
 
       # display a check box in type selection dialog in the next run
-      @display_addon_checkbox = false
+      # use nil to indicate the default value, true/false override the default
+      @display_addon_checkbox = nil
 
       # CD/DVD device name to use (e.g. /dev/sr1) in case of multiple
       # devices in the system. Empty string means use the default.


### PR DESCRIPTION
- The `nil` behaves exactly same as the original `false` value, the behavior has not changed
- Now we can distinguish whether the check box was hidden by default (`nil`) or hiding was requested by some YaST code (`false`)
- This is need in some other packages, the relevant pull requests will follow
- Related to [FATE#323163](https://fate.suse.com/323163)
- 4.0.13