### PR TITLE
Display the addon licenses from libzypp (bsc#1057223)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 15 12:15:00 UTC 2018 - lslezak@suse.cz
+
+- Also display the licenses stored in the RPM-MD repository
+  metadata, fixes displaying the license e.g. for SLE15-HA
+  product on the Packages DVD (bsc#1057223)
+- 4.0.38
+
+-------------------------------------------------------------------
 Fri Feb  9 14:17:05 UTC 2018 - jlopez@suse.com
 
 - Adapt to new MountPoint API (part of fate#318196).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.37
+Version:        4.0.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,8 +39,8 @@ BuildRequires:  yast2 >= 4.0.49
 # needed for icon for desktop file, it is verified at the end of build
 BuildRequires:       yast2_theme
 
-# Pkg::CompareVersions
-BuildRequires:  yast2-pkg-bindings >= 4.0.1
+# Pkg::PrdLicenseLocales
+BuildRequires:  yast2-pkg-bindings >= 4.0.8
 
 # Augeas lenses
 BuildRequires: augeas-lenses
@@ -48,8 +48,8 @@ BuildRequires: augeas-lenses
 # Newly added RPM
 Requires:       yast2-country-data >= 2.16.3
 
-# Pkg::CompareVersions
-Requires:       yast2-pkg-bindings >= 4.0.1
+# Pkg::PrdLicenseLocales
+Requires:       yast2-pkg-bindings >= 4.0.8
 
 # Mandatory language in Product#license and Product#license?
 Requires:       yast2 >= 4.0.49

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1646,7 +1646,7 @@ module Yast
 
         locales.each do |locale|
           license = Pkg.PrdGetLicenseToConfirm(product_name, locale)
-          next unless license && !license.empty?
+          next if license.nil? || license.empty?
 
           found_license = true
           log.info("Found license for language #{locale.inspect}, size: #{license.bytesize} bytes")
@@ -1655,6 +1655,10 @@ module Yast
           File.write(path, license)
           log.info("License saved to #{path}")
         end
+
+        # we can display only one license at one time, there should be only one
+        # product per addon repository anyway
+        break if found_license
       end
 
       if found_license


### PR DESCRIPTION
- [Trello card](https://trello.com/c/NFPbGpjO), [bsc#1057223](https://bugzilla.suse.com/show_bug.cgi?id=1057223)
- Added unit test
- Tested also manually using the latest build + updated `yast2-pkg-bindings` package

### Screenshot

Tested with the HA product from the Packages DVD:

![addon_license_agreement2](https://user-images.githubusercontent.com/907998/36202131-d81c98ae-1182-11e8-8312-68c2c5d30c51.png)
