### PR TITLE
Improved disk usage check (bsc#1073696)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan  8 13:17:00 UTC 2018 - lslezak@suse.cz
+
+- Improved disk usage check - check the parent directory if the
+  target directory does not exist (yet) (bsc#1073696)
+- 4.0.26
+
+-------------------------------------------------------------------
 Mon Jan  8 09:49:09 UTC 2018 - lslezak@suse.cz
 
 - Allow different handling handling of addons without

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.25
+Version:        4.0.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1073696
- Check the parent directory if the target directory does not exist (yet).
- In the bug above libzypp reports completely invalid directory (`/mounts/mp_0000`), but in theory it could report a directory which does not exist yet, e.g. for `foo` package `/usr/share/foo` will be very likely created *after* installing the package. This will also fix the incorrect case with `/mounts/mp_0000` path as YaST will be checking the `/mnt` directory instead.
- 4.0.26