### PR TITLE
Removed yast2_theme build dependency (related to boo#1109310)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov 29 14:47:37 UTC 2018 - lslezak@suse.cz
+
+- We do not need yast2_theme for building this package,
+  the desktopfile icon is included in this package now
+  (related to boo#1109310)
+- 4.1.19
+
+-------------------------------------------------------------------
 Wed Nov 28 08:01:43 UTC 2018 - Noah Davis <noahadvs@gmail.com>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.18
+Version:        4.1.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -37,9 +37,6 @@ BuildRequires:  yast2-storage-ng >= 4.0.141
 
 # Y2Packager::ProductLicense
 BuildRequires:  yast2 >= 4.0.63
-
-# needed for icon for desktop file, it is verified at the end of build
-BuildRequires:  yast2_theme
 
 # Pkg::PrdLicenseLocales
 BuildRequires:  yast2-pkg-bindings >= 4.0.8


### PR DESCRIPTION
We do not need yast2_theme for building this package anymore, the desktopfile icon is included in this package now.

- 4.1.19