### PR TITLE
Make the used ProductLicense methods public again (bsc#1084847)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 12 12:39:13 UTC 2018 - lslezak@suse.cz
+
+- Fixed crash when displaying license agreement in the registration
+  module (a private method called) (bsc#1084847)
+- 4.0.48
+
+-------------------------------------------------------------------
 Fri Mar  9 08:43:47 UTC 2018 - jreidinger@suse.com
 
 - Always allow next/back for adding new addon (bsc#1082286)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.47
+Version:        4.0.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1084847
- Some `ProductLicense` methods (`DisplayLicenseDialogWithTitle` and `HandleLicenseDialogRet`) have been changed to private methods. Unfortunately they are still in use by the `yast2-registration` module.
- This fix just moves the old methods back to the public API.

![eula_fixed](https://user-images.githubusercontent.com/907998/37284493-03c5f1de-25fc-11e8-9a38-57d1b5e87bfe.png)


## Test

Note: I tried using the existing public methods, but they do to allow setting a custom license location. They display the real location which in the case of SCC license does not make sense. It points to a temporary download location which is removed at the end. See the bottom of the screenshot.

A proper fix would require bigger refactoring which is quite risky in the RC phase, so just added `FIXME` for later.

![eula_test](https://user-images.githubusercontent.com/907998/37284467-ead4ef36-25fb-11e8-96f8-90dbc3fc9118.png)
