### PR TITLE
SP3 Version fix

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -7,7 +7,7 @@ Mon Jul 16 11:19:03 UTC 2018 - lslezak@suse.cz
   where nothing is going to be installed (bsc#926841)
 - Back ported disk usage fix - check the parent directory if the
   target directory does not exist (yet) (bsc#1073696)
-- 3.2.27
+- 3.2.26.1
 
 -------------------------------------------------------------------
 Fri Apr 13 08:26:41 UTC 2018 - gsouza@suse.com

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.27
+Version:        3.2.26.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The version 3.2.27 is already used in SP4, we need to use a fourth number for a SP3 maintenance update.