### PR TITLE
[master] Ignore read failures when backing up /var/log/YaST2 (bsc#1110913)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct  8 08:12:54 UTC 2018 - lslezak@suse.cz
+
+- Ignore a read failure when backing up /var/log/YaST2, YaST might
+  be updating the logs while the archive is being created
+  (bsc#1110913)
+- 4.1.8
+
+-------------------------------------------------------------------
 Tue Sep 25 11:56:41 UTC 2018 - lslezak@suse.cz
 
 - Copy also the role packages from the self-update repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.6
+Version:        4.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require "fileutils"
+require "shellwords"
 
 module Yast
   # Do various tasks before starting with installation of rpms.
@@ -223,22 +224,8 @@ module Yast
 
       if SCR.Execute(
         path(".target.bash"),
-        Ops.add(
-          Ops.add(
-            Ops.add(
-              Ops.add(
-                Ops.add(
-                  Ops.add("cd '", String.Quote(Installation.destdir)),
-                  "'; "
-                ),
-                "/bin/tar czf ."
-              ),
-              filename
-            ),
-            " "
-          ),
-          "var/log/YaST2"
-        )
+        "cd #{Shellwords.escape(Installation.destdir)}; " \
+          "/bin/tar --ignore-failed-read -czf .#{Shellwords.escape(filename)} var/log/YaST2"
       ).nonzero?
         Builtins.y2error(
           "backup of %1 to %2 failed",


### PR DESCRIPTION
- Just merging #378 to master.
- Bumping the version to 4.1.8, the 4.1.7 was by mistake only changed in *.changes.