### PR TITLE
Report chrony is missing

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov 20 10:37:59 UTC 2018 - knut.anderssen@suse.com
+
+- software_proposal: Added warning in case the NTP configuration
+  was modified but the package is not selected to be installed
+  (bsc#1082369)
+- 4.0.72
+
+-------------------------------------------------------------------
 Fri Nov 16 13:29:45 UTC 2018 - lslezak@suse.cz
 
 - sw_single_wrapper: fixed invalid variable reset causing a

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.0.71
+Version:        4.0.72
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/packager/clients/software_proposal.rb
+++ b/src/lib/packager/clients/software_proposal.rb
@@ -83,30 +83,13 @@ module Yast
           "warning_level" => :blocker
         )
       end
-      remote_installation_error = Packages.check_remote_installation_packages
-      unless remote_installation_error.empty?
-        # The Default warning_level is "error". So the user can continue
-        # installation.
-        if @ret["warning"]
-          @ret["warning"] << "\n"
-          @ret["warning"] << remote_installation_error
-        else
-          @ret["warning"] = remote_installation_error
-        end
-      end
 
-      if Yast::Mode.auto
-        # AY: Checking if second stage is needed and the environment has been setup.
-        error_message = Yast::AutoinstData.autoyast_second_stage_error
-        unless error_message.empty?
-          if @ret["warning"]
-            @ret["warning"] << "\n"
-          else
-            @ret["warning"] = ""
-          end
-          @ret["warning"] << error_message
-        end
-      end
+      # The Default warning_level is "error". So the user can continue
+      # installation.
+      add_warning_if_needed(Packages.check_ntp_installation_packages)
+      add_warning_if_needed(Packages.check_remote_installation_packages)
+      # AY: Checking if second stage is needed and the environment has been setup.
+      add_warning_if_needed(Yast::AutoinstData.autoyast_second_stage_error) if Yast::Mode.auto
 
       @ret
     end
@@ -142,6 +125,17 @@ module Yast
     end
 
   private
+
+    # @param msg [String] warning message to be added
+    def add_warning_if_needed(msg)
+      return if msg.empty?
+
+      if @ret.key?("warning")
+        @ret["warning"] << "\n#{msg}"
+      else
+        @ret["warning"] = msg
+      end
+    end
 
     def partitioning_changed?
       changed = false

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -80,6 +80,7 @@ module Yast
       Yast.import "URL"
       Yast.import "PackagesProposal"
       Yast.import "HTML"
+      Yast.import "NtpClient"
 
       Yast.include self, "packager/load_release_notes.rb"
 
@@ -855,6 +856,18 @@ module Yast
       end
 
       nil
+    end
+
+    # When the NTP configuration has been modified, it checks whether the
+    # service package is selected to be installed or not.
+    # @return [String] empty string or error message if the package is missing
+    def check_ntp_installation_packages
+      return "" unless NtpClient.modified
+      return "" if pkg_will_be_installed(NtpClientClass::REQUIRED_PACKAGE)
+
+      # TRANSLATORS: warning message, %s is the service name
+      _("The NTP configuration (%s) has been modified, " \
+        "but the package is not selected to be installed.") % "chrony"
     end
 
     # Checking if all needed packages for remote installation

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -80,7 +80,6 @@ module Yast
       Yast.import "URL"
       Yast.import "PackagesProposal"
       Yast.import "HTML"
-      Yast.import "NtpClient"
 
       Yast.include self, "packager/load_release_notes.rb"
 
@@ -862,12 +861,14 @@ module Yast
     # service package is selected to be installed or not.
     # @return [String] empty string or error message if the package is missing
     def check_ntp_installation_packages
+      Yast.import "NtpClient"
+
       return "" unless NtpClient.modified
       return "" if pkg_will_be_installed(NtpClientClass::REQUIRED_PACKAGE)
 
-      # TRANSLATORS: warning message, %s is the service name
-      _("The NTP configuration (%s) has been modified, " \
-        "but the package is not selected to be installed.") % "chrony"
+      # TRANSLATORS: warning message
+      _("The NTP configuration (chrony) has been modified, " \
+        "but the package is not selected to be installed.")
     end
 
     # Checking if all needed packages for remote installation

--- a/test/lib/clients/software_proposal_test.rb
+++ b/test/lib/clients/software_proposal_test.rb
@@ -25,7 +25,10 @@ RSpec.shared_examples "Installation::ProposalClient" do
 end
 
 describe Yast::SoftwareProposalClient do
+  let(:ntp) { double("Yast::NtpClient", modified: false) }
+
   before do
+    stub_const("Yast::NtpClient", ntp)
     allow(Yast::WFM).to receive(:CallFunction).and_return(:next)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ end
 
 stub_module("Language")
 stub_module("Proxy")
+stub_module("NtpClient")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1082369

## Warn the user when NTP was configured but removed from the software selection in the proposal.

![chronymissing](https://user-images.githubusercontent.com/7056681/48741465-2317c080-ec53-11e8-949f-10842dca0de9.png)

Note: Do not like adding the dependency to yast-packager just for the warning.