### PR TITLE
Fixed installing additional products at upgrade (bsc#1065485)

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -1,4 +1,4 @@
 # Development Code
 
-This directory contains code examples which is can be useful for development.
+This directory contains code examples which can be useful for development.
 They are not intented for regular use by end users.

--- a/devel/README.md
+++ b/devel/README.md
@@ -1,0 +1,4 @@
+# Development Code
+
+This directory contains code examples which is can be useful for development.
+They are not intented for regular use by end users.

--- a/devel/test_addon_selector.rb
+++ b/devel/test_addon_selector.rb
@@ -1,0 +1,29 @@
+# This is a testing client for the addon product dialog which is displayed
+# after adding a multi-repository medium.
+#
+# Run it using "yast2 ./test_addon_selector.rb" command
+
+require "y2packager/product_location"
+require "y2packager/dialogs/addon_selector"
+
+new_repos = [
+  ["Basesystem-Module 15-0", "/Basesystem"],
+  ["Desktop-Applications-Module 15-0", "/Desktop-Applications"],
+  ["Desktop-Productivity-Module 15-0", "/Desktop-Productivity"],
+  ["Development-Tools-Module 15-0", "/Development-Tools"],
+  ["HA-Module 15-0", "/HA"],
+  ["HPC-Module 15-0", "/HPC"],
+  ["Legacy-Module 15-0", "/Legacy"],
+  ["Public-Cloud-Module 15-0", "/Public-Cloud"],
+  ["SAP-Applications-Module 15-0", "/SAP-Applications"],
+  ["Scripting-Module 15-0", "/Scripting"],
+  ["Server-Applications-Module 15-0", "/Server-Applications"]
+]
+
+puts "Repositories to select: " + new_repos.inspect
+
+products = new_repos.map { |r| Y2Packager::ProductLocation.new(r[0], r[1]) }
+dialog = Y2Packager::Dialogs::AddonSelector.new(products)
+
+puts "Dialog result: " + dialog.run.inspect
+puts "Selected products: " + dialog.selected_products.inspect

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 27 15:28:29 UTC 2017 - lslezak@suse.cz
+
+- Do not install all available products (like SLED on SLES) during
+  upgrade (bsc#1065485)
+- 4.0.16
+
+-------------------------------------------------------------------
 Thu Oct 26 16:11:50 CEST 2017 - schubi@suse.de
 
 - Fixed spelling. (bnc#1055279, bnc#1058071)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.15
+Version:        4.0.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1902,6 +1902,11 @@ module Yast
         return true
       end
 
+      if Mode.update
+        log.info("Update mode - skipping product selection")
+        return true
+      end
+
       products = Pkg.ResolvableProperties("", :product, "")
 
       if !products || products.empty?


### PR DESCRIPTION
# Product Selection Fix

This fixes yet another instance of the *all available products* bug, see [bsc#1065485](https://bugzilla.suse.com/show_bug.cgi?id=1065485).

### The Original Issue

Originally at SLES12-SP3 upgrade YaST additionally installed also the other products like SLED which causes dependency issues (the products conflicts):

![media_upgrade_broken_products](https://user-images.githubusercontent.com/907998/32111769-c21999b4-bb3b-11e7-8933-11e9add16d36.png)

### With the Fix

With this fix no additional products are installed. The products should be upgraded using the *-release RPM packages on the new media, we do not need to select anything to install.

![media_upgrade_correct_products](https://user-images.githubusercontent.com/907998/32111777-cba387ce-bb3b-11e7-80e9-a013c3d34b51.png)

# Testing Client

I have added my small testing client used for developing the module selection dialog. I think it can be useful for somebody else later so let's share it.
