### PR TITLE
Install the packages needed for accessing the repositories (bsc#1063980)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Feb 26 12:05:46 UTC 2018 - lslezak@suse.cz
+
+- Fixed installing packages needed for accessing the installation
+  repositories (e.g. "nfs-client" for "nfs://" repositories),
+  additionally evaluate also the add-on repositories, not just the
+  base product repository (bsc#1063980)
+- 4.0.42
+
+-------------------------------------------------------------------
 Thu Feb 22 17:17:31 CET 2018 - schubi@suse.de
 
 - Added textdomain in order to activate translation (bnc#1081365).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.41
+Version:        4.0.42
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1073,7 +1073,7 @@ module Yast
       schemes = []
 
       # all enabled repositories
-      Pkg.SourceGetCurrent(true).map do |repo|
+      Pkg.SourceGetCurrent(true).each do |repo|
         url = Pkg.SourceURL(repo)
 
         begin

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -36,7 +36,8 @@ end
 
 PRODUCTS_FROM_ZYPP = load_zypp("products.yml").freeze
 
-describe Yast::Packages do
+describe "Yast::Packages" do
+  subject { Yast::Packages }
   before(:each) do
     log.info "--- test ---"
   end
@@ -1494,6 +1495,120 @@ describe Yast::Packages do
     context "installing from a DVD with an USB and a DVD addon" do
       let(:repos) { { 0 => volatile_repo, 1 => local_repo, 2 => volatile_repo } }
       it_behaves_like "sets priority", 0, 100
+    end
+  end
+
+  # helper for the #repo_schemes tests to mock the repository configuration
+  def expect_source_urls(mapping)
+    expect(Yast::Pkg).to receive(:SourceGetCurrent).with(true).and_return(mapping.keys)
+
+    mapping.each do |id, url|
+      expect(Yast::Pkg).to receive(:SourceURL).with(id).and_return(url)
+    end
+  end
+
+  describe "#repo_schemes" do
+    it "returns empty list if no repository is defined" do
+      expect_source_urls({})
+      expect(subject.repo_schemes).to eq([])
+    end
+
+    it "returns all used schemes" do
+      expect_source_urls(
+        0 => "http://example.com",
+        1 => "https://example.com",
+        2 => "ftp://example.com",
+        3 => "dir:///packages",
+        4 => "dvd:///"
+      )
+      expect(subject.repo_schemes).to eq(["http", "https", "ftp", "dir", "dvd"])
+    end
+
+    it "returns unique list" do
+      expect_source_urls(
+        0 => "http://example.com",
+        1 => "http://example2.com",
+        7 => "ftp://example.com",
+        8 => "ftp://example2.com"
+      )
+      expect(subject.repo_schemes).to eq(["http", "ftp"])
+    end
+
+    it "returns the scheme of the base URL for ISO scheme" do
+      expect_source_urls(
+        # ISO over NFS, see "man zypper"
+        0 => "iso:/subdir?iso=DVD1.iso&url=nfs://server/dir&mnt=/nfs&filesystem=udf"
+      )
+      expect(subject.repo_schemes).to eq(["nfs"])
+    end
+
+    it "converts the scheme names to lower case" do
+      expect_source_urls(
+        0 => "HTTP://example.com",
+        8 => "FTP://example2.com"
+      )
+      expect(subject.repo_schemes).to eq(["http", "ftp"])
+    end
+
+    it "ignores invalid URL" do
+      expect_source_urls(0 => ":")
+      expect(subject.repo_schemes).to eq([])
+    end
+
+    it "ignores incomplete ISO URL (missing 'url' parameter)" do
+      expect_source_urls(0 => "iso:/subdir?iso=DVD1.iso&mnt=/nfs&filesystem=udf")
+      expect(subject.repo_schemes).to eq([])
+    end
+
+    it "ignores incomplete ISO URL (empty 'url' parameter)" do
+      expect_source_urls(0 => "iso:/subdir?iso=DVD1.iso&url=&mnt=/nfs&filesystem=udf")
+      expect(subject.repo_schemes).to eq([])
+    end
+
+    it "ignores invalid ISO URL (invalid 'url' parameter)" do
+      expect_source_urls(
+        0 => "iso:/subdir?iso=DVD1.iso&url=:&filesystem=udf"
+      )
+      expect(subject.repo_schemes).to eq([])
+    end
+  end
+
+  describe "#sourceAccessPackages" do
+    it "returns empty list if no repository is defined" do
+      expect(subject).to receive(:repo_schemes).and_return([])
+      expect(subject.sourceAccessPackages).to eq([])
+    end
+
+    # these do not need any extra package to access them
+    it "returns empty list for http(s), ftp, hd, cd, dvd and dir schemes" do
+      schemes = ["http", "https", "ftp", "hd", "cd", "dvd", "dir"]
+      expect(subject).to receive(:repo_schemes).and_return(schemes)
+      expect(subject.sourceAccessPackages).to eq([])
+    end
+
+    it "returns 'nfs-client' for nfs scheme" do
+      schemes = ["nfs"]
+      expect(subject).to receive(:repo_schemes).and_return(schemes)
+      expect(subject.sourceAccessPackages).to eq(["nfs-client"])
+    end
+
+    it "returns 'cifs-mount' for smb scheme" do
+      schemes = ["smb"]
+      expect(subject).to receive(:repo_schemes).and_return(schemes)
+      expect(subject.sourceAccessPackages).to eq(["cifs-mount"])
+    end
+
+    it "returns 'cifs-mount' for cifs scheme" do
+      schemes = ["cifs"]
+      expect(subject).to receive(:repo_schemes).and_return(schemes)
+      expect(subject.sourceAccessPackages).to eq(["cifs-mount"])
+    end
+
+    it "returns 'cifs-mount' and 'nfs-client' for smb and nfs schemes" do
+      schemes = ["cifs", "nfs"]
+      expect(subject).to receive(:repo_schemes).and_return(schemes)
+      # sort the result to make it order independent
+      expect(subject.sourceAccessPackages.sort).to eq(["cifs-mount", "nfs-client"])
     end
   end
 end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1063980
- The `InstMode` value has been dropped from `install.inf`, not written by Linuxrc anymore
- Instead evaluate the repository URL
- Additionally evaluate also the add-on repositories, not just the base product repository
- Install e.g. `nfs-client` for `nfs://` repositories
- Properly evaluate the `iso://` repositories (the real URL is set in the `url` query parameter)
- 4.0.42