### PR TITLE
Fix product status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 11 13:29:10 UTC 2017 - igonzalezsosa@suse.com
+
+- Do not cache products status (related to bsc#1072063)
+- 4.0.21
+
+-------------------------------------------------------------------
 Thu Dec  7 15:04:15 UTC 2017 - igonzalezsosa@suse.com
 
 - Consider only installed products when deciding whether to disable

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.20
+Version:        4.0.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -427,7 +427,6 @@ module Yast
 
     # Add a new repository service.
     # @param url [String] service URL
-    # @param type [String] probed service type
     # @param preffered_name [String] service name, empty string means generate it
     def add_service(url, preffered_name)
       # all current aliases

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -29,7 +29,7 @@ module Y2Packager
 
       # Constructor
       #
-      # @param product [Array<Y2Packager::ProductLocation>] Products on the medium
+      # @param products [Array<Y2Packager::ProductLocation>] Products on the medium
       def initialize(products)
         super()
         textdomain "packager"

--- a/src/lib/y2packager/package.rb
+++ b/src/lib/y2packager/package.rb
@@ -77,7 +77,7 @@ module Y2Packager
 
     # Download and extract the package to the given directory
     #
-    # @param path [String,Pathname] Path to extract the package to
+    # @param directory [String,Pathname] Path to extract the package to
     # @see Packages::PackageExtractor
     def extract_to(directory)
       tmpfile = Tempfile.new("downloaded-package-#{name}-")

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -33,8 +33,6 @@ module Y2Packager
     attr_reader :version
     # @return [String] Architecture
     attr_reader :arch
-    # @return [Symbol] Status
-    attr_reader :status
     # @return [Symbol] Category
     attr_reader :category
     # @return [String] Vendor
@@ -70,10 +68,10 @@ module Y2Packager
 
       # Return the products with a given status
       #
-      # @param statuses [Array<Product>] Product status (:available, :installed, :selected, etc.)
+      # @param statuses [Array<Symbol>] Product status (:available, :installed, :selected, etc.)
       # @return [Array<Product>] Products with the given status
       def with_status(*statuses)
-        all.select { |s| statuses.include?(s.status) }
+        all.select { |p| p.status?(*statuses) }
       end
     end
 
@@ -84,19 +82,17 @@ module Y2Packager
     # @param display_name         [String]  Display name
     # @param version              [String]  Version
     # @param arch                 [String]  Architecture
-    # @param status               [Symbol]  Status (:selected, :removed, :installed, :available)
     # @param category             [Symbol]  Category (:base, :addon)
     # @param vendor               [String]  Vendor
     # @param order                [Integer] Display order
     # @param installation_package [String]  Installation package name
     def initialize(name: nil, short_name: nil, display_name: nil, version: nil, arch: nil,
-      status: nil, category: nil, vendor: nil, order: nil, installation_package: nil)
+      category: nil, vendor: nil, order: nil, installation_package: nil)
       @name = name
       @short_name = short_name
       @display_name = display_name
       @version = version
       @arch = arch.to_sym if arch
-      @status = status.to_sym if status
       @category = category.to_sym if category
       @vendor = vendor
       @order = order
@@ -228,19 +224,17 @@ module Y2Packager
       ReleaseNotesReader.new(self).release_notes(user_lang: user_lang, format: format)
     end
 
-  private
-
     # Determine whether a product is in a given status
     #
-    # Only the 'name' will be used to find out whether the product is installed,
+    # Only the 'name' will be used to find out whether the product status,
     # ignoring the architecture, version, vendor or any other property. libzypp
     # will take care of finding the proper product.
     #
-    # @param status [Symbol] Status to compare with.
+    # @param status [Array<Symbol>] Status to compare with.
     # @return [Boolean] true if it is in the given status
-    def status?(status)
+    def status?(*statuses)
       Yast::Pkg.ResolvableProperties(name, :product, "").any? do |res|
-        res["status"] == status
+        statuses.include?(res["status"])
       end
     end
   end

--- a/src/lib/y2packager/product.rb
+++ b/src/lib/y2packager/product.rb
@@ -215,8 +215,8 @@ module Y2Packager
 
     # Return product's release notes
     #
