### PR TITLE
Added a known upgrade from SLE-HPC to SLES_HPC (bsc#1086734)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 27 07:14:16 UTC 2018 - lslezak@suse.cz
+
+- Added a known upgrade from SLE-HPC to SLES_HPC (bsc#1086734)
+- 4.0.51
+
+-------------------------------------------------------------------
 Mon Mar 26 12:17:52 UTC 2018 - lslezak@suse.cz
 
 - SLES-12 + HPC module can be upgraded to SLES_HPC-15, display

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.50
+Version:        4.0.51
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -24,6 +24,8 @@ module Yast
       "SUSE_SLES_SAP"        => ["SLES_SAP"],
       # SLES-12 with HPC module can be replaced by SLES_HPC-15
       "SLES"                 => ["SLES_HPC"],
+      # this is an internal product so far...
+      "SLE-HPC"              => ["SLES_HPC"],
       # SMT is now integrated into the base SLES
       "sle-smt"              => ["SLES"],
       # Live patching is a module now (bsc#1074154)


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1086734#c9 for more details
- Travis fails because of an issue in the storage part, @joseivanlopez is fixing that, ignore it for now
- 4.0.51