### PR TITLE
Lower the priority of the initial installation repository (bsc#1071742)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 11 07:44:04 UTC 2018 - lslezak@suse.cz
+
+- Decrease the priority of the initial installation repository
+  to prefer the packages from the other media (bsc#1071742)
+- 4.0.27
+
+-------------------------------------------------------------------
 Mon Jan  8 13:17:00 UTC 2018 - lslezak@suse.cz
 
 - Improved disk usage check - check the parent directory if the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.26
+Version:        4.0.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1741,6 +1741,10 @@ module Yast
         end
       end
 
+      # Lower the priority of the initial installation repository to prefer
+      # the packages from the other media (bsc#1071742)
+      lower_repo_priority(initial_repository)
+
       # BNC #481828: Using LABEL from product
       AdjustSourcePropertiesAccordingToProduct(@base_source_id)
 
@@ -2774,6 +2778,15 @@ module Yast
       ret = provides.any? { |p| p[2] != :NONE }
       log.info("#{tag} will #{ret ? "" : "not "}be installed")
       ret
+    end
+
+    # Set a lower repository priority (prio+1, the higher number the lower priority!)
+    # to prefer the packages from the other repositories.
+    # @param src_id [Integer] the repository ID
+    def lower_repo_priority(src_id)
+      priority = Pkg.SourceGeneralData(src_id)["priority"]
+      # decrease the priority (the higher number the lower priority!)
+      Pkg.SourceSetPriority(src_id, priority + 1)
     end
   end
 


### PR DESCRIPTION
- To prefer the packages from the other media.
- See https://bugzilla.suse.com/show_bug.cgi?id=1071742
- 4.0.27