### PR TITLE
Licenses multi language support

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 15 18:52:40 UTC 2018 - igonzalezsosa@suse.com
+
+- Display licenses translations (related to FATE#322276).
+- 4.0.39
+
+-------------------------------------------------------------------
 Thu Feb 15 12:15:00 UTC 2018 - lslezak@suse.cz
 
 - Also display the licenses stored in the RPM-MD repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.38
+Version:        4.0.39
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -33,8 +33,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:cfa) >= 0.5.0
 # Y2Storage::Mountable#mount_path
 BuildRequires:  yast2-storage-ng >= 4.0.90
 
-# Mandatory language in Product#license and Product#license?
-BuildRequires:  yast2 >= 4.0.49
+# Y2Packager::Product#license_locales
+BuildRequires:  yast2 >= 4.0.51
 
 # needed for icon for desktop file, it is verified at the end of build
 BuildRequires:       yast2_theme
@@ -51,8 +51,8 @@ Requires:       yast2-country-data >= 2.16.3
 # Pkg::PrdLicenseLocales
 Requires:       yast2-pkg-bindings >= 4.0.8
 
-# Mandatory language in Product#license and Product#license?
-Requires:       yast2 >= 4.0.49
+# Y2Packager::Product#license_locales
+Requires:       yast2 >= 4.0.51
 
 # unzipping license file
 Requires:       unzip

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -34,7 +34,7 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:cfa) >= 0.5.0
 BuildRequires:  yast2-storage-ng >= 4.0.90
 
 # Y2Packager::Product#license_locales
-BuildRequires:  yast2 >= 4.0.51
+BuildRequires:  yast2 >= 4.0.52
 
 # needed for icon for desktop file, it is verified at the end of build
 BuildRequires:       yast2_theme
@@ -52,7 +52,7 @@ Requires:       yast2-country-data >= 2.16.3
 Requires:       yast2-pkg-bindings >= 4.0.8
 
 # Y2Packager::Product#license_locales
-Requires:       yast2 >= 4.0.51
+Requires:       yast2 >= 4.0.52
 
 # unzipping license file
 Requires:       unzip

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -37,6 +37,7 @@ module Y2Packager
       #
       # @return [String] Dialog's title
       def title
+        # TRANSLATORS: %s is a product name
         format(_("%s License Agreement"), product.label)
       end
 

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -11,16 +11,17 @@
 # ------------------------------------------------------------------------------
 
 require "yast"
-require "ui/installation_dialog"
-require "cgi/util"
+require "cwm"
+require "cwm/dialog"
+require "y2packager/widgets/product_license_translations"
+require "y2packager/widgets/product_license_confirmation"
+
 Yast.import "Language"
-Yast.import "UI"
-Yast.import "Report"
 
 module Y2Packager
   module Dialogs
     # Dialog which shows the user a license and ask for confirmation
-    class InstProductLicense < ::UI::InstallationDialog
+    class InstProductLicense < CWM::Dialog
       # @return [Y2Packager::Product] Product
       attr_reader :product
 
@@ -30,132 +31,26 @@ module Y2Packager
       def initialize(product)
         super()
         @product = product
-        self.language = Yast::Language.language
-        self.confirmed = product.license_confirmed?
       end
 
-      # Handler for the :language action
+      # Returns the dialog title
       #
-      # This happens when the user changes the license language
-      def language_handler
-        self.language = Yast::UI.QueryWidget(Id(:language), :Value)
-        Yast::UI.ReplaceWidget(Id(:license_replace_point), license_content)
-      end
-
-      # Handler for the :license_confirmation action
-      #
-      # This action happens when the user clicks the confirmation checkbox.
-      def license_confirmation_handler
-        @confirmed = Yast::UI.QueryWidget(Id(:license_confirmation), :Value)
-      end
-
-      # Handler for the :next action
-      #
-      # This action happens when the user clicks the 'Next' button
-      def next_handler
-        if confirmed
-          update_product_confirmation
-          finish_dialog(:next)
-        else
-          Yast::Report.Message(_("You must accept the license to install this product"))
-        end
-      end
-
-      # Handler for the :back action
-      #
-      # This action happens when the user clicks the 'Back' button
-      def back_handler
-        update_product_confirmation
-        finish_dialog(:back)
-      end
-
-    private
-
-      # @return [String] Language code (en_US, es_ES, etc.).
-      attr_accessor :language
-      # @return [Boolean] Determines whether the user confirmed the license
-      attr_accessor :confirmed
-
-      # Dialog content
-      #
-      # @see ::UI::Dialog
-      def dialog_content
-        VBox(
-          Left(language_selection),
-          VSpacing(0.5),
-          ReplacePoint(
-            Id(:license_replace_point),
-            license_content
-          ),
-          confirmation_checkbox
-        )
-      end
-
-      # Dialog title
-      #
-      # @see ::UI::Dialog
-      def dialog_title
+      # @return [String] Dialog's title
+      def title
         format(_("%s License Agreement"), product.label)
       end
 
