### PR TITLE
Decrease the priority of the initial DVD installation repository (bsc#1071742)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jan 11 11:54:47 UTC 2018 - lslezak@suse.cz
+
+- Decrease the priority of the initial DVD installation repository
+  to prefer the packages from the other DVD media (avoid media
+  changes between the "Packages" and the "Installer" DVDs)
+  (bsc#1071742)
+- 4.0.28
+
+-------------------------------------------------------------------
 Tue Jan  9 14:48:08 UTC 2018 - lslezak@suse.cz
 
 - Space check: ignore the partitions mounted before the installer

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.27
+Version:        4.0.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
To prefer the packages from the other DVD media, avoid media changes between the "Packages" and the "Installer" DVDs.

- See https://bugzilla.suse.com/show_bug.cgi?id=1071742
- Manually tested with the SLE15 "Installer" media + "Basesystem", "Server application" modules from the "Packages" medium. Everything was installed from the "Packages" medium, without any media change.
- It should work correctly with the openSUSE DVD + OSS online repositories, in that case the priority won't be changed and the DVD will be preferred (keeps the old behavior)
- See the Travis log for the [RSpec test cases output](https://travis-ci.org/yast/yast-packager/builds/327722678#L1298)
- 4.0.28