### PR TITLE
Fallback to the fallback-repo (fate#325482)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec 17 16:12:36 UTC 2018 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- If linuxrc does not provide a repo URL (parameter NOREPO), use
+  the fallback repository included in the inst-sys to get the
+  information about the products (fate#325482).
+- 4.1.22
+
+-------------------------------------------------------------------
 Sat Dec 15 13:16:11 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add missing icons and edit current ones (boo#1109310)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.21
+Version:        4.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/InstURL.rb
+++ b/src/modules/InstURL.rb
@@ -143,9 +143,9 @@ module Yast
       @installInf2Url = Linuxrc.InstallInf("ZyppRepoURL")
 
       if @installInf2Url.to_s.empty?
-        # Use the fallback repository containing only products information
+        # If possible, use the fallback repository containing only products information
         log.info "No install URL specified through ZyppRepoURL"
-        @installInf2Url = fallback_repo_url.to_s
+        @installInf2Url = fallback_repo? ? fallback_repo_url.to_s : ""
       else
         # The URL is parsed/built only if needed to avoid potential problems with corner cases.
         @installInf2Url = add_extra_dir_to_url(@installInf2Url, extra_dir) unless extra_dir.empty?
@@ -157,8 +157,8 @@ module Yast
     end
 
     # Location of the fallback repository in the int-sys
-    FALLBACK_REPO = "dir:///var/lib/fallback-repo".freeze
-    private_constant :FALLBACK_REPO
+    FALLBACK_REPO_PATH = "/var/lib/fallback-repo".freeze
+    private_constant :FALLBACK_REPO_PATH
 
     # URL of the fallback repository, located in the int-sys, that is used to
     # get the products information when the NOREPO option has been passed to
@@ -166,7 +166,16 @@ module Yast
     #
     # @return [URI::Generic]
     def fallback_repo_url
-      ::URI.parse(FALLBACK_REPO)
+      ::URI.parse("dir://#{FALLBACK_REPO_PATH}")
+    end
+
+    # Where there is a fallback repository in the int-sys
+    #
+    # @see #fallback_repo_url
+    #
+    # @return [Boolean]
+    def fallback_repo?
+      ::File.exist?(FALLBACK_REPO_PATH)
     end
 
   private

--- a/src/modules/InstURL.rb
+++ b/src/modules/InstURL.rb
@@ -143,9 +143,9 @@ module Yast
       @installInf2Url = Linuxrc.InstallInf("ZyppRepoURL")
 
       if @installInf2Url.to_s.empty?
-        # no fallback URL any more
+        # Use the fallback repository containing only products information
         log.info "No install URL specified through ZyppRepoURL"
-        @installInf2Url = ""
+        @installInf2Url = fallback_repo_url.to_s
       else
         # The URL is parsed/built only if needed to avoid potential problems with corner cases.
         @installInf2Url = add_extra_dir_to_url(@installInf2Url, extra_dir) unless extra_dir.empty?
@@ -154,6 +154,19 @@ module Yast
 
       log.info "Using install URL: #{URL.HidePassword(@installInf2Url)}"
       @installInf2Url
+    end
+
+    # Location of the fallback repository in the int-sys
+    FALLBACK_REPO = "dir:///var/lib/fallback-repo".freeze
+    private_constant :FALLBACK_REPO
+
+    # URL of the fallback repository, located in the int-sys, that is used to
+    # get the products information when the NOREPO option has been passed to
+    # the installer (fate#325482)
+    #
+    # @return [URI::Generic]
+    def fallback_repo_url
+      ::URI.parse(FALLBACK_REPO)
     end
 
   private

--- a/test/inst_url_test.rb
+++ b/test/inst_url_test.rb
@@ -28,9 +28,22 @@ describe Yast::InstURL do
 
     context "when ZyppRepoURL is not defined" do
       let(:zypp_repo_url) { nil }
+      before { allow(::File).to receive(:exist?).and_return fallback_present }
 
-      it "returns the url of the fallback repo for products" do
-        expect(inst_url.installInf2Url("")).to eq(inst_url.fallback_repo_url.to_s)
+      context "if the inst-sys contains a fallback repo to get the products" do
+        let(:fallback_present) { true }
+
+        it "returns the url of the fallback repository" do
+          expect(inst_url.installInf2Url("")).to eq(inst_url.fallback_repo_url.to_s)
+        end
+      end
+
+      context "if there is no fallback repository" do
+        let(:fallback_present) { false }
+
+        it "returns an empty string" do
+          expect(inst_url.installInf2Url("")).to eq("")
+        end
       end
     end
 

--- a/test/inst_url_test.rb
+++ b/test/inst_url_test.rb
@@ -29,8 +29,8 @@ describe Yast::InstURL do
     context "when ZyppRepoURL is not defined" do
       let(:zypp_repo_url) { nil }
 
-      it "returns an empty string" do
-        expect(inst_url.installInf2Url("")).to eq("")
+      it "returns the url of the fallback repo for products" do
+        expect(inst_url.installInf2Url("")).to eq(inst_url.fallback_repo_url.to_s)
       end
     end
 


### PR DESCRIPTION
Main PR for https://trello.com/c/ZZ263pmr/567-part-of-fate325482-use-fallback-repo-during-installation

Tested manually.

1 - If the `NOREPO` option is not used, everything works as always. No change at all.

2 - If `NOREPO=1` is used and the inst-sys includes a fallback repo, the products there are offered and the fallback repo is NOT present in the final installed system. See screenshots:

  2.a - With the fallback repo containing two products.

![norepo-two-products](https://user-images.githubusercontent.com/3638289/50153606-2f7d5080-02c7-11e9-8f00-740a0597adb0.png)

  2.b -  With the fallback repo containing just one product (the missing license term is being fixed in a separate PR).

![norepo-one-product](https://user-images.githubusercontent.com/3638289/50153616-399f4f00-02c7-11e9-9f63-b51d4debfbdf.png)

3 - If `NOREPO=1` is used and there is no fallback repo in the inst-sys, this dialog is presented.

![norepo-warning](https://user-images.githubusercontent.com/3638289/50153649-4d4ab580-02c7-11e9-8472-98b2e1b66978.png)

The installation is aborted if the user clicks "no".

![norepo-abort](https://user-images.githubusercontent.com/3638289/50153787-ba5e4b00-02c7-11e9-8b3a-93fcea591c7d.png)