-      # Return the UI for the language selector
-      def language_selection
-        ComboBox(
-          Id(:language),
-          Opt(:notify, :hstretch),
-          _("&License Language"),
-          Yast::Language.GetLanguageItems(:primary)
-        )
-      end
-
-      # Return the UI for the license content
-      def license_content
-        MinWidth(
-          80,
-          RichText(Id(:license_content), formatted_license_text)
-        )
-      end
-
-      # Regexp to determine whether the text is formatted as richtext
-      RICHTEXT_REGEXP = /<\/.*>/
-
-      # Return the license text
+      # Dialog content
       #
-      # It detects whether license text is richtext or not and format it
-      # accordingly.
-      #
-      # @return [String] Formatted license text
-      def formatted_license_text
-        text = product.license(language)
-        if RICHTEXT_REGEXP =~ text
-          text
-        else
-          "<pre>#{CGI.escapeHTML(text)}</pre>"
-        end
-      end
-
-      # Return the UI for the confirmation checkbox
-      def confirmation_checkbox
+      # @return [Yast::Term] Dialog's content
+      def contents
         VBox(
-          VSpacing(0.5),
-          Left(
-            CheckBox(
-              Id(:license_confirmation),
-              Opt(:notify),
-              # license agreement check box label
-              _("I &Agree to the License Terms."),
-              confirmed
-            )
+          Widgets::ProductLicenseTranslations.new(product, Yast::Language.language),
+          HBox(
+            Left(Widgets::ProductLicenseConfirmation.new(product)),
+            HStretch()
           )
         )
-      end
-
-      # Update the product's license confirmation status
-      #
-      # It will not update the status if it has not changed.
-      def update_product_confirmation
-        return if product.license_confirmed? == confirmed
-        product.license_confirmation = confirmed
       end
     end
   end

--- a/src/lib/y2packager/dialogs/product_license_translations.rb
+++ b/src/lib/y2packager/dialogs/product_license_translations.rb
@@ -1,0 +1,106 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+require "cwm/dialog"
+require "y2packager/widgets/product_license_translations"
+
+Yast.import "Label"
+
+module Y2Packager
+  module Dialogs
+    # This dialog displays available translation for a given product.
+    #
+    # The dialog is open as a pop-up (check #should_open_dialog,
+    # #wizard_create_dialog and #layout for technical details) and it relies
+    # heavily on the {Y2Packager::Widgets::ProductLicenseTranslations} widget.
+    class ProductLicenseTranslations < CWM::Dialog
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+      # @return [String] Default language code (eg. "en_US")
+      attr_reader :language
+
+      def initialize(product, language = nil)
+        super()
+        @product = product
+        @language = language || Yast::Language.language
+      end
+
+      # Returns the dialog title
+      #
+      # @return [String] Dialog's title
+      def title
+        _("License Agreement")
+      end
+
+      # Dialog content
+      #
+      # @return [Yast::Term] Dialog's content
+      def contents
+        VBox(
+          Y2Packager::Widgets::ProductLicenseTranslations.new(product, language)
+        )
+      end
+
+    private
+
+      # Force the dialog to be shown as a pop-up
+      #
+      # @return [True]
+      def should_open_dialog?
+        true
+      end
+
+      # Redefine how the dialog should be created
+      #
+      # @see #layout
+      def wizard_create_dialog(&block)
+        Yast::UI.OpenDialog(layout)
+        block.call
+      ensure
+        Yast::UI.CloseDialog()
+      end
+
+      # Define widget's layout
+      #
+      # @return [Yast::Term]
+      def layout
+        HBox(
+          VSpacing(Yast::UI.TextMode ? 21 : 25),
+          VBox(
+            Left(
+              # TRANSLATORS: dialog caption
+              Heading(Id(:title), _("License Agreement"))
+            ),
+            VSpacing(Yast::UI.TextMode ? 0.1 : 0.5),
+            HSpacing(82),
+            HBox(
+              VStretch(),
+              ReplacePoint(Id(:contents), Empty())
+            ),
+            ButtonBox(
+              PushButton(Id(:next), Opt(:okButton, :default, :key_F10), next_button)
+            )
+          )
+        )
+      end
+
+      # Define next button (ok) label
+      #
+      # @return [String]
+      def next_button
+        Yast::Label.OKButton
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/dialogs/product_license_translations.rb
+++ b/src/lib/y2packager/dialogs/product_license_translations.rb
@@ -30,6 +30,8 @@ module Y2Packager
       # @return [String] Default language code (eg. "en_US")
       attr_reader :language
 
+      # @param product  [Y2Packager::Product] Product
+      # @param language [String] Default language code (eg. "en_US")
       def initialize(product, language = nil)
         super()
         @product = product

--- a/src/lib/y2packager/widgets/license_translations_button.rb
+++ b/src/lib/y2packager/widgets/license_translations_button.rb
@@ -12,7 +12,7 @@
 
 require "yast"
 require "cwm"
-require "y2packager/dialogs/product_license"
+require "y2packager/dialogs/product_license_translations"
 
 module Y2Packager
   module Widgets
@@ -20,10 +20,12 @@ module Y2Packager
     class LicenseTranslationsButton < CWM::PushButton
       # @return [Y2Packager::Product] Product
       attr_reader :product
+      attr_reader :language
 
-      def initialize(product)
+      def initialize(product, language = nil)
         super()
         @product = product
+        @language = language || Yast::Language.language
       end
 
       # Widget label
@@ -38,7 +40,7 @@ module Y2Packager
       #
       # @see CWM::AbstractWidget#handle
       def handle
-        Y2Packager::Dialogs::ProductLicense.new(product).run
+        Y2Packager::Dialogs::ProductLicenseTranslations.new(product, language).run
         nil
       end
     end

--- a/src/lib/y2packager/widgets/license_translations_button.rb
+++ b/src/lib/y2packager/widgets/license_translations_button.rb
@@ -30,7 +30,7 @@ module Y2Packager
 
       # Widget label
       #
-      # @teturn [String] Translated label
+      # @return [String] Translated label
       # @see CWM::AbstractWidget#label
       def label
         _("License &Translations...")

--- a/src/lib/y2packager/widgets/license_translations_button.rb
+++ b/src/lib/y2packager/widgets/license_translations_button.rb
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+require "y2packager/dialogs/product_license"
+
+module Y2Packager
+  module Widgets
+    # This button launches the licenses translations dialog when pushed
+    class LicenseTranslationsButton < CWM::PushButton
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+
+      def initialize(product)
+        super()
+        @product = product
+      end
+
+      # Widget label
+      #
+      # @teturn [String] Translated label
+      # @see CWM::AbstractWidget#label
+      def label
+        _("License &Translations...")
+      end
+
+      # Launch the product license translations dialog
+      #
+      # @see CWM::AbstractWidget#handle
+      def handle
+        Y2Packager::Dialogs::ProductLicense.new(product).run
+        nil
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/widgets/product_license.rb
+++ b/src/lib/y2packager/widgets/product_license.rb
@@ -64,7 +64,7 @@ module Y2Packager
 
       # Translate the license content to the given language
       #
-      # @param language [String] Language code (en_US, de_DE, etc.).
+      # @param new_language [String] Language code (en_US, de_DE, etc.).
       def translate(new_language)
         self.language = new_language
         product_license_content.translate(language)

--- a/src/lib/y2packager/widgets/product_license_content.rb
+++ b/src/lib/y2packager/widgets/product_license_content.rb
@@ -55,7 +55,7 @@ module Y2Packager
 
     private
 
-      # @!method language=
+      # @!method language=(new_language)
       #   @param new_language [String] Language code
       attr_writer :language
 

--- a/src/lib/y2packager/widgets/product_license_content.rb
+++ b/src/lib/y2packager/widgets/product_license_content.rb
@@ -55,8 +55,8 @@ module Y2Packager
 
     private
 
-      # @!method language=(new_language)
-      #   @param new_language [String] Language code
+      # @!attribute [w] language
+      #   @return [String] Language code
       attr_writer :language
 
       # License content UI

--- a/src/lib/y2packager/widgets/product_license_content.rb
+++ b/src/lib/y2packager/widgets/product_license_content.rb
@@ -1,0 +1,95 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+
+module Y2Packager
+  module Widgets
+    # Widget to show a product's license content
+    class ProductLicenseContent < CWM::CustomWidget
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+      # @return [String] Language code (en_US, es_ES, etc.).
+      attr_reader :language
+
+      # @param product  [Y2Packager::Product] Product
+      # @param language [String]              Default language (en_US, es_ES, etc.).
+      def initialize(product, language)
+        textdomain "packager"
+        @product = product
+        @language = language
+      end
+
+      # Implement #init content
+      #
+      # @see CWM::AbstractWidget#init
+      def init
+        update_license_text
+      end
+
+      # Return the UI for the widget
+      #
+      # @return [Yast::Term] widget's UI
+      def contents
+        @contents ||= MinWidth(80, license_content)
+      end
+
+      # Translate license content
+      #
+      # @param new_language [String] New language code
+      def translate(new_language)
+        return if language == new_language
+        self.language = new_language
+        update_license_text
+      end
+
+    private
+
+      # @!method language=
+      #   @param new_language [String] Language code
+      attr_writer :language
+
+      # License content UI
+      #
+      # @return [Yast::Term] UI for the license content
+      def license_content
+        @license_content ||= CWM::RichText.new.tap { |r| r.value = formatted_license_text }
+      end
+
+      # Update license text
+      #
+      # @see #license_content
+      def update_license_text
+        license_content.value = formatted_license_text
+      end
+
+      # Regexp to determine whether the text is formatted as richtext
+      RICHTEXT_REGEXP = /<\/.*>/
+
+      # Return the license text
+      #
+      # It detects whether license text is richtext or not and format it
+      # accordingly.
+      #
+      # @return [String] Formatted license text
+      def formatted_license_text
+        text = product.license(language)
+        if RICHTEXT_REGEXP =~ text
+          text
+        else
+          "<pre>#{CGI.escapeHTML(text)}</pre>"
+        end
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -1,0 +1,83 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm"
+require "y2country/widgets/simple_language_selection"
+require "y2packager/widgets/product_license"
+
+module Y2Packager
+  module Widgets
+    # This widget display license translations for a given product
+    #
+    # The widget serves a glue between a pair of widgets:
+    #
+    # * {Y2Country::Widgets::SimpleLanguageSelector} to select the language,
+    # * {Y2Packager::Widgets::ProductLicenseContent} to display the license.
+    class ProductLicenseTranslations < CWM::CustomWidget
+      # @return [Y2Packager::Product] Product
+      attr_reader :product
+      # @return [String] Language code (en_US, es_ES, etc.).
+      attr_reader :language
+
+      # @param product  [Y2Packager::Product] Product
+      # @param language [String]              Default language (en_US, es_ES, etc.).
+      def initialize(product, language)
+        super()
+        @product = product
+        @language = language
+        self.handle_all_events = true
+      end
+
+      # Widget content
+      #
+      # @see CWM::CustomWidget#contents
+      def contents
+        VBox(
+          Left(language_selection),
+          VSpacing(0.5),
+          product_license
+        )
+      end
+
+      # Event handler
+      #
+      # Translate the license content if language has changed.
+      #
+      # @param event [Hash] Event data
+      def handle(event)
+        if event["ID"] == language_selection.widget_id
+          product_license.translate(language_selection.value)
+        end
+        nil
+      end
+
+    private
+
+      # Language selection widget
+      #
+      # @return [Y2Country::Widgets::SimpleLanguageSelection]
+      def language_selection
+        @language_selection ||=
+          Y2Country::Widgets::SimpleLanguageSelection.new(product.license_locales, language)
+      end
+
+      # Product  selection widget
+      #
+      # @return [Widgets::ProductLicenseContent]
+      def product_license
+        @product_license ||=
+          Y2Packager::Widgets::ProductLicenseContent.new(product, language)
+      end
+    end
+  end
+end

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -12,7 +12,7 @@
 
 require "yast"
 require "cwm"
-require "y2country/widgets/simple_language_selection"
+require "y2packager/widgets/simple_language_selection"
 require "y2packager/widgets/product_license"
 
 module Y2Packager
@@ -21,7 +21,7 @@ module Y2Packager
     #
     # The widget serves a glue between a pair of widgets:
     #
-    # * {Y2Country::Widgets::SimpleLanguageSelector} to select the language,
+    # * {Y2Packager::Widgets::SimpleLanguageSelector} to select the language,
     # * {Y2Packager::Widgets::ProductLicenseContent} to display the license.
     class ProductLicenseTranslations < CWM::CustomWidget
       # @return [Y2Packager::Product] Product
@@ -65,10 +65,10 @@ module Y2Packager
 
       # Language selection widget
       #
-      # @return [Y2Country::Widgets::SimpleLanguageSelection]
+      # @return [Y2Packager::Widgets::SimpleLanguageSelection]
       def language_selection
         @language_selection ||=
-          Y2Country::Widgets::SimpleLanguageSelection.new(product.license_locales, language)
+          Y2Packager::Widgets::SimpleLanguageSelection.new(product.license_locales, language)
       end
 
       # Product  selection widget

--- a/src/lib/y2packager/widgets/simple_language_selection.rb
+++ b/src/lib/y2packager/widgets/simple_language_selection.rb
@@ -65,7 +65,7 @@ module Y2Packager
       # Initialize to the given default language
       #
       # If the language is not in the list of options, it will try with the
-      # short code (for instance, "de" for "de_DE"). If it fails again, it
+      # short code (for instance, "de" for "de_DE"). If it fails again, its
       # initial value will be set to "en_US".
       def init
         languages = items.map(&:first)
@@ -106,7 +106,7 @@ module Y2Packager
           langs << [code, attrs[4]]
         end
         @items.uniq!
-        @items.sort_by! { |l| l[1] }
+        @items.sort_by!(&:last)
       end
     end
   end

--- a/src/lib/y2packager/widgets/simple_language_selection.rb
+++ b/src/lib/y2packager/widgets/simple_language_selection.rb
@@ -1,0 +1,113 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may find
+# current contact information at www.novell.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/widget"
+
+Yast.import "Language"
+
+module Y2Packager
+  module Widgets
+    # Language selection widget
+    #
+    # In contrast to {Y2Packager::Widgets::LanguageSelection}, this modules does not
+    # modify the system language in any way.
+    class SimpleLanguageSelection < CWM::ComboBox
+      # @return [String] Default language code
+      attr_reader :default
+      # @return [String] List of languages to display (en_US, de_DE, etc.)
+      attr_reader :languages
+
+      # @param languages [Array<String>] List of languages to display (en_US, de_DE, etc.)
+      # @param default   [String]        Default language code
+      def initialize(languages, default)
+        textdomain "y2packager"
+        @languages = languages
+        @default = default
+        self.widget_id = "simple_language_selection"
+      end
+
+      # Widget label
+      #
+      # @return [String]
+      def label
+        _("&Language")
+      end
+
+      # Widget options
+      #
+      # Widget is forced to report immediatelly after value changed.
+      def opt
+        opts = [:notify]
+        opts << :disabled unless items.size > 1
+        opts
+      end
+
+      # [String] Default license language.
+      DEFAULT_LICENSE_LANG = "en_US".freeze
+
+      # Initialize to the given default language
+      #
+      # If the language is not in the list of options, it will try with the
+      # short code (for instance, "de" for "de_DE"). If it fails again, it
+      # initial value will be set to "en_US".
+      def init
+        languages = items.map(&:first)
+        new_value =
+          if languages.include?(default)
+            default
+          elsif default.include?("_")
+            short_code = default.split("_").first
+            languages.include?(short_code) ? short_code : nil
+          end
+
+        self.value = new_value || DEFAULT_LICENSE_LANG
+      end
+
+      # Widget help text
+      #
+      # @return [String]
+      def help
+        ""
+      end
+
+      # Return the options to be shown in the combobox
+      #
+      # @return [Array<Array<String,String>>] Array of languages in form [code, description]
+      def items
+        return @items if @items
+        languages_map = Yast::Language.GetLanguagesMap(false)
+        @items = languages.each_with_object([]) do |code, langs|
+          attrs = languages_map.key?(code) ? languages_map[code] : nil
+          lang, attrs = languages_map.find { |k, _v| k.start_with?(code) } if attrs.nil?
+
+          if attrs.nil?
+            log.warn "Not valid language '#{lang}'"
+            next
+          end
+
+          log.debug "Using language '#{lang}' instead of '#{code}'" if lang != code
+          langs << [code, attrs[4]]
+        end
+        @items.uniq!
+        @items.sort_by! { |l| l[1] }
+      end
+    end
+  end
+end

--- a/test/lib/dialogs/inst_product_license_test.rb
+++ b/test/lib/dialogs/inst_product_license_test.rb
@@ -1,3 +1,16 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
 require_relative "../../test_helper"
 require "y2packager/dialogs/inst_product_license"
 require "y2packager/product"
@@ -5,152 +18,26 @@ require "y2packager/product"
 describe Y2Packager::Dialogs::InstProductLicense do
   subject(:dialog) { described_class.new(product) }
   let(:product) do
-    instance_double(
-      Y2Packager::Product,
-      label:                   "openSUSE",
-      license:                  content,
-      license_confirmed?:       confirmed?,
-      :license_confirmation= => nil
-    )
+    instance_double(Y2Packager::Product)
   end
 
   let(:language) { "en_US" }
-  let(:confirmed?) { false }
-  let(:content) { "content" }
 
-  describe "#run" do
+  describe "#contents" do
     before do
       allow(Yast::Language).to receive(:language).and_return(language)
-      allow(Yast::Language).to receive(:GetLanguageItems).and_return([])
     end
 
-    context "when user accepts the license" do
-      before do
-        allow(Yast::UI).to receive(:QueryWidget).with(Id(:license_confirmation), :Value)
-          .and_return(true)
-        allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, button)
-      end
-
-      context "and clicks :next" do
-        let(:button) { :next }
-
-        it "confirms the license" do
-          expect(product).to receive(:license_confirmation=).with(true)
-          dialog.run
-        end
-
-        it "returns :next" do
-          expect(dialog.run).to eq(:next)
-        end
-      end
-
-      context "and clicks :back" do
-        let(:button) { :back }
-
-        it "confirms the license" do
-          expect(product).to receive(:license_confirmation=).with(true)
-          dialog.run
-        end
-
-        it "returns :back" do
-          expect(dialog.run).to eq(:back)
-        end
-      end
+    it "includes a confirmation checkbox" do
+      expect(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new)
+        .with(product)
+      dialog.contents
     end
 
