### PR TITLE
Display the license confirmation checkbox only if needed

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 27 17:29:32 UTC 2018 - dgonzalez@suse.com
+
+- Display the license agreement checkbox only when needed
+  (related to fate#325482)
+- 4.1.24
+
+-------------------------------------------------------------------
 Mon Dec 17 16:12:37 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.23
+Version:        4.1.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/dialogs/inst_product_license.rb
+++ b/src/lib/y2packager/dialogs/inst_product_license.rb
@@ -55,10 +55,23 @@ module Y2Packager
         VBox(
           Widgets::ProductLicenseTranslations.new(product, Yast::Language.language),
           HBox(
-            Left(Widgets::ProductLicenseConfirmation.new(product)),
+            confirmation_checkbox,
             HStretch()
           )
         )
+      end
+
+    private
+
+      # Return the license confirmation widget if required
+      #
+      # It returns Empty() if confirmation is not needed.
+      #
+      # @return [Yast::Term,ProductLicenseConfirmation] Product confirmation license widget
+      #   or Empty() if confirmation is not needed.
+      def confirmation_checkbox
+        return Empty() unless product.license_confirmation_required?
+        Widgets::ProductLicenseConfirmation.new(product)
       end
     end
   end

--- a/test/lib/dialogs/inst_product_license_test.rb
+++ b/test/lib/dialogs/inst_product_license_test.rb
@@ -22,16 +22,30 @@ describe Y2Packager::Dialogs::InstProductLicense do
   end
 
   let(:language) { "en_US" }
+  let(:confirmation_required) { true }
 
   describe "#contents" do
     before do
       allow(Yast::Language).to receive(:language).and_return(language)
+      allow(product).to receive(:license_confirmation_required?).and_return(confirmation_required)
     end
 
-    it "includes a confirmation checkbox" do
-      expect(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new)
-        .with(product)
-      dialog.contents
+    context "when license acceptance is required" do
+      it "includes a confirmation checkbox" do
+        expect(Y2Packager::Widgets::ProductLicenseConfirmation).to receive(:new).with(product)
+
+        dialog.contents
+      end
+    end
+
+    context "when license acceptance is not required" do
+      let(:confirmation_required) { false }
+
+      it "doest not include a confirmation checkbox" do
+        expect(Y2Packager::Widgets::ProductLicenseConfirmation).to_not receive(:new).with(product)
+
+        dialog.contents
+      end
     end
 
     it "includes product translations using the current language as default" do


### PR DESCRIPTION
Related to https://trello.com/c/ish1gWEZ/568-part-of-fate325482-display-the-license-contained-in-the-fallback-repo (fate#325482)

---

The license confirmation can be ignored when the package contains the file/flag [`no-acceptance-needed`](https://github.com/openSUSE/libzypp/blob/5d59a317e7a8d523e569063abaaaf12c0aeab5bd/zypp/RepoInfo.cc#L757). In consequence, the confirmation checkbox only must be displayed when the acceptance is required.

---

See also https://github.com/yast/yast-yast2/pull/880