### PR TITLE
sw_single_wrapper: fixed invalid variable reset (bsc#1116226)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov 16 13:29:45 UTC 2018 - lslezak@suse.cz
+
+- sw_single_wrapper: fixed invalid variable reset causing a
+  possible command injection vulnerability via environment
+  variable (bsc#1116226)
+- 4.0.71
+
+-------------------------------------------------------------------
 Fri Sep 21 12:58:42 CEST 2018 - schubi@suse.de
 
 - add_on_products.xml : Added tag "confirm_license" to handle

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.70
+Version:        4.0.71
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/bin/sw_single_wrapper
+++ b/src/bin/sw_single_wrapper
@@ -1,14 +1,14 @@
-#! /bin/sh
+#! /bin/bash
 
 # This is a small wrapper around "yast2 sw_single"
 # which quotes all arguments before passing them
 # to xdg-su (to properly process file names contaning
 # spaces or special shell characters like quotes, ampersand...)
 
-$ARGS=""
+ARGS=""
 for ARG in "$@"
 do
-    QUOTED_ARG=`printf %q "$ARG"`
+    QUOTED_ARG=$(printf %q "$ARG")
     ARGS="$ARGS $QUOTED_ARG"
 done
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1116226
- Fixed invalid variable reset causing a possible command injection vulnerability via environment variable.
- 4.0.71

I have fixed all issues reported by [shellcheck](https://www.shellcheck.net/):
```
In sw_single_wrapper line 8:
$ARGS=""
 ^-- SC1066: Don't use $ on the left side of assignments.


In sw_single_wrapper line 11:
    QUOTED_ARG=`printf %q "$ARG"`
               ^-- SC2006: Use $(..) instead of legacy `..`.
                       ^-- SC2039: In POSIX sh, printf %q is undefined.
```