-    context "when user does not accept the license" do
-      context "and clicks :next" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:next, :back)
-        end
-
-        it "shows a message" do
-          expect(Yast::Report).to receive(:Message)
-          dialog.run
-        end
-      end
-
-      context "and clicks :back" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:back)
-        end
-
-        it "returns :back" do
-          expect(dialog.run).to eq(:back)
-        end
-
-        it "does not confirm the license" do
-          expect(product).to_not receive(:license_confirmation=)
-          dialog.run
-        end
-      end
-    end
-
-    context "when the user set as unconfirmed a previously confirmed license" do
-      let(:confirmed?) { true }
-
-      before do
-        allow(Yast::UI).to receive(:QueryWidget).with(Id(:license_confirmation), :Value)
-          .and_return(false)
-      end
-
-      context "and clicks :next" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, :next, :back)
-        end
-
-        it "confirms the license" do
-          expect(product).to receive(:license_confirmation=).with(false)
-          dialog.run
-        end
-
-        it "shows a message" do
-          expect(Yast::Report).to receive(:Message)
-          dialog.run
-        end
-      end
-
-      context "and clicks :back" do
-        let(:button) { :back }
-
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, button)
-        end
-
-        it "set as unconfirmed a license" do
-          expect(product).to receive(:license_confirmation=).with(false)
-          dialog.run
-        end
-
-        it "returns :back" do
-          expect(dialog.run).to eq(:back)
-        end
-      end
-    end
-
-    context "license formatting" do
-      before do
-        allow(Yast::UI).to receive(:UserInput).and_return(:license_confirmation, :back)
-      end
-
-      context "when license content is richtext" do
-        let(:content) { "<h1>title</h1>" }
-
-        it "does not modify the text" do
-          expect(subject).to receive(:RichText).with(Id(:license_content), content)
-          dialog.run
-        end
-      end
-
-      context "when license content is not richtext" do
-        let(:content) { "SLE 15 > SLE 12" }
-
-        it "converts to richtext" do
-          expect(subject).to receive(:RichText)
-            .with(Id(:license_content), "<pre>SLE 15 &gt; SLE 12</pre>")
-          dialog.run
-        end
-      end
+    it "includes product translations using the current language as default" do
+      expect(Y2Packager::Widgets::ProductLicenseTranslations).to receive(:new)
+        .with(product, language)
+      dialog.contents
     end
   end
 end

