### PR TITLE
Missing textdomain, HA product merge

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 27 10:37:41 UTC 2018 - lslezak@suse.cz
+
+- Added product merge: SLE11/12 HA GEO has been merged to SLE15 HA
+  (bsc#1069705)
+
+-------------------------------------------------------------------
 Tue Feb 27 08:36:20 UTC 2018 - lslezak@suse.cz
 
 - Added Live Patching product rename (bsc#1074154)

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -5,6 +5,7 @@ Tue Feb 27 10:37:41 UTC 2018 - lslezak@suse.cz
   (bsc#1069705)
 - Added a missing textdomain in a file (bsc#1083015)
 - Unified text domains to "packager"
+- 4.0.44
 
 -------------------------------------------------------------------
 Tue Feb 27 08:36:20 UTC 2018 - lslezak@suse.cz

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,6 +3,8 @@ Tue Feb 27 10:37:41 UTC 2018 - lslezak@suse.cz
 
 - Added product merge: SLE11/12 HA GEO has been merged to SLE15 HA
   (bsc#1069705)
+- Added a missing textdomain in a file (bsc#1083015)
+- Unified text domains to "packager"
 
 -------------------------------------------------------------------
 Tue Feb 27 08:36:20 UTC 2018 - lslezak@suse.cz

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.43
+Version:        4.0.44
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_product_upgrade_license.rb
+++ b/src/lib/y2packager/clients/inst_product_upgrade_license.rb
@@ -29,7 +29,7 @@ module Y2Packager
     # @see Y2Packager::Clients::InstProductLicense
     class InstProductUpgradeLicense < InstProductLicense
       def main
-        textdomain "installation"
+        textdomain "packager"
 
         # do not display the license when going back, skip the dialog
         return :back if Yast::GetInstArgs.going_back

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -35,7 +35,7 @@ module Y2Packager
 
       # Client main method
       def main
-        textdomain "installation"
+        textdomain "packager"
 
         if !init_installation_repositories
           Yast::Popup.Error(

--- a/src/lib/y2packager/widgets/license_translations_button.rb
+++ b/src/lib/y2packager/widgets/license_translations_button.rb
@@ -24,6 +24,8 @@ module Y2Packager
 
       def initialize(product, language = nil)
         super()
+        textdomain "packager"
+
         @product = product
         @language = language || Yast::Language.language
       end

--- a/src/lib/y2packager/widgets/simple_language_selection.rb
+++ b/src/lib/y2packager/widgets/simple_language_selection.rb
@@ -37,7 +37,7 @@ module Y2Packager
       # @param languages [Array<String>] List of languages to display (en_US, de_DE, etc.)
       # @param default   [String]        Default language code
       def initialize(languages, default)
-        textdomain "y2packager"
+        textdomain "packager"
         @languages = languages
         @default = default
         self.widget_id = "simple_language_selection"

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -15,8 +15,12 @@ module Yast
       "SUSE_SLES"            => ["SLES"],
       # SLED or Workstation extension
       "SUSE_SLED"            => ["SLED", "sle-we"],
-      "sle-haegeo"           => ["sle-ha-geo"],
+      # SLE11 HA has been renamed since SLE12
       "sle-hae"              => ["sle-ha"],
+      # SLE11 HA GEO is now included in SLE15 HA
+      "sle-haegeo"           => ["sle-ha"],
+      # SLE12 HA GEO is now included in SLE15 HA
+      "sle-ha-geo"           => ["sle-ha"],
       "SUSE_SLES_SAP"        => ["SLES_SAP"],
       # SMT is now integrated into the base SLES
       "sle-smt"              => ["SLES"],

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -369,17 +369,35 @@ describe "Yast::Packages" do
     end
 
     it "returns updated product which has been renamed" do
-      products = [
-        { "name" => "sle-haegeo", "status" => :removed },
-        { "name" => "sle-ha-geo", "status" => :selected }
-      ]
+      hae = { "name" => "sle-hae", "status" => :removed }
+      ha = { "name" => "sle-ha", "status" => :selected }
+      products = [hae, ha]
 
       status = Yast::Packages.group_products_by_status(products)
 
-      expect(status[:updated].size).to eq(1)
-      old_product, new_product = status[:updated].first
-      expect(old_product["name"]).to eq("sle-haegeo")
-      expect(new_product["name"]).to eq("sle-ha-geo")
+      updates = status[:updated]
+      expect(updates.size).to eq(1)
+
+      # check the HAE => HA rename
+      expect(updates[hae]).to eq(ha)
+    end
+
+    it "returns updated products which have been merged" do
+      hae = { "name" => "sle-hae", "status" => :removed }
+      haegeo = { "name" => "sle-haegeo", "status" => :removed }
+      ha = { "name" => "sle-ha", "status" => :selected }
+      products = [hae, haegeo, ha]
+
+      status = Yast::Packages.group_products_by_status(products)
+
+      # product updates
+      updates = status[:updated]
+      expect(updates.size).to eq(2)
+
+      # check the HAE => HA rename
+      expect(updates[hae]).to eq(ha)
+      # check the HAE GEO => HA merge
+      expect(updates[haegeo]).to eq(ha)
     end
 
     it "handles mixed renamed and unchanged products" do


### PR DESCRIPTION
Two small fixes:

- SLE11/12 HA GEO products have been merged to the standard SLE15 HA (https://bugzilla.suse.com/show_bug.cgi?id=1069705)
- Fixed missing texdomain (https://bugzilla.suse.com/show_bug.cgi?id=1083015)
- Unified/merged textdomains to simple `packager`