### PR TITLE
Fixed argument handling in the yast2-packager.desktop file (bsc#1087352)

### DIFF
--- a/desktop/yast2-packager.desktop
+++ b/desktop/yast2-packager.desktop
@@ -2,7 +2,10 @@
 Encoding=UTF-8
 Name=Install/Remove Software
 GenericName=Install/Remove Software
-Exec=xdg-su -c "/sbin/yast2 sw_single %F"
+# we cannot use xdg-su -c "/sbin/yast2 sw_single %F"
+# directly here as %F must not be used inside a quoted argument
+# see https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
+Exec=/usr/lib/YaST2/bin/sw_single_wrapper %F
 Icon=yast-sw_single
 Terminal=false
 Type=Application

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed May 16 11:35:45 UTC 2018 - lslezak@suse.cz
+
+- Fixed argument handling in the .desktop file for the
+  "Install/Remove Software" item (bsc#1087352)
+- Properly process paths containing spaces or special shell
+  characters
+- 4.0.62
+
+-------------------------------------------------------------------
 Thu May  3 14:02:55 UTC 2018 - lslezak@suse.cz
 
 - Adapted /dev cleanup at upgrade to work properly with the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.61
+Version:        4.0.62
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -134,6 +134,8 @@ rake install DESTDIR="%{buildroot}"
 %dir %{yast_libdir}/packager
 %dir %{yast_libdir}/packager/cfa
 %dir %{yast_libdir}/y2packager
+%dir %{yast_ybindir}
+%{yast_ybindir}/*
 %{yast_yncludedir}/checkmedia/*
 %{yast_yncludedir}/packager/*
 %{yast_libdir}/packager/*

--- a/src/bin/sw_single_wrapper
+++ b/src/bin/sw_single_wrapper
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+# This is a small wrapper around "yast2 sw_single"
+# which quotes all arguments before passing them
+# to xdg-su (to properly process file names contaning
+# spaces or special shell characters like quotes, ampersand...)
+
+$ARGS=""
+for ARG in "$@"
+do
+    QUOTED_ARG=`printf %q "$ARG"`
+    ARGS="$ARGS $QUOTED_ARG"
+done
+
+xdg-su -c "/sbin/yast2 sw_single $ARGS"
+


### PR DESCRIPTION
- Fixed argument handling in the .desktop file for the "Install/Remove Software" item
- See https://bugzilla.suse.com/show_bug.cgi?id=1087352
- Properly process paths containing spaces or special shell characters
- Tested manually in Leap 15 with LXDE (the `%F` was not expanded there)
- Tested manually with an RPM package in `test test` directory (note the space in the middle !)
- 4.0.62