--- a/test/lib/dialogs/product_license_translations_test.rb
+++ b/test/lib/dialogs/product_license_translations_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../test_helper"
+require "y2packager/dialogs/product_license_translations"
+require "y2packager/product"
+
+describe Y2Packager::Dialogs::ProductLicenseTranslations do
+  subject(:dialog) { described_class.new(product, language) }
+  let(:product) { instance_double("Y2Packager::Product") }
+  let(:language) { "en_US" }
+
+  describe "#contents" do
+    it "includes a ProductLicenseTranslations widget" do
+      expect(Y2Packager::Widgets::ProductLicenseTranslations).to receive(:new)
+        .with(product, language).and_call_original
+      expect(dialog.contents.to_s).to include("Widgets::ProductLicenseTranslations")
+    end
+  end
+
+  describe "#language" do
+    context "when it is not specified" do
+      before do
+        allow(Yast::Language).to receive(:language).and_return("de_DE")
+      end
+
+      it "uses the system's current language" do
+        dialog = described_class.new(product)
+        expect(dialog.language).to eq("de_DE")
+      end
+    end
+
+    context "when it is specified" do
+      it "uses the given one" do
+        dialog = described_class.new(product, "cs_CZ")
+        expect(dialog.language).to eq("cs_CZ")
+      end
+    end
+  end
+end

