### PR TITLE
Ignore read failures when backing up /var/log/YaST2 (bsc#1110913)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct  8 08:12:54 UTC 2018 - lslezak@suse.cz
+
+- Ignore a read failure when backing up /var/log/YaST2, YaST might
+  be updating the logs while the archive is being created
+  (bsc#1110913)
+- 3.2.30
+
+-------------------------------------------------------------------
 Fri Aug 31 13:54:53 UTC 2018 - snwint@suse.com
 
 - allow hard disks with file systems to be selected in add-on dialog (bsc#1003263)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.2.29
+Version:        3.2.30
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -10,6 +10,7 @@
 #
 
 require "fileutils"
+require "shellwords"
 
 module Yast
   class InstKickoffClient < Client
@@ -349,22 +350,8 @@ module Yast
 
         if SCR.Execute(
             path(".target.bash"),
-            Ops.add(
-              Ops.add(
-                Ops.add(
-                  Ops.add(
-                    Ops.add(
-                      Ops.add("cd '", String.Quote(Installation.destdir)),
-                      "'; "
-                    ),
-                    "/bin/tar czf ."
-                  ),
-                  filename
-                ),
-                " "
-              ),
-              "var/log/YaST2"
-            )
+            "cd #{Shellwords.escape(Installation.destdir)}; " \
+              "/bin/tar --ignore-failed-read -czf .#{Shellwords.escape(filename)} var/log/YaST2"
           ) != 0
           Builtins.y2error(
             "backup of %1 to %2 failed",


### PR DESCRIPTION
- Ignore read failures when backing up `/var/log/YaST2`, YaST might be changing it meanwhile, there is a race condition
- YaST might rotate the logs or add new lines to the log while the tar is creating the archive
- See https://bugzilla.suse.com/show_bug.cgi?id=1110913
- Use `--ignore-failed-read` to ignore the errors for modified/missing files, it is already used [elsewhere](https://github.com/yast/yast-packager/blob/df637b77c9fed5f03d3c60057517271e04bd01a3/src/clients/inst_kickoff.rb#L449)
- This is just about archiving the old y2log which is not critical for the end user and it very likely happens only with Y2DEBUG=1, 
- The fix is untested, this race condition is difficult to trigger, but it was reported by openQA so hopefully it will be tested there again
- 3.2.30

