### PR TITLE
Automatically select the driver packages (bsc#953522)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 14 07:46:00 UTC 2019 - lslezak@suse.cz
+
+- Automatically preselect the driver packages from new repositories
+  (bsc#953522)
+- 4.1.27
+
+-------------------------------------------------------------------
 Fri Feb  8 17:21:41 UTC 2019 - knut.anderssen@suse.com
 
 - Replaced SuSEFirewall2 by firewalld when checking if the firewall

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.26
+Version:        4.1.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/known_repositories.rb
+++ b/src/lib/y2packager/known_repositories.rb
@@ -37,9 +37,7 @@ module Y2Packager
 
       # accessible only for the root user, the repository URLs should not contain
       # any passwords but rather be safe than sorry
-      File.open(status_file, "w", 0o600) do |f|
-        f.write(repositories.to_yaml)
-      end
+      File.write(status_file, repositories.to_yaml, open_args: ["w", 0o600])
     end
 
     def update

--- a/src/lib/y2packager/known_repositories.rb
+++ b/src/lib/y2packager/known_repositories.rb
@@ -1,0 +1,98 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yaml"
+require "yast"
+
+module Y2Packager
+  # Track the known repositories from which the system packages (drivers)
+  # have been installed (or suggested to the user).
+  # @see https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages
+  class KnownRepositories
+    include Yast::Logger
+
+    STATUS_FILE = "/var/lib/YaST2/system_packages_repos.yaml".freeze
+
+    # Constructor
+    def initialize
+      Yast.import "Pkg"
+      Yast.import "Installation"
+    end
+
+    def repositories
+      @repositories ||= read_repositories
+    end
+
+    def write
+      log.info("Writing known repositories #{repositories.inspect} to #{status_file}")
+
+      # accessible only for the root user, the repository URLs should not contain
+      # any passwords but rather be safe than sorry
+      File.open(status_file, "w", 0o600) do |f|
+        f.write(repositories.to_yaml)
+      end
+    end
+
+    def update
+      # add the current repositories
+      repositories.concat(current_repositories)
+      # remove duplicates and sort them
+      repositories.uniq!
+      repositories.sort!
+    end
+
+    #
+    # Return new (unknown) repositories
+    #
+    # @return [Array<String>] List of new repositories (URLs)
+    #
+    def new_repositories
+      log.info "current repositories: #{current_repositories.inspect}"
+      log.info "known repositories: #{repositories.inspect}"
+
+      new_repos = current_repositories - repositories
+      log.info "New repositories: #{new_repos.inspect}"
+      new_repos
+    end
+
+  private
+
+    def read_repositories
+      if !File.exist?(status_file)
+        log.info("Status file #{status_file} not found")
+        return []
+      end
+
+      status = YAML.load_file(status_file)
+      # unify the file in case it was manually modified
+      status.uniq!
+      status.sort!
+
+      log.info("Read known repositories from #{status_file}: #{status}")
+      status
+    end
+
+    def current_repositories
+      # only the enabled repositories
+      repo_ids = Yast::Pkg.SourceGetCurrent(true)
+
+      urls = repo_ids.map { |r| Yast::Pkg.SourceGeneralData(r)["url"] }
+      urls.uniq!
+      urls.sort
+    end
+
+    def status_file
+      # add the current target prefix
+      File.join(Yast::Installation.destdir, STATUS_FILE)
+    end
+  end
+end

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -1,0 +1,92 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+module Y2Packager
+  # Preselect the system packages (drivers) from the specified repositories.
+  # @see https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages
+  class SystemPackages
+    include Yast::Logger
+
+    # @return [Array<String>] Repositories from which the driver packages should be selected
+    attr_reader :repositories
+
+    #
+    # Constructor
+    #
+    # @param repository_urls [Array<String>] Repositories from which the driver
+    #  packages should be selected
+    #
+    def initialize(repository_urls)
+      log.info "System packages repositories: #{repository_urls.inspect}"
+      @repositories = repository_urls
+    end
+
+    def packages
+      @packages ||= find_packages
+    end
+
+    def select
+      return if packages.empty?
+      log.info "Preselecting system packages: #{packages.inspect}"
+      packages.each { |p| Yast::Pkg.PkgInstall(p) }
+    end
+
+  private
+
+    #
+    # Create repository ID to URL mapping
+    #
+    # @return [Array<Integer>] List of repository IDs
+    #
+    def repo_ids(urls)
+      repo_ids = Yast::Pkg.SourceGetCurrent(true)
+      repo_ids.each_with_object([]) do |i, list|
+        list << i if urls.include?(Yast::Pkg.SourceGeneralData(i)["url"])
+      end
+    end
+
+    def find_packages
+      if repositories.empty?
+        log.info "No new repository found, not searching system packages"
+        return []
+      end
+
+      original_solver_flags = Yast::Pkg.GetSolverFlags
+
+      # solver flags for selecting minimal recommended packages (e.g. drivers)
+      Yast::Pkg.SetSolverFlags(
+        "ignoreAlreadyRecommended" => false,
+        "onlyRequires"             => true
+      )
+      # select the packages
+      Yast::Pkg.PkgSolve(true)
+
+      ids = repo_ids(repositories)
+
+      pkgs = Yast::Pkg.ResolvableProperties("", :package, "")
+      pkgs = pkgs.select do |p|
+        # the packages from the specified repositories selected by the solver
+        p["status"] == :selected && ids.include?(p["source"]) && p["transact_by"] == :solver
+      end
+
+      # set back the original solver flags
+      Yast::Pkg.SetSolverFlags(original_solver_flags)
+
+      pkgs.map! { |p| p["name"] }
+      log.info "Found system packages: #{pkgs}"
+
+      pkgs
+    end
+  end
+end

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -50,8 +50,8 @@ module Y2Packager
     # @return [Array<Integer>] List of repository IDs
     #
     def repo_ids(urls)
-      repo_ids = Yast::Pkg.SourceGetCurrent(true)
-      repo_ids.select { |i| urls.include?(Yast::Pkg.SourceGeneralData(i)["url"]) }
+      all_ids = Yast::Pkg.SourceGetCurrent(true)
+      all_ids.select { |i| urls.include?(Yast::Pkg.SourceGeneralData(i)["url"]) }
     end
 
     def find_packages

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -51,9 +51,7 @@ module Y2Packager
     #
     def repo_ids(urls)
       repo_ids = Yast::Pkg.SourceGetCurrent(true)
-      repo_ids.each_with_object([]) do |i, list|
-        list << i if urls.include?(Yast::Pkg.SourceGeneralData(i)["url"])
-      end
+      repo_ids.select { |i| urls.include?(Yast::Pkg.SourceGeneralData(i)["url"]) }
     end
 
     def find_packages
@@ -65,6 +63,8 @@ module Y2Packager
       original_solver_flags = Yast::Pkg.GetSolverFlags
 
       # solver flags for selecting minimal recommended packages (e.g. drivers)
+      # see https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages,
+      # https://bugzilla.suse.com/show_bug.cgi?id=953522
       Yast::Pkg.SetSolverFlags(
         "ignoreAlreadyRecommended" => false,
         "onlyRequires"             => true

--- a/test/known_repositories_test.rb
+++ b/test/known_repositories_test.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "y2packager/known_repositories"
+
+describe Y2Packager::KnownRepositories do
+  Yast.import "Pkg"
+
+  let(:repo_url) { "http://example.com/repo" }
+  let(:repos) { [repo_url] }
+  let(:source_id) { 42 }
+
+  before do
+    allow(Yast::WFM).to receive(:scr_root).and_return("/")
+  end
+
+  describe "#repositories" do
+    it "returns empty list if the file does not exist" do
+      expect(File).to receive(:exist?).with(Y2Packager::KnownRepositories::STATUS_FILE)
+        .and_return(false)
+      expect(subject.repositories).to eq([])
+    end
+
+    it "reads the repository list from file" do
+      expect(File).to receive(:exist?).with(Y2Packager::KnownRepositories::STATUS_FILE)
+        .and_return(true)
+      expect(YAML).to receive(:load_file).with(Y2Packager::KnownRepositories::STATUS_FILE)
+        .and_return(repos)
+
+      expect(subject.repositories).to eq(repos)
+    end
+  end
+
+  describe "#write" do
+    it "writes the known repositories to the file" do
+      allow(subject).to receive(:repositories).and_return(repos)
+
+      file = double("file")
+      expect(File).to receive(:open).with(Y2Packager::KnownRepositories::STATUS_FILE, "w", 0o600)
+        .and_yield(file)
+      expect(file).to receive(:write).with(repos.to_yaml)
+
+      subject.write
+    end
+  end
+
+  describe "#new_repositories" do
+    it "return the unknown repositories" do
+      allow(subject).to receive(:repositories).and_return(repos)
+
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true).and_return([source_id])
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(source_id)
+        .and_return("url" => "http://new.example.com")
+
+      expect(subject.new_repositories).to eq(["http://new.example.com"])
+    end
+  end
+
+  describe "#update" do
+    it "add the current repositories to the known repositories" do
+      allow(subject).to receive(:repositories).and_return(repos)
+
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).with(true).and_return([source_id])
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(source_id)
+        .and_return("url" => "http://new.example.com")
+
+      subject.update
+      expect(repos).to eq(["http://example.com/repo", "http://new.example.com"])
+    end
+  end
+
+end

--- a/test/known_repositories_test.rb
+++ b/test/known_repositories_test.rb
@@ -35,10 +35,8 @@ describe Y2Packager::KnownRepositories do
     it "writes the known repositories to the file" do
       allow(subject).to receive(:repositories).and_return(repos)
 
-      file = double("file")
-      expect(File).to receive(:open).with(Y2Packager::KnownRepositories::STATUS_FILE, "w", 0o600)
-        .and_yield(file)
-      expect(file).to receive(:write).with(repos.to_yaml)
+      expect(File).to receive(:write)
+        .with(Y2Packager::KnownRepositories::STATUS_FILE, repos.to_yaml, open_args: ["w", 0o600])
 
       subject.write
     end

--- a/test/system_packages_test.rb
+++ b/test/system_packages_test.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "y2packager/system_packages"
+
+describe Y2Packager::SystemPackages do
+  Yast.import "Pkg"
+
+  let(:repo_url) { "http://example.com/repo" }
+  let(:repos) { [repo_url] }
+  let(:source_id) { 42 }
+  let(:system_package) { "system_package" }
+
+  subject do
+    Y2Packager::SystemPackages.new(repos)
+  end
+
+  describe "#packages" do
+    it "returns the packages from the new repository" do
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([source_id])
+      allow(Yast::Pkg).to receive(:SourceGeneralData).and_return("url" => repo_url)
+      allow(Yast::Pkg).to receive(:GetSolverFlags)
+      allow(Yast::Pkg).to receive(:PkgSolve)
+      allow(Yast::Pkg).to receive(:SetSolverFlags)
+      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
+        [
+          "name"        => system_package,
+          "source"      => source_id,
+          "status"      => :selected,
+          "transact_by" => :solver
+        ]
+      )
+
+      expect(subject.packages).to eq(["system_package"])
+    end
+
+    it "returns empty list if repository list is empty" do
+      expect(Y2Packager::SystemPackages.new([]).packages).to eq([])
+    end
+  end
+
+  describe "#select" do
+    it "selects the system packages to install" do
+      allow(subject).to receive(:packages).and_return([system_package])
+      expect(Yast::Pkg).to receive(:PkgInstall).with(system_package)
+
+      subject.select
+    end
+  end
+
+end


### PR DESCRIPTION
## Summay

The driver packages should be automatically preselected to install in installed system (during installation it already works), see https://bugzilla.suse.com/show_bug.cgi?id=953522.

## Solution

- We need to set a specific solver mode and let the solver preselect the system packages.
- We need to only preselect the drivers from new repositories (to not offer them again if user deselects them).
- See https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages for more details

## Testing

- Added unit tests
- Tested in installed system
  - Added a new repository in the repository manager and started the package manager,  the new drivers were preselected
  - Started the repository manager directly from the package manager
- Tested in installation
  - After the repositories used during installation were marked as "known" in the installed system. (Implemented in https://github.com/yast/yast-installation/pull/774)

## References 

- https://github.com/yast/yast-packager/wiki/Selecting-the-Driver-Packages
- https://bugzilla.suse.com/show_bug.cgi?id=953522
- https://github.com/yast/yast-installation/pull/774
