### PR TITLE
Fix disable local repos

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  7 15:04:15 UTC 2017 - igonzalezsosa@suse.com
+
+- Consider only installed products when deciding whether to disable
+  or not local repositories (bsc#1071702). 
+- 4.0.20
+
+-------------------------------------------------------------------
 Fri Dec  1 16:04:22 CET 2017 - schubi@suse.de
 
 - Allowing AutoYaST to add initialize add-on products provided

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.19
+Version:        4.0.20
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -145,9 +145,9 @@ module Yast
     #
     # @return [Array<Y2Packager::Repository>] List of disabled repositories
     def disable_local_repos
-      candidates_repos, remote_repos = *::Y2Packager::Repository.enabled.partition(&:local?)
+      local_repos, remote_repos = *::Y2Packager::Repository.enabled.partition(&:local?)
       remote_products = remote_repos.map(&:products).flatten.uniq
-      candidates_repos.each_with_object([]) do |repo, disabled|
+      local_repos.each_with_object([]) do |repo, disabled|
         if repo.products.empty?
           log.info("Repo #{repo.repo_id} (#{repo.name}) does not have products; ignored")
           next

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -145,14 +145,14 @@ module Yast
     #
     # @return [Array<Y2Packager::Repository>] List of disabled repositories
     def disable_local_repos
-      candidates_repos, other_repos = *::Y2Packager::Repository.enabled.partition(&:local?)
-      products = other_repos.map(&:products).flatten.uniq
+      candidates_repos, remote_repos = *::Y2Packager::Repository.enabled.partition(&:local?)
+      remote_products = remote_repos.map(&:products).flatten.uniq
       candidates_repos.each_with_object([]) do |repo, disabled|
         if repo.products.empty?
           log.info("Repo #{repo.repo_id} (#{repo.name}) does not have products; ignored")
           next
         end
-        uncovered = repo.products.reject { |p| products.include?(p) }
+        uncovered = repo.products.select { |p| p.installed? && !remote_products.include?(p) }
         if uncovered.empty?
           log.info("Repo #{repo.repo_id} (#{repo.name}) will be disabled because products " \
             "are present in other repositories")

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -126,9 +126,19 @@ module Y2Packager
     #
     # @return [Boolean] true if it is selected
     def selected?
-      Yast::Pkg.ResolvableProperties(name, :product, "").any? do |res|
-        res["status"] == :selected
-      end
+      status?(:selected)
+    end
+
+    # is the product selected to install?
+    #
+    # Only the 'name' will be used to find out whether the product is installed,
+    # ignoring the architecture, version, vendor or any other property. libzypp
+    # will take care of finding the proper product.
+    #
+    # @see #status?
+    # @return [Boolean] true if it is installed
+    def installed?
+      status?(:installed)
     end
 
     # select the product to install
@@ -216,6 +226,22 @@ module Y2Packager
     # @see ReleaseNotes
     def release_notes(format = :txt, user_lang = Yast::Language.language)
       ReleaseNotesReader.new(self).release_notes(user_lang: user_lang, format: format)
+    end
+
+  private
+
+    # Determine whether a product is in a given status
+    #
+    # Only the 'name' will be used to find out whether the product is installed,
+    # ignoring the architecture, version, vendor or any other property. libzypp
+    # will take care of finding the proper product.
+    #
+    # @param status [Symbol] Status to compare with.
+    # @return [Boolean] true if it is in the given status
+    def status?(status)
+      Yast::Pkg.ResolvableProperties(name, :product, "").any? do |res|
+        res["status"] == status
+      end
     end
   end
 end

--- a/test/pkg_finish_test.rb
+++ b/test/pkg_finish_test.rb
@@ -87,22 +87,24 @@ describe Yast::PkgFinishClient do
       end
 
       let(:sles_product) do
-        Y2Packager::Product.new(name: "SLES", version: "12.2",
-          arch: "x86_64", category: "base", status: :available, vendor: "SUSE")
+        instance_double(Y2Packager::Product, name: "SLES", installed?: true)
+      end
+
+      let(:sled_product) do
+        instance_double(Y2Packager::Product, name: "SLED", installed?: false)
       end
 
       let(:sles_ha_product) do
-        Y2Packager::Product.new(name: "SLESHA", version: "12.2",
-          arch: "x86_64", category: "base", status: :available, vendor: "SUSE")
+        instance_double(Y2Packager::Product, name: "SLESHA", installed?: false)
       end
 
       before do
-        allow(local_repo).to receive(:products).and_return([sles_product.clone])
+        allow(local_repo).to receive(:products).and_return([sles_product, sled_product])
       end
 
-      context "if their products are available through other repos" do
+      context "if installed products are available through other repos" do
         before do
-          allow(remote_repo).to receive(:products).and_return([sles_product.clone])
+          allow(remote_repo).to receive(:products).and_return([sles_product])
         end
 
         it "disables the local repository" do
@@ -111,7 +113,7 @@ describe Yast::PkgFinishClient do
         end
       end
 
-      context "if their products are not available through other repos" do
+      context "if installed products are not available through other repos" do
         before do
           allow(remote_repo).to receive(:products).and_return([sles_ha_product])
         end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -114,6 +114,29 @@ describe Y2Packager::Product do
     end
   end
 
+  describe "#installed?" do
+    before do
+      allow(Yast::Pkg).to receive(:ResolvableProperties).with(product.name, :product, "")
+        .and_return([{ "name" => product.name, "status" => status }])
+    end
+
+    context "if product is installed" do
+      let(:status) { :installed }
+
+      it "returns true" do
+        expect(product).to be_installed
+      end
+    end
+
+    context "if product is not installed" do
+      let(:status) { :available }
+
+      it "returns false" do
+        expect(product).to_not be_installed
+      end
+    end
+  end
+
   describe "#select" do
     it "selects the product for installation" do
       expect(Yast::Pkg).to receive(:ResolvableInstall).with(product.name, :product, "")


### PR DESCRIPTION
Now we only consider installed products when deciding whether to disable a repository in order to work with multi-product media.

[bsc#1071702](https://bugzilla.suse.com/show_bug.cgi?id=1071702)