### PR TITLE
allow hard disks with file systems to be selected in add-on dialog (bsc#1003263)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 31 14:03:43 UTC 2018 - snwint@suse.com
+
+- allow hard disks with file systems to be selected in add-on dialog (bsc#1003263)
+- 4.1.3
+
+-------------------------------------------------------------------
 Wed Aug 22 14:14:44 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -1076,13 +1076,16 @@ module Yast
     end
 
     def DetectPartitions(disk_id)
+      # this kills things like /dev/fd0 (that don't have a disk_id)
+      return [ ] if disk_id.empty?
+
       command = Builtins.sformat("ls %1-part*", disk_id)
 
       out = Convert.to_map(SCR.Execute(path(".target.bash_output"), command))
 
       if Ops.get_integer(out, "exit", -1).nonzero?
-        Builtins.y2error("Command %1 failed", command)
-        return []
+        Builtins.y2milestone("no partitions on %1, using full disk", disk_id)
+        return [ disk_id ]
       end
 
       ret = Builtins.splitstring(Ops.get_string(out, "stdout", ""), "\n")
@@ -1173,7 +1176,7 @@ module Yast
         dev = Ops.get_string(disk, "dev", "")
         Builtins.foreach(Ops.get_list(disk, "partitions", [])) do |part|
           partnum = Builtins.regexpsub(part, ".*-part([0-9]*)$", "\\1")
-          disk_label = Ops.add(label, Builtins.sformat(" (%1%2)", dev, partnum))
+          disk_label = "#{label} (#{dev}#{partnum})"
           found ||= part == selected
           ret = Builtins.add(ret, Item(Id(part), disk_label, part == selected))
         end

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -1077,7 +1077,7 @@ module Yast
 
     def DetectPartitions(disk_id)
       # this kills things like /dev/fd0 (that don't have a disk_id)
-      return [ ] if disk_id.empty?
+      return [] if disk_id.empty?
 
       command = Builtins.sformat("ls %1-part*", disk_id)
 
@@ -1085,7 +1085,7 @@ module Yast
 
       if Ops.get_integer(out, "exit", -1).nonzero?
         Builtins.y2milestone("no partitions on %1, using full disk", disk_id)
-        return [ disk_id ]
+        return [disk_id]
       end
 
       ret = Builtins.splitstring(Ops.get_string(out, "stdout", ""), "\n")


### PR DESCRIPTION
That is, disks without partition table.

This is the same as https://github.com/yast/yast-packager/pull/371.