### PR TITLE
Fix version number

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,7 +3,7 @@ Tue Mar 26 17:27:18 CET 2019 - schubi@suse.de
 
 - Fix: Checking if the proposal has been changed (right sorting).
   (bsc#1125718)
-- 4.1.35
+- 4.2.0
 
 -------------------------------------------------------------------
 Mon Mar 25 15:34:46 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.35
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
> Previous changes are related to SP2 only. So, the right version is 4.2.0
instead of 4.1.35 ([which is already in use in SP1](https://github.com/yast/yast-packager/pull/417)).
> 
> More info at https://yastgithubio.readthedocs.io/en/latest/versioning/