### PR TITLE
Warning msg for a repo that belongs to a service (bsc#1078323)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 13 08:26:41 UTC 2018 - gsouza@suse.com
+
+- Added warning to inform the user that changes in a  repository
+  managed by a service will be lost in the next refresh of the
+  service (bsc#1078323).
+- 3.2.26
+
+-------------------------------------------------------------------
 Thu Jul 27 11:12:01 CEST 2017 - schubi@suse.de
 
 - AutoYaST: Configuring EULA acceptance of add-on products has

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri Apr 13 08:26:41 UTC 2018 - gsouza@suse.com
 
-- Added warning to inform the user that changes in a  repository
+- Added warning to inform the user that changes in a repository
   managed by a service will be lost in the next refresh of the
   service (bsc#1078323).
 - 3.2.26

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.25
+Version:        3.2.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -1661,6 +1661,7 @@ module Yast
       repo = @sourceStatesOut[global_current] || {}
       return if !repo["service"].to_s.empty? && !plugin_service_check(repo["service"], repo_change_msg)
 
+      warn_service_repository(sourceState)
       state = !sourceState["enabled"]
       # corresponds to the "Enable/Disable" button
       state_symbol = state ? UI.Glyph(:CheckMark) : ""
@@ -1701,6 +1702,8 @@ module Yast
       source_id = sourceState["SrcId"]
       src_data = Pkg.SourceGeneralData(source_id)
       return if !plugin_service_check(sourceState["service"], repo_change_msg)
+
+      warn_service_repository(sourceState)
 
       type = src_data["type"]
       state = !sourceState["autorefresh"]
@@ -1763,6 +1766,8 @@ module Yast
     # @param [Integer] global_current index of the repository in the @sourceStatesOut
     def repo_keeppackages_handler(sourceState, global_current)
       return if !plugin_service_check(sourceState["service"], repo_change_msg)
+
+      warn_service_repository(sourceState)
 
       # refresh the value in the table
       new_keep = UI.QueryWidget(Id(:keeppackages), :Value)
@@ -1922,6 +1927,8 @@ module Yast
 
           new_name = SourceDialogs.GetRepoName
           if new_name != Ops.get_string(sourceState, "name", "")
+            warn_service_repository(sourceState)
+
             Ops.set(sourceState, "name", new_name)
             Ops.set(@sourceStatesOut, global_current, sourceState)
 
@@ -2062,7 +2069,7 @@ module Yast
     # @param [Hash] sourceState the current state of the repository or service
     def warn_service_repository(source_state)
       msg = _("Repository '%{name}' is managed by service '%{service}'.\n"\
-        "Your manual changes will be reset by the next service refresh!") % {name: source_state["name"],
+        "Your manual changes might be reset by the next service refresh!") % {name: source_state["name"],
         service: source_state["service"]}
       if source_state["service"] != "" && !@services_repos.include?(source_state["SrcId"])
         Popup.Warning(msg)

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -2061,7 +2061,7 @@ module Yast
     # Shows a warning message when repository managed by a service
     # @param [Hash] sourceState the current state of the repository or service
     def warn_service_repository(source_state)
-      msg = _("Repo %{name} is managed by service %{service}.\n"\
+      msg = _("Repository '%{name}' is managed by service '%{service}'.\n"\
         "Your manual changes will be reset by the next service refresh!") % {name: source_state["name"],
         service: source_state["service"]}
       if source_state["service"] != "" && !@services_repos.include?(source_state["SrcId"])

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -20,10 +20,9 @@ module Yast
     NO_SERVICE = :no_service
     NO_SERVICE_ITEM = :no_service_item
 
-    def main
+    def import_modules
       Yast.import "Pkg"
       Yast.import "UI"
-      textdomain "packager"
 
       Yast.import "Confirm"
       Yast.import "Mode"
@@ -47,12 +46,15 @@ module Yast
       Yast.include self, "packager/inst_source_dialogs.rb"
       Yast.include self, "packager/key_manager_dialogs.rb"
       Yast.include self, "packager/repositories_include.rb"
+    end
+
+    def initialize
+      textdomain "packager"
 
       @full_mode = false
 
       # cache for textmode value
       @text_mode = nil
-
 
       @sourcesToDelete = []
       @reposFromDeletedServices = []
@@ -88,6 +90,10 @@ module Yast
       # list of repositories that was already informed to the user that they are
       # managed by service
       @services_repos = []
+    end
+
+    def main
+      import_modules
 
       if WFM.Args == [:sw_single_mode]
         Builtins.y2milestone("Started from sw_single, switching the mode")

--- a/test/lib/clients/repositories_test.rb
+++ b/test/lib/clients/repositories_test.rb
@@ -52,7 +52,7 @@ describe Yast::RepositoriesClient do
       let(:source_state) { { "name" => "repo", "service" => "some-service", "SrcId" => "1" } }
 
       it "shows a warning message only once" do
-        expect(Yast::Popup).to receive(:Warning).once
+        expect(Yast::Popup).to receive(:Warning).with(/manual changes will be reset/).once
         client.warn_service_repository(source_state)
         client.warn_service_repository(source_state)
       end

--- a/test/lib/clients/repositories_test.rb
+++ b/test/lib/clients/repositories_test.rb
@@ -48,15 +48,10 @@ describe Yast::RepositoriesClient do
   end
 
   describe "#warn_service_repository" do
-
-    before do
-      client.main
-    end
-
     context "when the repository is managed by a service" do
       let(:source_state) { { "name" => "repo", "service" => "some-service", "SrcId" => "1" } }
 
-      it "shows an warning message once" do
+      it "shows a warning message only once" do
         expect(Yast::Popup).to receive(:Warning).once
         client.warn_service_repository(source_state)
         client.warn_service_repository(source_state)

--- a/test/lib/clients/repositories_test.rb
+++ b/test/lib/clients/repositories_test.rb
@@ -52,7 +52,7 @@ describe Yast::RepositoriesClient do
       let(:source_state) { { "name" => "repo", "service" => "some-service", "SrcId" => "1" } }
 
       it "shows a warning message only once" do
-        expect(Yast::Popup).to receive(:Warning).with(/manual changes will be reset/).once
+        expect(Yast::Popup).to receive(:Warning).with(/manual changes might be reset/).once
         client.warn_service_repository(source_state)
         client.warn_service_repository(source_state)
       end

--- a/test/lib/clients/repositories_test.rb
+++ b/test/lib/clients/repositories_test.rb
@@ -46,4 +46,30 @@ describe Yast::RepositoriesClient do
       end
     end
   end
+
+  describe "#warn_service_repository" do
+
+    before do
+      client.main
+    end
+
+    context "when the repository is managed by a service" do
+      let(:source_state) { { "name" => "repo", "service" => "some-service", "SrcId" => "1" } }
+
+      it "shows an warning message once" do
+        expect(Yast::Popup).to receive(:Warning).once
+        client.warn_service_repository(source_state)
+        client.warn_service_repository(source_state)
+      end
+    end
+
+    context "when the repository is not managed by a service" do
+      let(:source_state) { { "name" => "repo", "service" => "", "SrcId" => "1" } }
+
+      it "shows no warning message" do
+        expect(Yast::Popup).to_not receive(:Warning)
+        client.warn_service_repository(source_state)
+      end
+    end
+  end
 end

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -26,7 +26,7 @@ describe "PackagerRepositoriesIncludeInclude" do
         expect(RepositoryIncludeTester.autorefresh_for?(url)).to eq(true)
       end
     end
-    
+
     it "handles uppercase URLs correctly" do
       expect(RepositoryIncludeTester.autorefresh_for?("FTP://FOO/BAR")).to eq(true)
       expect(RepositoryIncludeTester.autorefresh_for?("DVD://FOO/BAR")).to eq(false)


### PR DESCRIPTION
[Trello Card](https://trello.com/c/jvHFPZ2k/1376-3-warn-when-priority-name-of-a-repository-that-is-managed-by-a-service-is-changed)
https://bugzilla.suse.com/show_bug.cgi?id=1078323

This just replaced #343 making Travis happy again and basically because #342 was against SP2.

![warning_repo_service](https://user-images.githubusercontent.com/536990/38665096-d2c9887c-3e3b-11e8-8b6d-6a694848077b.png)