--- a/test/lib/widgets/license_translations_button_test.rb
+++ b/test/lib/widgets/license_translations_button_test.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+require "y2packager/widgets/license_translations_button"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::LicenseTranslationsButton do
+  subject(:widget) { described_class.new(product) }
+  let(:product) { instance_double(Y2Packager::Product, license: "content") }
+
+  describe "#handle" do
+    let(:dialog) { instance_double(Y2Packager::Dialogs::ProductLicense, run: nil) }
+
+    before do
+      allow(Y2Packager::Dialogs::ProductLicense).to receive(:new)
+        .with(product).and_return(dialog)
+    end
+
+    it "opens a dialog" do
+      expect(dialog).to receive(:run)
+      widget.handle
+    end
+
+    it "returns nil" do
+      expect(widget.handle).to be_nil
+    end
+  end
+end

--- a/test/lib/widgets/license_translations_button_test.rb
+++ b/test/lib/widgets/license_translations_button_test.rb
@@ -19,16 +19,20 @@ require "y2packager/product"
 describe Y2Packager::Widgets::LicenseTranslationsButton do
   subject(:widget) { described_class.new(product) }
   let(:product) { instance_double(Y2Packager::Product, license: "content") }
+  let(:language) { "en_US" }
 
   describe "#handle" do
