### PR TITLE
Display an error when the "fips" pattern is not available (bsc#1093060)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 17 10:51:58 UTC 2018 - lslezak@suse.cz
+
+- Display an error popup when the FIPS compliant mode is active
+  and the "fips" pattern is not available (installing an
+  unregistered system or without the Packages DVD) (bsc#1093060)
+- 4.0.63
+
+-------------------------------------------------------------------
 Wed May 16 11:35:45 UTC 2018 - lslezak@suse.cz
 
 - Fixed argument handling in the .desktop file for the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.62
+Version:        4.0.63
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- The "fips" pattern is included in a separate SLE15 module and might not be available in all cases. We should display an error if it is missing otherwise the installation will crash.
- 4.0.63

## Changed the FIPS Mode Detection

The openSUSE Leap 15 does not support the FIPS compliant mode and it does not provide the "fips" pattern. That means the popup should be skipped in openSUSE (using `fips=1` is irrelevant there, it does not change anything). The popup should be displayed only in SLES or the other products which support the FIPS mode.

I found out:

- If the kernel does not support the FIPS mode the file `/proc/sys/crypto/fips_enabled` does not exist (openSUSE)
- If the kernel supports the FIPS mode the file `/proc/sys/crypto/fips_enabled` exists (SLES)
  - If the FIPS mode is not active (the default) `0\n` is read
  - If the FIPS mode is active (used `fips=1` boot option) `1\n` is read

Which means we should not test the presence of the `fips=1` boot option but rather check the kernel status.

## Screenshots

![missing_fips_pattern](https://user-images.githubusercontent.com/907998/40179327-59b4cd4c-59e4-11e8-8ac6-8156023b68f3.png)

![missing_fips_pattern_textmode](https://user-images.githubusercontent.com/907998/40179330-5e09fd5e-59e4-11e8-94d0-b8b1877b040a.png)

# Tested Scenarios

- SLES-15
  - `fips=1`, minimal system => popup displayed
  - `fips=1`, minimal system in text mode => popup displayed properly also in the text mode
  - `fips=1`, Server Applications module added (from the Packages DVD) => popup not displayed, the FIPS pattern selected
  - without `fips=1` boot option, minimal system => popup not displayed
- openSUSE Leap 15
  - `fips=1`, minimal system => popup not displayed
  - `fips=1`, default system => popup not displayed
  - without `fips=1`, minimal system => popup not displayed
  - without `fips=1`, default system => popup not displayed