-    # @param format     [Symbol] Release notes format (use :txt as default)
-    # @return user_lang [String] Preferred language (use current language as default)
+    # @param format    [Symbol] Release notes format (use :txt as default)
+    # @param user_lang [String] Preferred language (use current language as default)
     # @return [ReleaseNotes] Release notes for product, language and format
     # @see ReleaseNotesReader
     # @see ReleaseNotes
@@ -230,7 +230,7 @@ module Y2Packager
     # ignoring the architecture, version, vendor or any other property. libzypp
     # will take care of finding the proper product.
     #
-    # @param status [Array<Symbol>] Status to compare with.
+    # @param statuses [Array<Symbol>] Status to compare with.
     # @return [Boolean] true if it is in the given status
     def status?(*statuses)
       Yast::Pkg.ResolvableProperties(name, :product, "").any? do |res|

--- a/src/lib/y2packager/product_reader.rb
+++ b/src/lib/y2packager/product_reader.rb
@@ -70,7 +70,7 @@ module Y2Packager
 
         Y2Packager::Product.new(
           name: prod["name"], short_name: prod["short_name"], display_name: prod["display_name"],
-          version: prod["version"], status: prod["status"], order: displayorder,
+          version: prod["version"], order: displayorder,
           installation_package: installation_package_mapping[prod["name"]]
         )
       end

--- a/src/lib/y2packager/release_notes_fetchers/base.rb
+++ b/src/lib/y2packager/release_notes_fetchers/base.rb
@@ -36,7 +36,7 @@ module Y2Packager
 
       # Get release notes for the given product
       #
-      # @param prefs [ReleaseNotesContentPrefs] Content preferences
+      # @param _prefs [ReleaseNotesContentPrefs] Content preferences
       # @return [String,nil] Release notes or nil if a release notes were not found
       #   (no package providing release notes or notes not found in the package)
       def release_notes(_prefs)

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -151,8 +151,7 @@ module Y2Packager
       # Build an array of Y2Packager::Product objects
       @products = candidates.map do |data|
         Y2Packager::Product.new(name: data["name"], version: data["version"],
-          arch: data["arch"], category: data["category"], status: data["status"],
-          vendor: data["vendor"])
+          arch: data["arch"], category: data["category"], vendor: data["vendor"])
       end
     end
 

--- a/src/lib/y2packager/widgets/product_license.rb
+++ b/src/lib/y2packager/widgets/product_license.rb
@@ -23,7 +23,7 @@ module Y2Packager
     class ProductLicense < CWM::CustomWidget
       # @return [Y2Packager::Product] Product
       attr_reader :product
-      # @param skip_validation [Boolean] Skip value validation
+      # @return [Boolean] Skip value validation
       attr_reader :skip_validation
 
       # Constructor

--- a/src/lib/y2packager/widgets/product_license_confirmation.rb
+++ b/src/lib/y2packager/widgets/product_license_confirmation.rb
@@ -24,7 +24,7 @@ module Y2Packager
     class ProductLicenseConfirmation < CWM::CheckBox
       # @return [Y2Packager::Product] Product
       attr_reader :product
-      # @param skip_validation [Boolean] Skip value validation
+      # @return [Boolean] Skip value validation
       attr_reader :skip_validation
 
       # Constructor

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2765,7 +2765,7 @@ module Yast
 
     # Checking if a package will be installed or is already installed
     # on a system and will not be deleted.
-    # @param [String] package name
+    # @param tag [String] package name
     # @return [Boolean] true if the package will be on the installed system
     def pkg_will_be_installed(tag)
       provides = Pkg.PkgQueryProvides(tag)


### PR DESCRIPTION
* Fixes [bsc#1072063](https://bugzilla.suse.com/show_bug.cgi?id=1072063)
* The bug was caused because we have several `SLES` instance products (one as `:removed` and another one as `:selected`).
* Trying to cache product status can be dangerous, so I've modified product class to expose a `status?` method.
* I've fixed documentation and added `rake check:doc` to Travis.