### PR TITLE
Fix licenses display in textmode for extensions/modules/add-ons

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May 29 22:47:39 UTC 2018 - igonzalezsosa@suse.com
+
+- When running the installation in textmode, consider only the
+  preselected language when showing the license for extensions,
+  modules or add-ons (related to bsc#1094793).
+- 4.0.67
+
+-------------------------------------------------------------------
 Tue May 29 15:11:39 UTC 2018 - knut.anderssen@suse.com
 
 - During an upgrade, skip the base produce license dialog when the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.66
+Version:        4.0.67
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -675,8 +675,8 @@ module Yast
 
       # For some languages (like Japanese, Chinese or Korean) YaST needs to use a fbiterm in order
       # to display symbols correctly when running on textmode. To avoid such problems, consider only
-      # the preselected (on installation) or the default language (on running system). See
-      # bsc#1094793 for further information.
+      # the preselected (on installation) or the default language (on running system). This will
+      # setup fbiterm correctly. See bsc#1094793 for further information.
       if Yast::UI.TextMode
         lang = default_language
         candidate_languages = [lang, lang[0..1]] + DEFAULT_FALLBACK_LANGUAGES

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1710,7 +1710,7 @@ module Yast
         log.info("License locales for product #{product_name.inspect}: #{locales.inspect}")
 
         locales.each do |locale|
-          license_locale = Yast::UI.TextMode ? default_language : locale
+          license_locale = (Yast::UI.TextMode && locale.empty?) ? default_language : locale
           license = Pkg.PrdGetLicenseToConfirm(product_name, license_locale)
           next if license.nil? || license.empty?
 

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -64,7 +64,7 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
           widget.contents
         end
 
-        context "when there is not translation for the preselected language" do
+        context "when there is no translation for the preselected language" do
           let(:preselected) { "hu_HU" }
 
           it "the language selector includes only 'english'" do


### PR DESCRIPTION
Similar to #355 but for add-ons.