### PR TITLE
Add online repos during installation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 14 13:56:53 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Support for adding online repos during installation (bsc#1112937)
+- Added pop-up dialog to ask user first if he would like to add
+  online repos during installation and upgrade (only once)
+- 4.1.13
+
+-------------------------------------------------------------------
 Fri Nov  2 15:34:01 UTC 2018 - lslezak@suse.cz
 
 - Break the yast2-packager -> yast2-storage-ng -> yast2-packager

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -87,6 +87,7 @@ module Yast
   #     </group>
   #   </metapackage>
   class InstProductsourcesClient < Client
+    # rubocop:disable Style/ClassVars
     include Yast::Logger
 
     # too low memory for using online repositories (in MiB),
@@ -119,6 +120,7 @@ module Yast
         end
 
         if !ask_activate_online_repos
+          log.info("Skipping module")
           return :auto
         end
       end

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1739,6 +1739,7 @@ module Yast
       # Ask only once
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
+      default_button = :focus_yes
       msg = _("Your system has an active network connection.\n" \
               "Additional software is available online.\n"      \
               "Would you like to activate online repositories?")
@@ -1751,10 +1752,16 @@ module Yast
                  "\n"                                                      \
                  "Using the online repositories later in the installed\n"  \
                  "system is recommended.") % LOW_MEMORY_MIB
+        default_button = :focus_no
         @@posted_low_memory_warning = true
       end
 
-      @@ask_activate_online_repos_result = Yast::Popup.YesNo(msg)
+      @@ask_activate_online_repos_result = Popup.AnyQuestion(
+        Popup.NoHeadline,
+        msg,
+        Label.YesButton,
+        Label.NoButton,
+        default_button)
     end
 
     # fallback when alias is not defined

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1756,12 +1756,8 @@ module Yast
         @@posted_low_memory_warning = true
       end
 
-      @@ask_activate_online_repos_result = Popup.AnyQuestion(
-        Popup.NoHeadline,
-        msg,
-        Label.YesButton,
-        Label.NoButton,
-        default_button)
+      @@ask_activate_online_repos_result = Popup.AnyQuestion(Popup.NoHeadline,
+        msg, Label.YesButton, Label.NoButton, default_button)
     end
 
     # fallback when alias is not defined

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -113,6 +113,11 @@ module Yast
       end
 
       if Mode.installation || Mode.update
+        if !NetworkService.isNetworkRunning
+          log.info("No network connection - skipping module")
+          return :auto
+        end
+
         if !ask_activate_online_repos
           return :auto
         end

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1732,7 +1732,9 @@ module Yast
       # Ask only once
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
-      msg = _("Would you like to activate online repositories?")
+      msg = _("Your system has an active network connection.\n" \
+              "Additional software is available online.\n"      \
+              "Would you like to activate online repositories?")
 
       if low_memory?
         msg += "\n\n"

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1695,8 +1695,6 @@ module Yast
     # with low memory (the installer may crash or freeze, see bnc#854755)
     def check_memory_size
       return if !Mode.installation
-      # less than LOW_MEMORY_MIB RAM, the 64MiB buffer is for possible
-      # rounding in hwinfo memory detection (bsc#1045915)
       return unless low_memory?
 
       # Warn only once
@@ -1717,6 +1715,8 @@ module Yast
     # @return Boolean
     #
     def low_memory?
+      # less than LOW_MEMORY_MIB RAM, the 64MiB buffer is for possible
+      # rounding in hwinfo memory detection (bsc#1045915)
       Yast2::HwDetection.memory < ((LOW_MEMORY_MIB - 64) << 20)
     end
 

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1288,7 +1288,6 @@ module Yast
         # bnc #392111
         Wizard.RestoreNextButton
         Wizard.EnableNextButton
-        Wizard.DisableBackButton
 
         # from add-ons
         if @script_called_from_another

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -87,6 +87,8 @@ module Yast
   #     </group>
   #   </metapackage>
   class InstProductsourcesClient < Client
+    include Yast::Logger
+
     # too low memory for using online repositories (in MiB),
     # at least 1GiB is recommended
     LOW_MEMORY_MIB = 1024
@@ -94,22 +96,30 @@ module Yast
     # we want new target in releaseversion and not old one )
     RELEASEVER_ENV = "ZYPP_REPO_RELEASEVER".freeze
 
+    @@posted_low_memory_warning = false
+    @@ask_activate_online_repos_result = nil
+
     def main
       textdomain "packager"
 
       if AddOnProduct.skip_add_ons
-        Builtins.y2milestone("Skipping module (as requested before)")
+        log.info("Skipping module (as requested before)")
         return :auto
       end
 
-      if GetInstArgs.going_back
-        Builtins.y2milestone("Going back...")
+      if GetInstArgs.going_back && Mode.update
+        log.info("Going back...")
         ENV.delete(RELEASEVER_ENV)
-        return :back
+      end
+
+      if Mode.installation || Mode.update
+        if !ask_activate_online_repos
+          return :auto
+        end
       end
 
       @args = WFM.Args
