### PR TITLE
Remove xinetd from the list of VNC packages.

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,3 +1,8 @@
+Thu Nov  9 14:45:15 UTC 2017 - knut.anderssen@suse.com
+
+- VNC does not depend on xinetd anymore. (bsc#1067169)
+- 4.0.18
+
 -------------------------------------------------------------------
 Wed Nov  8 12:03:13 UTC 2017 - igonzalezsosa@suse.com
 

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,6 +1,7 @@
+-------------------------------------------------------------------
 Thu Nov  9 14:45:15 UTC 2017 - knut.anderssen@suse.com
 
-- VNC does not depend on xinetd anymore. (bsc#1067169)
+- VNC does not depend on xinetd anymore. (bsc#1058820)
 - 4.0.18
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.17
+Version:        4.0.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -21,7 +21,7 @@ module Yast
     RESOLVABLE_SORT_ORDER = { product: "source", pattern: "order" }.freeze
 
     # Minimum set of packages tags required to enable VNC server
-    VNC_BASE_TAGS = ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts", "xinetd"].freeze
+    VNC_BASE_TAGS = ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"].freeze
     # Additional packages tags needed to run second stage in graphical mode
     AUTOYAST_X11_TAGS = ["libyui-qt", "yast2-x11"].freeze
     # Default window manager for VNC if none is installed

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -491,7 +491,7 @@ describe Yast::Packages do
 
   describe "#vnc_packages" do
     let(:packages) { Yast::Packages.vnc_packages.sort.uniq }
-    let(:base_packages) { ["xinetd", "xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"] }
+    let(:base_packages) { ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"] }
     let(:base_packages_and_wm) { ["icewm"] + base_packages }
     let(:autoyast_x11_packages) { ["libyui-qt6", "yast2-x11"] }
 
@@ -514,7 +514,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsSelected).and_return true
         end
 
-        it "includes xinetd and xorg" do
+        it "includes xorg" do
           expect(packages).to eq(base_packages)
         end
       end
@@ -524,7 +524,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsSelected).and_return false
         end
 
-        it "includes xinetd, xorg and icewm" do
+        it "includes xorg and icewm" do
           expect(packages).to eq(base_packages_and_wm)
         end
       end
@@ -541,7 +541,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsSelected).and_return true
         end
 
-        it "includes xinetd, xorg and autoyast X11 packages" do
+        it "includes xorg and autoyast X11 packages" do
           expected = (base_packages + autoyast_x11_packages).sort
           expect(packages).to eq(expected)
         end
@@ -552,7 +552,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsSelected).and_return false
         end
 
-        it "includes xinetd, xorg and icewm" do
+        it "includes xorg and icewm" do
           expected = (base_packages_and_wm + autoyast_x11_packages).sort
           expect(packages).to eq(expected)
         end
@@ -570,7 +570,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsProvided).and_return true
         end
 
-        it "includes xinetd and xorg" do
+        it "includes xorg" do
           expect(packages).to eq(base_packages)
         end
       end
@@ -580,7 +580,7 @@ describe Yast::Packages do
           allow(Yast::Pkg).to receive(:IsProvided).and_return false
         end
 
-        it "includes xinetd, xorg and icewm" do
+        it "includes xorg and icewm" do
           expect(packages).to eq(base_packages_and_wm)
         end
       end


### PR DESCRIPTION
- It will part of this incoming [Trello Card](https://trello.com/c/yTCpqUtX/1728-sles15-p3-1058820-yast2-remote-administration-vnc-complains-about-missing-servicevnc-httpd)

- Fixed conflicts and added changelog to #286 

- This is needed by https://github.com/yast/yast-network/pull/565 (I have been working on some cleanup, so hope to create a PR which supersedes also original one) 