### PR TITLE
Updated /dev cleanup at upgrade (bsc#1089643)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  3 14:02:55 UTC 2018 - lslezak@suse.cz
+
+- Adapted /dev cleanup at upgrade to work properly with the
+  registration rollback (bsc#1089643)
+- 4.0.61
+
+-------------------------------------------------------------------
 Tue Apr 24 19:49:40 UTC 2018 - igonzalezsosa@suse.com
 
 - Fix text direction for RTL languages in software patterns list

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.60
+Version:        4.0.61
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -51,7 +51,9 @@ module Yast
           # Mount (bind) the current /dev/ to the /installed_system/dev/
           LocalCommand(
             Builtins.sformat(
-              "/bin/rm -rf '%1/dev/' && /bin/mkdir -p '%1/dev/' && " \
+              # try unmounting the /mnt/dev directory before the cleanup, usually there
+              # is a bind mount /dev -> /mnt/dev which would remove the files also from /dev
+              "/usr/bin/umount '%1/dev/'; /bin/rm -rf '%1/dev/' && /bin/mkdir -p '%1/dev/' && " \
                 "/bin/mount -v --bind '/dev/' '%1/dev/'",
               String.Quote(Installation.destdir)
             )


### PR DESCRIPTION
- Updated `/dev` cleanup at upgrade to work properly with the registration rollback
- Try unmounting the `/mnt/dev` directory before the cleanup
- For rollback we need `/mnt/dev` which is being mounted in https://github.com/yast/yast-update/pull/97
- 4.0.61