### PR TITLE
Fixed free space overflow for disks > 8EiB (bsc#991090)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Mon Jul 16 11:19:03 UTC 2018 - lslezak@suse.cz
+
+- Do not display a false "not enough free space" warning popup if
+  the free space is bigger than 8EiB (2^63) (bsc#991090)
+- Do not display the "not enough free space" warning for partitions
+  where nothing is going to be installed (bsc#926841)
+- Back ported disk usage fix - check the parent directory if the
+  target directory does not exist (yet) (bsc#1073696)
+- 3.2.27
+
+-------------------------------------------------------------------
 Fri Apr 13 08:26:41 UTC 2018 - gsouza@suse.com
 
 - Added warning to inform the user that changes in a repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.26
+Version:        3.2.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -337,6 +337,7 @@ module Yast
             end
 
             target_dir = Ops.add(Installation.destdir, part)
+            # the current free space (in bytes)
             disk_available = Pkg.TargetAvailable(target_dir)
             Builtins.y2debug(
               "partition: %1 (%2), available: %3",
@@ -350,7 +351,8 @@ module Yast
               next
             end
 
-            if disk_available < required_space
+            # we need to convert the size to KiB to compare it with the libzypp size
+            if (disk_available / 1024) < required_space
               Builtins.y2warning(
                 "Not enough free space in %1 (%2): available: %3, required: %4",
                 part,
@@ -377,7 +379,8 @@ module Yast
           end
         else
           # disk usage for each partition is not known
-          # assume that all files will be installed into the root directory
+          # assume that all files will be installed into the root directory,
+          # this is the current free space (in bytes)
           disk_available = Pkg.TargetAvailable(Installation.destdir)
 
           Builtins.y2milestone(

--- a/test/slide_show_callabacks_test.rb
+++ b/test/slide_show_callabacks_test.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "SlideShowCallbacks"
+
+describe Yast::SlideShowCallbacksClass do
+  subject { Yast::SlideShowCallbacksClass.new }
+
+  describe "#DisplayStartInstall" do
+    let(:pkg_name) { "libyui-ncurses-pkg-devel" }
+    let(:pkg_location) { "pkg_location" }
+    let(:pkg_description) { "pkg_description" }
+    let(:pkg_size) { 138510 }
+    let(:deleting) { false }
+    
+    before do
+      allow(Yast::PackageSlideShow).to receive(:SlideDisplayStart)
+      allow(subject).to receive(:HandleInput)
+      allow(Yast::Installation).to receive(:destdir).and_return("/")
+      allow(File).to receive(:exist?).and_return(true)
+      allow(Yast::SlideShow).to receive(:SetUserAbort)
+      
+      subject.instance_variable_set(:@ask_again, true)
+      subject.instance_variable_set(:@pkg_inprogress, pkg_name)
+    end
+
+    RSpec.shared_examples "free space check" do
+      it "does not display the space warning when free space is >8EiB" do
+        # sizes > 8EiB are returned as negative numbers (data overflow)
+        expect(Yast::Pkg).to receive(:TargetAvailable).and_return(-42)
+        expect(subject).to_not receive(:YesNoAgainWarning)
+        
+        subject.DisplayStartInstall(pkg_name, pkg_location, pkg_description, pkg_size, deleting)
+      end
+
+      it "does not display the space warning when free space is enough" do
+        # 1MiB free space
+        expect(Yast::Pkg).to receive(:TargetAvailable).and_return(1 << 20)
+        expect(subject).to_not receive(:YesNoAgainWarning)
+        
+        subject.DisplayStartInstall(pkg_name, pkg_location, pkg_description, pkg_size, deleting)
+      end
+
+      it "displays the space warning when free space is not enough" do
+        # 64KiB free space
+        expect(Yast::Pkg).to receive(:TargetAvailable).and_return(1 << 16)
+        expect(subject).to receive(:YesNoAgainWarning)
+        
+        subject.DisplayStartInstall(pkg_name, pkg_location, pkg_description, pkg_size, deleting)
+      end
+    end
+
+    context "package data usage is available" do
+      before do
+        expect(Yast::Pkg).to receive(:PkgDU).with(pkg_name).and_return(
+          # required space 230KiB
+          "/" => [6854656, 4483116, 4483346, 0]
+        )
+      end
+
+      include_examples "free space check"
+    end
+
+    context "package data usage is not available" do
+      before do
+        expect(Yast::Pkg).to receive(:PkgDU).with(pkg_name).and_return(nil)
+      end
+
+      include_examples "free space check"
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug where a "not enough free space" popup is displayed for disks where the free space is bigger than 8EiB (2<sup>63</sup>). The problem is that `YCPInteger` internally uses signed 64-bit `long long` and numbers bigger than 2<sup>63</sup> become negative.

See [bug#1073696](https://bugzilla.suse.com/show_bug.cgi?id=991090) for more details.

![not_enough_space](https://user-images.githubusercontent.com/907998/42757382-21678b1e-8900-11e8-8f2c-1ed3085c0e4d.png)

So if we get a negative free space then we skip the check, more than 8EiB free space should be always enough so far. :smile: 

## Note

The sizes reported by libzypp are in KiB, that means the libzypp API can support sizes >8EiB without causing data overflow (the limit is 8ZiB). The problem is with the `Pkg.TargetAvailable` call which returns the size in bytes and is affected by the `YCPInteger` limit.

## Additional Fixes

- The "not enough free space" warning is now skipped when there is nothing to install to that partition. Originally the code complained even for full data partitions where nothing was going to install. See [bug#926841](https://bugzilla.suse.com/show_bug.cgi?id=926841).
- When comparing the code with `master` I found yet another fix which is worth of backporting to SP3  (and SP4) - that's the check for non-existing directories. See [bug#1073696](https://bugzilla.suse.com/show_bug.cgi?id=1073696) an PR #307.