### PR TITLE
Display the product license at upgrade (bsc#1069124)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 17 13:07:52 UTC 2018 - lslezak@suse.cz
+
+- Added a new client for displaying the product license at upgrade
+  (bsc#1069124)
+- 4.0.29
+
+-------------------------------------------------------------------
 Thu Jan 11 11:54:47 UTC 2018 - lslezak@suse.cz
 
 - Decrease the priority of the initial DVD installation repository
@@ -32,7 +39,7 @@ Mon Jan  8 09:49:09 UTC 2018 - lslezak@suse.cz
 - 4.0.25
 
 -------------------------------------------------------------------
-Mon Dec 15 14:07:50 CET 2017 - schubi@suse.de
+Fri Dec 15 14:07:50 CET 2017 - schubi@suse.de
 
 - Warn the user if the infrastructure is not available for running
   the second stage (bnc#1061754)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.28
+Version:        4.0.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_product_upgrade_license.rb
+++ b/src/clients/inst_product_upgrade_license.rb
@@ -1,0 +1,3 @@
+require "y2packager/clients/inst_product_upgrade_license"
+
+Y2Packager::Clients::InstProductUpgradeLicense.new.main

--- a/src/lib/y2packager/clients/inst_product_upgrade_license.rb
+++ b/src/lib/y2packager/clients/inst_product_upgrade_license.rb
@@ -1,0 +1,64 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+require "y2packager/clients/inst_product_license"
+require "y2packager/product"
+
+Yast.import "Pkg"
+Yast.import "Report"
+
+module Y2Packager
+  module Clients
+    # This client shows a license confirmation dialog for the upgraded base product
+    #
+    # The client will display an error and return :back if not product is found.
+    # If no license is found for the selected product it returns :auto.
+    # @see Y2Packager::Clients::InstProductLicense
+    class InstProductUpgradeLicense < InstProductLicense
+      def main
+        textdomain "installation"
+
+        if !product
+          # TRANSLATORS: An error message, the package solver could not find
+          # any product to upgrade in the selected partition.
+          Yast::Report.Error(_("Error: Cannot find any product to upgrade.\n" \
+            "Make sure the selected partition contains an upgradable product."))
+          return :back
+        end
+
+        return :auto unless available_license?
+
+        Y2Packager::Dialogs::InstProductLicense.new(product).run
+      end
+
+    private
+
+      # Return the selected base product for upgrade
+      #
+      # @return [Y2Packager::Product]
+      # @see Y2Packager::Product.selected_base
+      def product
+        return @product if @product
+
+        # temporarily run the update mode to let the solver select the product for upgrade
+        # (this will correctly handle possible product renames)
+        Yast::Pkg.PkgUpdateAll({})
+        @product = Y2Packager::Product.selected_base
+        # restore the initial status, the package update will be turned on later again
+        Yast::Pkg.PkgReset
+        @product
+      end
+    end
+  end
+end

--- a/test/lib/clients/inst_product_upgrade_license_test.rb
+++ b/test/lib/clients/inst_product_upgrade_license_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "y2packager/clients/inst_product_upgrade_license"
+
+describe Y2Packager::Clients::InstProductUpgradeLicense do
+  describe "#main" do
+    before do
+      expect(Yast::Pkg).to receive(:PkgUpdateAll)
+      expect(Yast::Pkg).to receive(:PkgReset)
+      allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
+      allow(Yast::Report).to receive(:Error)
+    end
+
+    context "no product found" do
+      let(:product) { nil }
+
+      it "displays an error popup" do
+        expect(Yast::Report).to receive(:Error).with(/Cannot find any product to upgrade/)
+        subject.main
+      end
+
+      it "returns :back" do
+        expect(subject.main).to eq(:back)
+      end
+    end
+
+    context "base product found" do
+      let(:product) do
+        instance_double(
+          Y2Packager::Product,
+          label:              "SLES",
+          license?:           true,
+          license_confirmed?: false
+        )
+      end
+
+      it "returns :auto if no product license is found" do
+        expect(product).to receive(:license?).at_least(:once).and_return(false)
+        expect(subject.main).to eq(:auto)
+      end
+
+      it "displays the product license" do
+        allow(Yast::Language).to receive(:language).and_return("en_US")
+        expect_any_instance_of(Y2Packager::Dialogs::InstProductLicense).to receive(:run)
+        subject.main
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added a new `inst_product_upgrade_license.rb` client
- The code reuses the existing client for displaying the license at installation- Tested manually
- 4.0.24

### Control File Update

- Added the client to the SLES `control.xml` (https://github.com/yast/skelcd-control-SLES/pull/100)
- Added the client to the SLED `control.xml` (https://github.com/yast/skelcd-control-SLED/pull/70)

### Screenshot

This license dialog is displayed after selecting a partition containing installed SLES:

![sle15_upgrade_eula](https://user-images.githubusercontent.com/907998/34049248-02a0e91e-e1b7-11e7-9167-8af8feae7473.png)

