### PR TITLE
Unify the DVD product selection dialog (bsc#1071771)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 13 09:10:23 UTC 2017 - lslezak@suse.cz
+
+- Make the dialog for selecting modules from DVD look similar
+  to the module selection dialog in registration (bsc#1071771)
+- 4.0.22
+
+-------------------------------------------------------------------
 Mon Dec 11 13:29:10 UTC 2017 - igonzalezsosa@suse.com
 
 - Do not cache products status (related to bsc#1072063)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.21
+Version:        4.0.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -13,8 +13,10 @@
 require "yast"
 require "ui/installation_dialog"
 
-Yast.import "UI"
 Yast.import "Report"
+Yast.import "Stage"
+Yast.import "UI"
+Yast.import "Wizard"
 
 module Y2Packager
   module Dialogs
@@ -70,6 +72,16 @@ module Y2Packager
           "cannot be automatically detected and checked.</p>")
       end
 
+      # Display the the dialog title on the left side at installation
+      # (in the first stage) to have the same layout as in the registration
+      # addons dialog.
+      def run
+        Yast::Wizard.OpenLeftTitleNextBackDialog if Yast::Stage.initial
+        super()
+      ensure
+        Yast::Wizard.CloseDialog if Yast::Stage.initial
+      end
+
     private
 
       attr_writer :selected_products
@@ -82,18 +94,19 @@ module Y2Packager
       #
       # @see ::UI::Dialog
       def dialog_content
-        # do not stretch the MultiSelectionBox widget over the entire screen,
-        # squash it to as small as possible size...
-        HVSquash(
-          # ...and then set a resonable minimum size
-          MinSize(60, 16,
+        VBox(
+          # TRANSLATORS: Product selection label (above a multi-selection box)
+          Left(Heading(_("Available Extensions and Modules"))),
+
+          VWeight(75, MinHeight(12,
             MultiSelectionBox(
               Id("addon_repos"),
-
-              # TRANSLATORS: Product selection label (multi-selection box)
-              _("&Select Products to Install"),
+              "",
               selection_content
-            ))
+            ))),
+
+          VSpacing(0.4),
+          details_widget
         )
       end
 
@@ -120,6 +133,22 @@ module Y2Packager
         # TRANSLATORS: Popup with [Continue] [Cancel] buttons
         _("No product has been selected.\n\n" \
           "Do you really want to continue without adding any product?")
+      end
+
+      # description widget
+      # @return [Yast::Term] the addon details widget
+      def details_widget
+        MinHeight(3,
+          VWeight(25, RichText(Id(:details), Opt(:disabled), "<small>" +
+          description + "</small>")))
+      end
+
+      # extra help text
+      # @return [String] translated text
+      def description
+        # TRANSLATORS: inline help text displayed below the product selection widget
+        _("The dependencies between products are not handled automatically. " \
+          "The dependent modules or extensions must be selected manually.")
       end
     end
   end


### PR DESCRIPTION
- Changed the dialog for selecting modules from DVD to look similar to the module selection dialog in the registration module ([bsc#1071771](https://bugzilla.suse.com/show_bug.cgi?id=1071771))
- 4.0.22

## Screenshots

### The Product Selection in the Registration Module

![addons_scc](https://user-images.githubusercontent.com/907998/33931136-671bd4a4-dfef-11e7-9712-f95196500df8.png)

### Original DVD Product Selection

As you can see the dialog looked completely differently:

![addons_dvd_orig](https://user-images.githubusercontent.com/907998/33931167-7c99ad56-dfef-11e7-9b38-f3b2e6f80d22.png)

### New Unified DVD Product Selection

The improved dialog looks much more similar to the registration dialog:

- The dialog title is displayed on the left side
- The selection widget is right aligned and has full size
- The label above it is the same
- There is some inline help text displayed below (The fact that the product dependencies need to be handled manually is very important. It's also described in the help text but that's hidden by default.)

![addons_dvd_unified](https://user-images.githubusercontent.com/907998/33931196-94f523e4-dfef-11e7-9318-e149e4e867cd.png)

However there are still some look&feel differences because the DVD medium does not provide additional metadata as SCC does:

- No Beta filter (Beta status is not available)
- No descriptions for the products
- No dependency check
- No preselected recommended modules

But that's an unrelated technical issue outside YaST...

### Text Mode

The same screenshots in the text mode:

### Original DVD Product Selection

![addons_dvd_orig_ncurses](https://user-images.githubusercontent.com/907998/33932116-601e96b6-dff2-11e7-9334-77ad2ab682e9.png)

### New Unified DVD Product Selection

![addons_dvd_unified_ncurses](https://user-images.githubusercontent.com/907998/33932125-693f4876-dff2-11e7-8180-9b99654c6d36.png)
