### PR TITLE
Product merge (AdvMgmt -> Basesystem) (related to bsc#1089477)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Apr 16 13:46:16 UTC 2018 - lslezak@suse.cz
+
+- The Advanced Systems Management Module has been moved to the
+  Basesystem module, added the product change into the list
+  (related to bsc#1089477)
+- 4.0.57
+
+-------------------------------------------------------------------
 Tue Apr 10 16:21:29 CEST 2018 - schubi@suse.de
 
 - Error: Add-On products has been reset during the installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.56
+Version:        4.0.57
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -12,27 +12,29 @@ module Yast
     # @return [Hash] Product renames default map. Used when information is not
     #                found elsewhere.
     DEFAULT_PRODUCT_RENAMES = {
-      "SUSE_SLES"            => ["SLES"],
+      "SUSE_SLES"                         => ["SLES"],
       # SLED or Workstation extension
-      "SUSE_SLED"            => ["SLED", "sle-we"],
+      "SUSE_SLED"                         => ["SLED", "sle-we"],
       # SLE11 HA has been renamed since SLE12
-      "sle-hae"              => ["sle-ha"],
+      "sle-hae"                           => ["sle-ha"],
       # SLE11 HA GEO is now included in SLE15 HA
-      "sle-haegeo"           => ["sle-ha"],
+      "sle-haegeo"                        => ["sle-ha"],
       # SLE12 HA GEO is now included in SLE15 HA
-      "sle-ha-geo"           => ["sle-ha"],
-      "SUSE_SLES_SAP"        => ["SLES_SAP"],
+      "sle-ha-geo"                        => ["sle-ha"],
+      "SUSE_SLES_SAP"                     => ["SLES_SAP"],
       # SLES-12 with HPC module can be replaced by SLES_HPC-15
-      "SLES"                 => ["SLES_HPC"],
+      "SLES"                              => ["SLES_HPC"],
       # this is an internal product so far...
-      "SLE-HPC"              => ["SLES_HPC"],
+      "SLE-HPC"                           => ["SLES_HPC"],
       # SMT is now integrated into the base SLES
-      "sle-smt"              => ["SLES"],
+      "sle-smt"                           => ["SLES"],
       # Live patching is a module now (bsc#1074154)
-      "sle-live-patching"    => ["sle-module-live-patching"],
+      "sle-live-patching"                 => ["sle-module-live-patching"],
+      # The Advanced Systems Management Module has been moved to the Basesystem module
+      "sle-module-adv-systems-management" => ["sle-module-basesystem"],
       # Toolchain and SDK are now included in the Development Tools SLE15 module
-      "sle-module-toolchain" => ["sle-module-development-tools"],
-      "sle-sdk"              => ["sle-module-development-tools"]
+      "sle-module-toolchain"              => ["sle-module-development-tools"],
+      "sle-sdk"                           => ["sle-module-development-tools"]
     }.freeze
 
     # @return [Hash] Product renames added externally through the #add_rename method


### PR DESCRIPTION
- The Advanced Systems Management Module has been moved to the Basesystem module. (see https://bugzilla.suse.com/show_bug.cgi?id=1089477)
- 4.0.57

Note: The change caused reformatting the hash with products and the diff is more difficult to read, it's better to review the diff with [ignoring white space changes here](https://github.com/yast/yast-packager/pull/344/files?w=1).

## Screenshots

Before patching the Advanced Systems Management Module was marked as unchanged and potentially problematic: 
![advmgmt_migration](https://user-images.githubusercontent.com/907998/38813034-276a508c-418e-11e8-889b-33668c0b3218.png)

With the fix the product is correctly reported as replaced by the Basesystem Module:
![advmgmt_migration_fix](https://user-images.githubusercontent.com/907998/38813044-2d909868-418e-11e8-9c10-4d0977226d2a.png)

