### PR TITLE
Added nil service check (bsc#1106837)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  3 12:18:14 UTC 2018 - lslezak@suse.cz
+
+- Fixed service check for the newly added repositories in the
+  repository manager (bsc#1106837)
+- 4.1.4
+
+-------------------------------------------------------------------
 Fri Aug 31 14:03:43 UTC 2018 - snwint@suse.com
 
 - allow hard disks with file systems to be selected in add-on dialog (bsc#1003263)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -2078,7 +2078,7 @@ module Yast
       msg = _("Repository '%{name}' is managed by service '%{service}'.\n"\
         "Your manual changes might be reset by the next service refresh!") %
         { name: source_state["name"], service: source_state["service"] }
-      if source_state["service"] != "" && !@services_repos.include?(source_state["SrcId"])
+      if !source_state["service"].to_s.empty? && !@services_repos.include?(source_state["SrcId"])
         Popup.Warning(msg)
         @services_repos.push(source_state["SrcId"])
       end


### PR DESCRIPTION
- For the newly added repositories the "service" key is missing in the data and is evaluated as `nil`
- The `source_state["service"].to_s.empty?` idiom is used several times in the code, this (last) place was missing.
- 4.1.4