-    let(:dialog) { instance_double(Y2Packager::Dialogs::ProductLicense, run: nil) }
+    let(:dialog) { instance_double(Y2Packager::Dialogs::ProductLicenseTranslations, run: nil) }
 
     before do
-      allow(Y2Packager::Dialogs::ProductLicense).to receive(:new)
-        .with(product).and_return(dialog)
+      allow(Yast::Language).to receive(:language).and_return(language)
+      allow(Y2Packager::Dialogs::ProductLicenseTranslations).to receive(:new)
+        .and_return(dialog)
     end
 
     it "opens a dialog" do
+      expect(Y2Packager::Dialogs::ProductLicenseTranslations).to receive(:new)
+        .with(product, language).and_return(dialog)
       expect(dialog).to receive(:run)
       widget.handle
     end

--- a/test/lib/widgets/product_license_content_test.rb
+++ b/test/lib/widgets/product_license_content_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+require "y2packager/widgets/product_license_content"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::ProductLicenseContent do
+  include_examples "CWM::CustomWidget"
+
+  subject(:widget) { described_class.new(product, language) }
+
+  let(:language) { "de_DE" }
+  let(:product) { instance_double(Y2Packager::Product, license: "content") }
+
+  describe "#contents" do
+    it "includes license content in the given language" do
+      expect(product).to receive(:license).with(language)
+        .and_return("license content")
+      widget.contents
+    end
+  end
+
+  describe "#translate" do
+    let(:richtext) { CWM::RichText.new }
+
+    before do
+      allow(product).to receive(:license).with("es_ES")
+        .and_return("content es_ES")
+      allow(CWM::RichText).to receive(:new).and_return(richtext)
+    end
+
+    it "shows license content in the given language" do
+      widget.contents
+      expect(richtext).to receive(:value=).with(/content es_ES/)
+      widget.translate("es_ES")
+    end
+  end
+end

