### PR TITLE
Set InitialPreference in yast2-packager.desktop

### DIFF
--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -10,4 +10,4 @@ Categories=System;PackageManager;X-SuSE-ControlCenter-System;
 MimeType=application/x-rpm;application/x-redhat-package-manager;
 NotShowIn=GNOME;MATE;
 StartupNotify=true
-
+InitialPreference=10


### PR DESCRIPTION
By setting InitialPreference to 10, yast takes precedence over other handlers,
like archivers or software centers.