### PR TITLE
SLES-12 + HPC module can be upgraded to SLES_HPC-15 (bsc#1086734)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 26 12:17:52 UTC 2018 - lslezak@suse.cz
+
+- SLES-12 + HPC module can be upgraded to SLES_HPC-15, display
+  correctly this product change in the migration selection and the
+  upgrade summary dialog (bsc#1086734)
+- 4.0.50
+
+-------------------------------------------------------------------
 Thu Mar 15 12:35:23 UTC 2018 - lslezak@suse.cz
 
 - Cleanup, do not use the obsolete scripts which have been dropped

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.49
+Version:        4.0.50
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -22,6 +22,8 @@ module Yast
       # SLE12 HA GEO is now included in SLE15 HA
       "sle-ha-geo"           => ["sle-ha"],
       "SUSE_SLES_SAP"        => ["SLES_SAP"],
+      # SLES-12 with HPC module can be replaced by SLES_HPC-15
+      "SLES"                 => ["SLES_HPC"],
       # SMT is now integrated into the base SLES
       "sle-smt"              => ["SLES"],
       # Live patching is a module now (bsc#1074154)


### PR DESCRIPTION
- Display correctly this product change in the migration selection and the upgrade summary dialog.
- 4.0.50

## Screenshots

#### The Original Proposal

The original proposal contained an invalid note about the original SLES12-SP3 product (see the last item in the list):

![hpc_migration_proposal1](https://user-images.githubusercontent.com/907998/37907909-bbcfc2b8-3106-11e8-892f-32a0bf7626a2.png)


#### New Proposal

Now the SLES12-SP3 is correctly described as upgraded to SLES_HPC-15:

![hpc_migration_proposal2](https://user-images.githubusercontent.com/907998/37907943-cabc2dfc-3106-11e8-8c2a-68f0711f6d40.png)
