### PR TITLE
Fix `rpm` commands

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 26 16:48:09 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Fix malformed rpm commands (bsc#1129422).
+- 4.1.35
+
+-------------------------------------------------------------------
 Mon Mar 25 15:34:46 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Use correct method name mount_path, not nonexistent mountpoint

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.34
+Version:        4.1.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -215,7 +215,7 @@ module Yast
           if Ops.greater_than(SCR.Read(path(".target.size"), package), 0)
             out = SCR.Execute(
               path(".target.bash_output"),
-              "/bin/rpm -q --qf '%%{NAME}' -p #{package.shellescape}"
+              "/bin/rpm -q --qf '%{NAME}' -p #{package.shellescape}"
             )
 
             if Ops.get_integer(out, "exit", -1).nonzero?
@@ -234,7 +234,7 @@ module Yast
             # is it a source package?
             out = SCR.Execute(
               path(".target.bash_output"),
-              "/bin/rpm -q --qf '%%{SOURCEPACKAGE}' -p #{package.shellescape}"
+              "/bin/rpm -q --qf '%{SOURCEPACKAGE}' -p #{package.shellescape}"
             )
             if Ops.get_integer(out, "exit", -1).nonzero?
               # error message


### PR DESCRIPTION
## Problem

YaST2 Software Management prompt an (empty) error when trying to install an `rpm` package.

This happens because a malformed `rpm` commands, containing wrong `--queryformat` string, are being executed. It is a consequence of the [hardening done few months ago](https://github.com/yast/yast-packager/commit/f26cea3f43fd0d69454e4eaafa67e78437462c03?diff=unified#diff-83b901d9f6ec2c74708f3b3276b598ebR215), when the `Builtins.sformat`, which [removes the additional (and not necessary) `%` character](https://github.com/yast/yast-ruby-bindings/blob/master/src/ruby/yast/builtins.rb#L581), was also removed.

- https://bugzilla.suse.com/show_bug.cgi?id=1129422
- Related to #396 

## Solution

Fix commands removing the unnecessary `%` character.


## Testing

- ***Only** tested manually*