-      Builtins.y2milestone("Script args: %1", @args)
+      log.info("Script args: #{@args}")
 
       # similar to commandline mode but actually it's called from another YaST script
       @script_noncmdline_args = {}
@@ -1680,15 +1690,62 @@ module Yast
       return if !Mode.installation
       # less than LOW_MEMORY_MIB RAM, the 64MiB buffer is for possible
       # rounding in hwinfo memory detection (bsc#1045915)
-      return if Yast2::HwDetection.memory >= ((LOW_MEMORY_MIB - 64) << 20)
+      return unless low_memory?
 
+      # Warn only once
+      return if @@posted_low_memory_warning
+
+      @@posted_low_memory_warning = true
       Report.Warning(_("Low memory detected.\n\nUsing online repositories " \
             "during initial installation with less than\n" \
-            "%dMiB system memory is not recommended.\n\n" \
+            "%d MiB system memory is not recommended.\n\n" \
             "The installer may crash or freeze if the additional package data\n" \
             "need too much memory.\n\n" \
             "Using the online repositories later in the installed system is\n" \
             "recommended in this case.") % LOW_MEMORY_MIB)
+    end
+
+    # Return 'true' if running on a system with low memory, 'false' if not.
+    #
+    # @return Boolean
+    #
+    def low_memory?
+      Yast2::HwDetection.memory < ((LOW_MEMORY_MIB - 64) << 20)
+    end
+
+    # Ask the user if he wishes to activate online repos.
+    # Return 'true' if the user answered "Yes", 'false' if 'No'.
+    #
+    # @return Boolean
+    #
+    def ask_activate_online_repos
+      if GetInstArgs.going_back && @@ask_activate_online_repos_result == false
+        # If the user previously answered "no" and he is now going back, give
+        # him a chance to change his mind when he comes here the next time
+        # going forward again. But for now, since we are going back, prepare to
+        # skip this step since otherwise it would open the full dialog which he
+        # has not seen before, so that would be awkward.
+        @@ask_activate_online_repos_result = nil
+        return false
+      end
+
+      # Ask only once
+      return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
+
+      msg = _("Would you like to activate online repositories?")
+
+      if low_memory?
+        msg += "\n\n"
+        msg += _("Since your system has less than %d MiB memory,\n"        \
+                 "there is a significant risk of running out of memory,\n" \
+                 "and the installer may crash or freeze.\n"                \
+                 "\n"                                                      \
+                 "Using the online repositories later in the installed\n"  \
+                 "system is recommended.") % LOW_MEMORY_MIB
+        @@posted_low_memory_warning = true
+      end
+
+      @@ask_activate_online_repos_result = Yast::Popup.YesNo(msg)
     end
 
     # fallback when alias is not defined

--- a/test/lib/clients/inst_productsources_test.rb
+++ b/test/lib/clients/inst_productsources_test.rb
@@ -19,12 +19,6 @@ describe Yast::InstProductsourcesClient do
       expect(client.main).to eq :auto
     end
 
-    it "returns :back if going back" do
-      allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
-
-      expect(client.main).to eq :back
-    end
-
     context "run as command line" do
       before do
         allow(Yast::Mode).to receive(:normal).and_return(true)


### PR DESCRIPTION
## Trello

https://trello.com/c/VgNO1EBi/442-ludwigs-favorite-feature-leap-151-add-possibility-to-add-online-updates-repo-during-installation

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1112937

## Changes Summary

- Support for adding online repos during installation 

- Added pop-up dialog to ask user first if he would like to add online repos during installation and upgrade (only once)

## Details

During installation or upgrade, this now opens a pop-up dialog first:

![yast2-001](https://user-images.githubusercontent.com/11538225/48498869-70e98e80-e837-11e8-8721-798cf083464b.png)

If memory is low, it also comes with a warning:

![yast2-001](https://user-images.githubusercontent.com/11538225/48498919-878fe580-e837-11e8-931f-b7e59a0efca7.png)

(only one of those two is displayed)

If the user clicks on "Yes", the next step is configuring which online repos to use:

![yast2-002](https://user-images.githubusercontent.com/11538225/48498961-a42c1d80-e837-11e8-9444-3788c105dce3.png)

When going back and forth in the workflow, the behavior is consistent:

- The pop-up is only posted once if the user answered with "Yes", so the full-fledged dialog is then shown immediately, no matter how often the user goes back and forth.

- If the user answered the pop-up with "No", the module is skipped when going backwards, so the first dialog (license / language / keyboard) is shown; when going forward again, the pop-up is shown again so the user still has a chance to get online repos.

In other modes, there may be the old low memory warning dialog. The module now makes sure to show that warning only once; if the new pop-up is shown, it already contains that warning, so the old warning is not shown.

## Related PR

https://github.com/yast/skelcd-control-openSUSE/pull/151

## Stakeholder Feedback

Demonstrated to and approved by @lnussel.

He extended the first (simpler) pop-up dialog text, and he requested to skip this workflow step entirely if no network is available.

His reasoning was that the network is configured early in the workflow anyway, and having yet another network configuration from this online repos module (which it can do!) would only add confusion rather than be helpful.