### PR TITLE
AutoYaST: skip product license dialog when it was already accepted

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 16 16:48:14 UTC 2018 - igonzalezsosa@suse.com
+
+- In AutoYaST, skip base product license dialog when the same
+  license was already accepted (fate#325461).
+- 4.0.58
+
+-------------------------------------------------------------------
 Mon Apr 16 13:46:16 UTC 2018 - lslezak@suse.cz
 
 - The Advanced Systems Management Module has been moved to the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.57
+Version:        4.0.58
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -23,12 +23,14 @@ describe Y2Packager::Clients::InstProductLicense do
   let(:confirmation_required?) { true }
   let(:license_confirmed?) { false }
   let(:language) { double("Yast::Language", language: "en_US") }
+  let(:auto) { false }
 
   before do
     allow(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
       .and_return(dialog)
     allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
     allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
+    allow(Yast::Mode).to receive(:auto).and_return(auto)
     stub_const("Yast::Language", language)
   end
 
@@ -81,14 +83,6 @@ describe Y2Packager::Clients::InstProductLicense do
       end
     end
 
-    context "when only one base product is found" do
-      let(:products) { [product] }
-
-      it "returns :auto" do
-        expect(client.main).to eq(:auto)
-      end
-    end
-
     context "when no license is found for the selected base product" do
       let(:license?) { false }
 
@@ -98,8 +92,60 @@ describe Y2Packager::Clients::InstProductLicense do
         client.main
       end
 
-      it "returns :auto" do
-        expect(client.main).to eq(:auto)
+      context "and running during normal installation" do
+        let(:auto) { false }
+
+        it "returns :auto" do
+          expect(client.main).to eq(:auto)
+        end
+      end
+
+      context "and running during autoinstallation" do
+        let(:auto) { true }
+
+        it "returns :next" do
+          expect(client.main).to eq(:next)
+        end
+      end
+    end
+
+    context "during normal installation" do
+      let(:auto) { false }
+
+      context "when only one base product is found" do
+        let(:products) { [product] }
+
+        it "returns :auto" do
+          expect(client.main).to eq(:auto)
+        end
+      end
+
+      context "when more than one product is found" do
+        it "opens the license dialog" do
+          expect(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
+          client.main
+        end
+      end
+    end
+
+    context "during autoinstallation" do
+      let(:auto) { true }
+
+      context "when the license has been accepted" do
+        let(:license_confirmed?) { true }
+
+        it "returns :next" do
+          expect(client.main).to eq(:next)
+        end
+      end
+
+      context "when the license has not been accepted" do
+        let(:license_confirmed?) { false }
+
+        it "opens the license dialog" do
+          expect(Y2Packager::Dialogs::InstProductLicense).to receive(:new)
+          client.main
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes a corner case of fate#325461 when `confirm_base_product_license`
is set to `true` in AutoYaST. The problem is that, in AutoYaST, you get base product licenses *after* add-on ones and the `inst_product_license` client was not working in those situations.