### PR TITLE
Ignore the partition with the installer (bsc#1073696)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan  9 14:48:08 UTC 2018 - lslezak@suse.cz
+
+- Space check: ignore the partitions mounted before the installer
+  is started, e.g. ignore the HDD installation source or the user
+  mounts for remote logging (bsc#1073696)
+- 4.0.27
+
+-------------------------------------------------------------------
 Mon Jan  8 13:17:00 UTC 2018 - lslezak@suse.cz
 
 - Improved disk usage check - check the parent directory if the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -69,8 +69,8 @@ Requires:       /usr/bin/md5sum
 # .process agent
 Requires:       yast2-core >= 2.16.35
 
-# Storage (requires y2storage)
-Requires:       yast2-storage-ng
+# Mountable#persistent?
+Requires:       yast2-storage-ng >= 4.0.68
 
 # Augeas lenses
 Requires: augeas-lenses

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.26
+Version:        4.0.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SpaceCalculation.rb
+++ b/src/modules/SpaceCalculation.rb
@@ -1052,7 +1052,23 @@ module Yast
     # @return [Array<Storage::Filesystem>]
     def target_filesystems
       filesystems = Y2Storage::Filesystems::BlkFilesystem.all(staging_devicegraph)
-      filesystems.select! { |fs| fs.mountpoint && fs.mountpoint.start_with?("/") }
+      filesystems.select! do |fs|
+        # Ignore the devices mounted before starting the installer (e.g. the
+        # installation repository mounted by linuxrc when installing from HDD or
+        # the user mounted devices like for remote logging). Such devices will
+        # not be saved in the final /etc/fstab therefore check that flag.
+        # Check this only in the initial installation (as the non-fstab values
+        # will be missing in "/mnt"), in installed system they will stay available
+        # at "/".
+        # TODO: use a better API when provided by the libstorage-ng wrapper
+        if fs.mountpoint
+          log.debug("#{fs.mountpoint.inspect} in fstab: " \
+            "#{fs.to_storage_value.mount_point.in_etc_fstab?}")
+        end
+
+        fs.mountpoint && fs.mountpoint.start_with?("/") &&
+          (!Stage.initial || fs.to_storage_value.mount_point.in_etc_fstab?)
+      end
       filesystems.reject! { |fs| TARGET_FS_TYPES_TO_IGNORE.include?(fs.type) }
       filesystems
     end

--- a/src/modules/SpaceCalculation.rb
+++ b/src/modules/SpaceCalculation.rb
@@ -1056,18 +1056,15 @@ module Yast
         # Ignore the devices mounted before starting the installer (e.g. the
         # installation repository mounted by linuxrc when installing from HDD or
         # the user mounted devices like for remote logging). Such devices will
-        # not be saved in the final /etc/fstab therefore check that flag.
+        # not be saved in the final /etc/fstab therefore check the persistency.
         # Check this only in the initial installation (as the non-fstab values
         # will be missing in "/mnt"), in installed system they will stay available
-        # at "/".
-        # TODO: use a better API when provided by the libstorage-ng wrapper
+        # at "/". See bsc#1073696 for details.
         if fs.mountpoint
-          log.debug("#{fs.mountpoint.inspect} in fstab: " \
-            "#{fs.to_storage_value.mount_point.in_etc_fstab?}")
+          log.debug("Persistent #{fs.mountpoint.inspect}: #{fs.persistent?}")
         end
 
-        fs.mountpoint && fs.mountpoint.start_with?("/") &&
-          (!Stage.initial || fs.to_storage_value.mount_point.in_etc_fstab?)
+        fs.mountpoint && fs.mountpoint.start_with?("/") && (!Stage.initial || fs.persistent?)
       end
       filesystems.reject! { |fs| TARGET_FS_TYPES_TO_IGNORE.include?(fs.type) }
       filesystems

--- a/test/space_calculation_test.rb
+++ b/test/space_calculation_test.rb
@@ -23,6 +23,10 @@ def expect_to_execute(command)
   expect(Yast::SCR).to receive(:Execute).with(SCR_BASH_PATH, command)
 end
 
+def expect_to_not_execute(command)
+  expect(Yast::SCR).to_not receive(:Execute).with(SCR_BASH_PATH, command)
+end
+
 def filesystem(size_k: 0, block_size: 4096, type: :ext2, tune_options: "")
   disk_size = Y2Storage::DiskSize.KiB(size_k)
   region = Y2Storage::Region.create(0, disk_size.to_i, Y2Storage::DiskSize.B(block_size))
@@ -125,6 +129,19 @@ describe Yast::SpaceCalculation do
           expect_to_execute(
             /mount -o ro \/dev\/mapper\/cr_ata-VBOX_HARDDISK_VB57271fd6-27adef38-part3/
           ).and_return(-1)
+          Yast::SpaceCalculation.get_partition_info
+        end
+      end
+
+      context "on non-fstab device" do
+        let(:target_map) { "xfs" }
+        let(:with_options) { false }
+
+        it "skips non-fstab devices" do
+          # for simplicity simulate nothing in fstab
+          allow_any_instance_of(Storage::MountPoint).to receive(:in_etc_fstab?).and_return(false)
+          # ensure nothing is mounted
+          expect_to_not_execute(/mount/)
           Yast::SpaceCalculation.get_partition_info
         end
       end

--- a/test/space_calculation_test.rb
+++ b/test/space_calculation_test.rb
@@ -138,8 +138,9 @@ describe Yast::SpaceCalculation do
         let(:with_options) { false }
 
         it "skips non-fstab devices" do
-          # for simplicity simulate nothing in fstab
-          allow_any_instance_of(Storage::MountPoint).to receive(:in_etc_fstab?).and_return(false)
+          # for simplicity simulate no persistent mount at all
+          allow_any_instance_of(Y2Storage::Filesystems::BlkFilesystem).to \
+            receive(:persistent?).and_return(false)
           # ensure nothing is mounted
           expect_to_not_execute(/mount/)
           Yast::SpaceCalculation.get_partition_info


### PR DESCRIPTION
- Ignore the partitions mounted before the installer is started
- E.g. ignore the HDD installation source or the user mounts for remote logging
- See https://bugzilla.suse.com/show_bug.cgi?id=1073696
- Tested manually with manually mounted `/var/log` before running the installer - it was correctly ignored
- Added a simple unit test
- 4.0.27

  