### PR TITLE
online repo popup: change wording to passive

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 29 08:08:04 UTC 2019 - dgonzalez@suse.com
+
+- Change wording of the popup that asks to enable online repos
+  (related to bsc#1112937).
+- 4.1.25
+
+-------------------------------------------------------------------
 Thu Dec 27 17:29:32 UTC 2018 - dgonzalez@suse.com
 
 - Display the license agreement checkbox only when needed

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.24
+Version:        4.1.25
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1725,6 +1725,7 @@ module Yast
     # @return Boolean
     #
     def ask_activate_online_repos
+      msg = []
       if GetInstArgs.going_back && @@ask_activate_online_repos_result == false
         # If the user previously answered "no" and he is now going back, give
         # him a chance to change his mind when he comes here the next time
@@ -1738,27 +1739,28 @@ module Yast
       # Ask only once
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
-      default_button = :focus_yes
-      msg = _("The system has an active network connection.\n" \
-              "Additional software is available online.\n")
+      msg << _("The system has an active network connection.\n" \
+              "Additional software is available online.")
 
       if low_memory?
-        msg += "\n\n"
-        msg += _("Since the system has less than %d MiB memory,\n"        \
+        msg << _("Since the system has less than %d MiB memory,\n"         \
                  "there is a significant risk of running out of memory,\n" \
                  "and the installer may crash or freeze.\n"                \
                  "\n"                                                      \
                  "Using the online repositories later in the installed\n"  \
                  "system is recommended.") % LOW_MEMORY_MIB
-        default_button = :focus_no
         @@posted_low_memory_warning = true
       end
 
-      msg += "\n"
-      msg += _("Activate online repositories now?")
+      msg << _("Activate online repositories now?")
 
-      @@ask_activate_online_repos_result = Popup.AnyQuestion(Popup.NoHeadline,
-        msg, Label.YesButton, Label.NoButton, default_button)
+      @@ask_activate_online_repos_result = Popup.AnyQuestion(
+        Popup.NoHeadline,
+        msg.join("\n\n"),
+        Label.YesButton,
+        Label.NoButton,
+        @@posted_low_memory_warning ? :focus_no : :focus_yes
+      )
     end
 
     # fallback when alias is not defined

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1739,13 +1739,12 @@ module Yast
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
       default_button = :focus_yes
-      msg = _("Your system has an active network connection.\n" \
-              "Additional software is available online.\n"      \
-              "Would you like to activate online repositories?")
+      msg = _("The system has an active network connection.\n" \
+              "Additional software is available online.\n")
 
       if low_memory?
         msg += "\n\n"
-        msg += _("Since your system has less than %d MiB memory,\n"        \
+        msg += _("Since the system has less than %d MiB memory,\n"        \
                  "there is a significant risk of running out of memory,\n" \
                  "and the installer may crash or freeze.\n"                \
                  "\n"                                                      \
@@ -1754,6 +1753,9 @@ module Yast
         default_button = :focus_no
         @@posted_low_memory_warning = true
       end
+
+      msg += "\n"
+      msg += _("Activate online repositories now?")
 
       @@ask_activate_online_repos_result = Popup.AnyQuestion(Popup.NoHeadline,
         msg, Label.YesButton, Label.NoButton, default_button)


### PR DESCRIPTION
Change wording of the popup that asks to enable online repos to
passive. Additionally move the actual question so it's at the end of
the dialog even in low memory situations.