### PR TITLE
Replace SuSEFirewall2 with firewalld

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  8 17:21:41 UTC 2019 - knut.anderssen@suse.com
+
+- Replaced SuSEFirewall2 by firewalld when checking if the firewall
+  is running and thus maybe blocking SLP discovery (fate#323460)
+- 4.1.26
+
+-------------------------------------------------------------------
 Tue Jan 29 08:08:04 UTC 2019 - dgonzalez@suse.com
 
 - Change wording of the popup that asks to enable online repos

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.25
+Version:        4.1.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/SourceManagerSLP.rb
+++ b/src/modules/SourceManagerSLP.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "yast"
+require "y2firewall/firewalld"
 
 # YaST Namespace
 module Yast
@@ -12,7 +13,6 @@ module Yast
       Yast.import "Wizard"
       Yast.import "Directory"
       Yast.import "Stage"
-      Yast.import "SuSEFirewall"
       Yast.import "Report"
       Yast.import "Label"
       #    import "IP";
@@ -541,12 +541,12 @@ module Yast
       # no servers found
       if slp_services_found.nil? || Builtins.size(slp_services_found).zero?
         Builtins.y2warning("No SLP repositories were found")
-        if !Stage.initial && SuSEFirewall.IsStarted
+        if !Stage.initial && firewalld.running?
           Report.Message(
             # error popup
             _(
               "No SLP repositories have been found on your network.\n" \
-                "This could be caused by a running SuSEfirewall2,\n" \
+                "This could be caused by a running firewall,\n" \
                 "which probably blocks the network scanning."
             )
           )
@@ -578,6 +578,10 @@ module Yast
       Builtins.y2milestone("Selected URL: %1", url)
 
       url
+    end
+
+    def firewalld
+      Y2Firewall::Firewalld.instance
     end
 
     publish function: :SelectOneSLPService, type: "string ()"


### PR DESCRIPTION
## Problem

**SuSEFirewall2** has been replaced by **firewalld** in the distribution, as the module will be dropped completely there might not be any reference to it.

- https://fate.suse.com/323460

## Solution

- Replace **SuSEFirewall2** with **firewalld**