### PR TITLE
Stub missing dependency

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,7 @@ stub_module("Proxy")
 stub_module("FTP")
 stub_module("HTTP")
 stub_module("NtpClient")
+stub_module("InstFunctions")
 
 if ENV["COVERAGE"]
   require "simplecov"


### PR DESCRIPTION
> It is necessary to stub "InstFunctions" to run tests. The
`BuildRequire:` is not an option since `yast-installation` already
requires `yast-packager` and it would create a circular dependency.