### PR TITLE
Use correct method name mount_path, not nonexistent mountpoint

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 25 15:34:46 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use correct method name mount_path, not nonexistent mountpoint
+  (bsc#1130287)
+- 4.1.34
+
+-------------------------------------------------------------------
 Fri Mar 15 15:51:00 CET 2019 - schubi@suse.de
 
 - AutoYaST: Disabling local repositories in second stage only.

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.33
+Version:        4.1.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -529,7 +529,7 @@ module Yast
         delim = summary.fetch("warning", "").empty? ? "" : "<BR>"
         if Builtins.contains(
           @basic_dirs,
-          failed_mount.mountpoint
+          failed_mount.mount_path
         )
           Ops.set(
             summary,
@@ -542,7 +542,7 @@ module Yast
                   "Error: Cannot check free space in basic directory %1 (device %2), " \
                     "cannot start installation."
                 ),
-                failed_mount.mountpoint,
+                failed_mount.mount_path,
                 fs_dev_name(failed_mount)
               )
             )
@@ -562,7 +562,7 @@ module Yast
                 _(
                   "Warning: Cannot check free space in directory %1 (device %2)."
                 ),
-                failed_mount.mountpoint,
+                failed_mount.mount_path,
                 fs_dev_name(failed_mount)
               )
             )


### PR DESCRIPTION
## Trello

https://trello.com/c/jyThUKpA/

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1130287

## Backtrace

```
.../modules/Packages.rb:532:in `block in AddFailedMounts'
.../yast/builtins.rb:83:in `block in foreach'
.../yast/builtins.rb:82:in `each'
.../yast/builtins.rb:82:in `foreach'
.../modules/Packages.rb:528:in `AddFailedMounts'
.../modules/Packages.rb:657:in `Summary'
.../modules/Packages.rb:2164:in `Proposal'
.../packager/clients/software_proposal.rb:57:in `make_proposal'
.../installation/proposal_client.rb:86:in `run'
.../clients/software_proposal.rb:3:in `<top (required)>'
.../yast/wfm.rb:318:in `eval'
.../yast/wfm.rb:318:in `run_client'
.../yast/wfm.rb:206:in `call_builtin'
.../yast/wfm.rb:206:in `call_builtin_wrapper'
.../yast/wfm.rb:195:in `CallFunction'
.../installation/proposal_store.rb:480:in `make_proposal'
.../installation/proposal_store.rb:166:in `block (2 levels) in make_proposals'
.../installation/proposal_store.rb:165:in `each'
.../installation/proposal_store.rb:165:in `block in make_proposals'
.../installation/proposal_store.rb:164:in `loop'
.../installation/proposal_store.rb:164:in `make_proposals'
.../installation/proposal_runner.rb:486:in `make_proposal'
.../installation/proposal_runner.rb:137:in `run'
.../installation/proposal_runner.rb:41:in `run'
.../clients/inst_proposal.rb:24:in `<top (required)>'
.../yast/wfm.rb:318:in `eval'
.../yast/wfm.rb:318:in `run_client'
.../yast/wfm.rb:206:in `call_builtin'
.../yast/wfm.rb:206:in `call_builtin_wrapper'
.../yast/wfm.rb:195:in `CallFunction'
.../modules/ProductControl.rb:1336:in `RunFrom'
.../installation/clients/inst_complex_welcome.rb:109:in `merge_and_run_workflow'
.../installation/clients/inst_complex_welcome.rb:73:in `block in main'
.../installation/clients/inst_complex_welcome.rb:65:in `loop'
.../installation/clients/inst_complex_welcome.rb:65:in `main'
.../clients/inst_complex_welcome.rb:2:in `<top (required)>'
.../yast/wfm.rb:318:in `eval'
.../yast/wfm.rb:318:in `run_client'
.../yast/wfm.rb:206:in `call_builtin'
.../yast/wfm.rb:206:in `call_builtin_wrapper'
.../yast/wfm.rb:195:in `CallFunction'
.../modules/ProductControl.rb:1336:in `RunFrom'
.../modules/ProductControl.rb:1508:in `Run'
.../installation/clients/inst_worker_initial.rb:101:in `main'
.../clients/inst_worker_initial.rb:2:in `<top (required)>'
.../yast/wfm.rb:318:in `eval'
.../yast/wfm.rb:318:in `run_client'
.../yast/wfm.rb:206:in `call_builtin'
.../yast/wfm.rb:206:in `call_builtin_wrapper'
.../yast/wfm.rb:195:in `CallFunction'
.../installation/clients/installation.rb:93:in `main'
.../clients/installation.rb:2:in `<top (required)>'
.../yast/wfm.rb:318:in `eval'
.../yast/wfm.rb:318:in `run_client'
.../yast/wfm.rb:206:in `call_builtin'
.../yast/wfm.rb:206:in `call_builtin_wrapper'
.../yast/wfm.rb:195:in `CallFunction'
/usr/lib/YaST2/bin/y2start:62:in `<main>'
```

## Problem

The code used a method name `mountpoint` which no longer exists.

## Fix

Use `mount_path` which is a convenience method for `mount_point.path`.

## Test

Cannot easily reproduce, cannot easily add a suitable unit test.
That code is still old YCP-style with a gazillion ycpkiller leftovers.