--- a/test/lib/widgets/product_license_test.rb
+++ b/test/lib/widgets/product_license_test.rb
@@ -34,7 +34,8 @@ describe Y2Packager::Widgets::ProductLicense do
     end
 
     it "shows the license in the given language" do
-      expect(product).to receive(:license).with(language).and_return("de_DE license")
+      expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+        .with(product, language).and_return("de_DE license")
       expect(widget.contents.to_s).to include("de_DE license")
     end
 
@@ -60,6 +61,21 @@ describe Y2Packager::Widgets::ProductLicense do
       it "does includes a confirmation checkbox" do
         expect(widget.contents.to_s).to_not include("confirmation_widget")
       end
+    end
+  end
+
+  describe "#translate" do
+    let(:license_content) { instance_double(Y2Packager::Widgets::ProductLicenseContent) }
+
+    before do
+      allow(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+        .and_return(license_content)
+    end
+
+    it "translate the license to the given language" do
+      widget.contents
+      expect(license_content).to receive(:translate).with("es_ES")
+      widget.translate("es_ES")
     end
   end
 end

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -29,7 +29,7 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
 
   describe "#contents" do
     it "includes a language selector" do
-      expect(Y2Country::Widgets::SimpleLanguageSelection).to receive(:new)
+      expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
         .with(languages: product.license_locales, default: language)
       widget.contents
     end
@@ -43,12 +43,12 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
 
   describe "#handle" do
     let(:language_widget) do
-      Y2Country::Widgets::SimpleLanguageSelection.new(["en_US", "es"], "en_US")
+      Y2Packager::Widgets::SimpleLanguageSelection.new(["en_US", "es"], "en_US")
     end
     let(:content_widget) { instance_double(Y2Packager::Widgets::ProductLicenseContent) }
 
     before do
-      allow(Y2Country::Widgets::SimpleLanguageSelection).to receive(:new)
+      allow(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
         .and_return(language_widget)
       allow(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
         .and_return(content_widget)

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -30,7 +30,7 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
   describe "#contents" do
     it "includes a language selector" do
       expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
-        .with(languages: product.license_locales, default: language)
+        .with(product.license_locales, language)
       widget.contents
     end
 

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -34,7 +34,7 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
       widget.contents
     end
 
-    it "includes a the product license text" do
+    it "includes the product license text" do
       expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
         .with(product, language)
       widget.contents

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../test_helper"
+require "cwm/rspec"
+
+require "y2packager/widgets/product_license_translations"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::ProductLicenseTranslations do
+  include_examples "CWM::CustomWidget"
+
+  subject(:widget) { described_class.new(product, language) }
+
+  let(:language) { "de_DE" }
+  let(:product) do
+    instance_double(Y2Packager::Product, license_locales: ["en_US"], license: "content")
+  end
+
+  describe "#contents" do
+    it "includes a language selector" do
+      expect(Y2Country::Widgets::SimpleLanguageSelection).to receive(:new)
+        .with(languages: product.license_locales, default: language)
+      widget.contents
+    end
+
+    it "includes a the product license text" do
+      expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+        .with(product, language)
+      widget.contents
+    end
+  end
+
+  describe "#handle" do
+    let(:language_widget) do
+      Y2Country::Widgets::SimpleLanguageSelection.new(["en_US", "es"], "en_US")
+    end
+    let(:content_widget) { instance_double(Y2Packager::Widgets::ProductLicenseContent) }
+
+    before do
+      allow(Y2Country::Widgets::SimpleLanguageSelection).to receive(:new)
+        .and_return(language_widget)
+      allow(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+        .and_return(content_widget)
+    end
+
+    context "when the event comes from the language selector" do
+      let(:event) { { "ID" => language_widget.widget_id } }
+
+      before do
+        allow(language_widget).to receive(:value).and_return("es")
+      end
+
+      it "translates the license content" do
+        expect(content_widget).to receive(:translate).with("es")
+        widget.handle(event)
+      end
+    end
+
+    context "when the event comes from another widget" do
+      let(:event) { { "ID" => "other_widget" } }
+
+      it "does not translate the license content" do
+        expect(content_widget).to_not receive(:translate)
+        widget.handle(event)
+      end
+    end
+  end
+end

--- a/test/lib/widgets/simple_language_selection_test.rb
+++ b/test/lib/widgets/simple_language_selection_test.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../test_helper"
+require "y2packager/widgets/simple_language_selection"
+require "cwm/rspec"
+require "y2packager/product"
+
+describe Y2Packager::Widgets::SimpleLanguageSelection do
+  include_examples "CWM::AbstractWidget"
+
+  subject(:widget) { described_class.new(["de_DE", "en", "cs"], default) }
+
+  let(:default) { "en" }
+  let(:languages_map) do
+    {
+      "de_DE" => ["Deutsch", "Deutsch", ".UTF-8", "@euro", "German"],
+      "en_US" => ["English (US)", "English (US)", ".UTF-8", "", "English (US)"],
+      "es_ES" => ["Español", "Espanol", ".UTF-8", "@euro", "Spanish"],
+      "cs_CZ" => ["Čeština", "Cestina", ".UTF-8", "", "Czech"]
+    }
+  end
+
+  before do
+    allow(Yast::Language).to receive(:GetLanguagesMap).with(false)
+      .and_return(languages_map)
+  end
+
+  describe "#init" do
+    it "sets the widget's value to the default one" do
+      expect(widget).to receive(:value=).with(default)
+      widget.init
+    end
+
+    context "when full language code does not exist" do
+      let(:default) { "cs_CZ" }
+
+      it "tries using the short language code" do
+        expect(widget).to receive(:value=).with("cs")
+        widget.init
+      end
+
+      context "and short language code does not exist" do
+        let(:default) { "es" }
+
+        it "tries to the default 'en_US'" do
+          expect(widget).to receive(:value=).with("en_US")
+          widget.init
+        end
+      end
+    end
+  end
+
+  describe "#items" do
+    it "contains only given languages" do
+      expect(widget.items).to eq(
+        [["cs", "Czech"], ["en", "English (US)"], ["de_DE", "German"]]
+      )
+    end
+  end
+
+  describe "#opt" do
+    it "sets the :notify option" do
+      expect(widget.opt).to eq([:notify])
+    end
+
+    context "when there is only one option" do
+      let(:languages_map) do
+        { "en_US" => ["English (US)", "English (US)", ".UTF-8", "", "English (US)"] }
+      end
+
+      it "sets the :disabled option" do
+        expect(widget.opt).to include(:disabled)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR enables the installer to show licenses translations. It depends on https://github.com/yast/yast-yast2/pull/694.

PBI: https://trello.com/c/VjEpcE8x/

## How it looks

When using a multi-product DVD, the language can be selected in the second step (when displaying the license).

![license-translations-multi-product](https://user-images.githubusercontent.com/15836/36249603-2684503a-1233-11e8-94f5-321d0e8c2746.png)

For single product media, I brought back the *License Translations* button:

![license-tranlations-single-product](https://user-images.githubusercontent.com/15836/36249614-2b937434-1233-11e8-8948-fdbc13b6ea01.png)

## Additional changes

As part of this PR, I've done some refactoring, unifying the code which handles with licenses as much as possible. Now we have a set of smal widgets that we combine in order to build the complex welcome screen, the licenses translations pop-up and the `InstProductLicense` dialog (which is now a CWM widget too).