### PR TITLE
Select available product on single product media

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov  8 12:03:13 UTC 2017 - igonzalezsosa@suse.com
+
+- On single product media, select the available product during
+  upgrade (bsc#1066709 and bsc#1065172).
+- 4.0.17 
+
+-------------------------------------------------------------------
 Fri Oct 27 15:28:29 UTC 2017 - lslezak@suse.cz
 
 - Do not install all available products (like SLED on SLES) during

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.16
+Version:        4.0.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -73,13 +73,22 @@ module Y2Packager
 
       # Adjust product selection
       #
-      # All products are selected by default. So if there is more than 1, we should unselect
-      # them all. The user will select one later.
+      # During installation, all products are selected by default. So if there
+      # is more than 1, we should unselect them all. The user will select one
+      # later.
       #
-      # See https://github.com/yast/yast-packager/blob/7e1a0bbb90823b03c15d92f408036a560dca8aa3/src/modules/Packages.rb#L1876
+      # On the other hand, if only one product is available, we should make
+      # sure that it is selected for installation because, during upgrade, it
+      # is not automatically selected.
+      #
+      # @see https://github.com/yast/yast-packager/blob/7e1a0bbb90823b03c15d92f408036a560dca8aa3/src/modules/Packages.rb#L1876
+      # @see https://github.com/yast/yast-packager/blob/fbc396df910e297915f9f785fc460e72e30d1948/src/modules/Packages.rb#L1905
       def adjust_base_product_selection
-        return unless products.size > 1
-        products.each(&:restore)
+        if products.size == 1
+          products.first.select
+        else
+          products.each(&:restore)
+        end
       end
 
       # Return base available products

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -7,8 +7,8 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
   subject(:client) { described_class.new }
 
   let(:success) { true }
-  let(:prod1) { instance_double(Y2Packager::Product) }
-  let(:prod2) { instance_double(Y2Packager::Product) }
+  let(:prod1) { instance_double(Y2Packager::Product, select: nil) }
+  let(:prod2) { instance_double(Y2Packager::Product, select: nil) }
   let(:products) { [prod1] }
 
   describe "#main" do
@@ -44,8 +44,8 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
     context "when only one product is available" do
       let(:products) { [prod1] }
 
-      it "does not unselect the product for installation" do
-        expect(prod1).to_not receive(:restore)
+      it "selects the product for installation" do
+        expect(prod1).to receive(:select)
         client.main
       end
     end


### PR DESCRIPTION
It should fix these bugs:

* [bsc#1066709](https://bugzilla.suse.com/show_bug.cgi?id=1066709)
* [bsc#1065172](https://bugzilla.suse.com/show_bug.cgi?id=1065172)

Manually tested with the Storage-NG ISO (https://yast-openqa.suse.cz/tests/5331).