### PR TITLE
Do not use the obsolete scripts (part of bsc#1080979)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 15 12:35:23 UTC 2018 - lslezak@suse.cz
+
+- Cleanup, do not use the obsolete scripts which have been dropped
+  (part of bsc#1080979)
+- 4.0.49
+
+-------------------------------------------------------------------
 Mon Mar 12 12:39:13 UTC 2018 - lslezak@suse.cz
 
 - Fixed crash when displaying license agreement in the registration

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.48
+Version:        4.0.49
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -120,10 +120,6 @@ module Yast
         # backup some stuff
         backup_stuff
 
-        # remove some stuff
-        # do not remove when updating running system (#49608)
-        remove_stuff
-
         # set update mode to yes
         SCR.Write(
           path(".target.string"),
@@ -133,18 +129,6 @@ module Yast
         SCR.Execute(
           path(".target.remove"),
           Ops.add(Installation.destdir, "/var/lib/YaST/update.inf")
-        )
-
-        # check passwd and group of target
-        SCR.Execute(
-          path(".target.bash"),
-          Ops.add(
-            Ops.add(
-              "/usr/lib/YaST2/bin/update_users_groups " + "'",
-              String.Quote(Installation.destdir)
-            ),
-            "'"
-          )
         )
 
         # create /etc/mdadm.conf if it does not exist
@@ -160,31 +144,6 @@ module Yast
       end
 
       :next
-    end
-
-    #  Remove some old junk.
-    def remove_stuff
-      # remove old junk, script is in yast2-update
-      SCR.Execute(
-        path(".target.bash"),
-        Ops.add(
-          Ops.add(
-            Ops.add(Ops.add(Directory.ybindir, "/remove_junk "), "'"),
-            String.Quote(Installation.destdir)
-          ),
-          "'"
-        )
-      )
-
-      # possibly remove /usr/share/info/dir
-      if !Pkg.TargetFileHasOwner("/usr/share/info/dir")
-        SCR.Execute(
-          path(".target.remove"),
-          Ops.add(Installation.destdir, "/usr/share/info/dir")
-        )
-      end
-
-      nil
     end
 
     #  Handle the backup.


### PR DESCRIPTION
- This is related to https://github.com/yast/yast-update/pull/95
  - The `update_users_groups` and `remove_junk` scripts have been removed (not needed anymore)
  - The `/usr/share/info/dir` file has an owner in SLE12-SP3:
    ``` console
    # rpm -qf /usr/share/info/dir
    info-4.13a-37.229.x86_64
    ```
    and also in SLE11-SP4:
    ``` console
    # rpm -qf /usr/share/info/dir
    info-4.12-1.86
    ```
    So this also looks like a very old hack which we can remove...
- 4.0.49