### PR TITLE
[WIP] Use the Docker image built by OBS in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: bash
 services:
   - docker
 
+cache:
+  directories:
+    - /var/lib/docker
+
 before_install:
   - docker build -t yast-packager-image .
   # list the installed packages (just for easier debugging)
@@ -12,6 +16,6 @@ script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   # exclude the yardoc step, we run the more strict check:doc later
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
+  - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
+  - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
+  - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ cache:
 
 before_install:
   - 'if [ -f $HOME/docker/yast-ruby.tar ]; then docker load -i $HOME/docker/yast-ruby.tar; fi'
-  - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest
+  - docker images
+  - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest | tee $HOME/docker.log
+  - docker images
   - docker build -t yast-packager-image .
   # list the installed packages (just for easier debugging)
   - docker run --rm -it yast-packager-image rpm -qa | sort

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
 
 cache:
   directories:
-    - docker
+    - $HOME/docker
 
 before_install:
-  - 'if [ -f docker/yast-ruby.tar ]; then docker load -i docker/yast-ruby.tar; fi'
+  - 'if [ -f $HOME/docker/yast-ruby.tar ]; then docker load -i $HOME/docker/yast-ruby.tar; fi'
   - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest
   - docker build -t yast-packager-image .
   # list the installed packages (just for easier debugging)
@@ -22,4 +22,4 @@ script:
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
-  - mkdir docker; docker save -o docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest
+  - mkdir -p $HOME/docker; docker save -o $HOME/docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,5 @@ script:
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
-
-after_script:
   - mkdir -p $HOME/docker; grep -q "up to date" $HOME/docker.log || docker save -o $HOME/docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ services:
 
 cache:
   directories:
-    - /var/lib/docker
+    - docker
 
 before_install:
+  - 'if [ -f docker/yast-ruby.tar ]; then docker load -i docker/yast-ruby.tar; fi'
+  - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest
   - docker build -t yast-packager-image .
   # list the installed packages (just for easier debugging)
   - docker run --rm -it yast-packager-image rpm -qa | sort
@@ -20,3 +22,4 @@ script:
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
+  - mkdir docker; docker save -o docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest | tee $HOME/docker.log
   - docker images
   - docker build -t yast-packager-image .
+  - docker images
+  - docker build -t yast-packager-image .
   # list the installed packages (just for easier debugging)
   - docker run --rm -it yast-packager-image rpm -qa | sort
 
@@ -24,4 +26,6 @@ script:
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
   - docker run -it --rm -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
-  - mkdir -p $HOME/docker; docker save -o $HOME/docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+after_script:
+  - mkdir -p $HOME/docker; grep -q "up to date" $HOME/docker.log || docker save -o $HOME/docker/yast-ruby.tar registry.opensuse.org/yast/head/containers/yast-ruby:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
   - docker images
   - docker pull registry.opensuse.org/yast/head/containers/yast-ruby:latest | tee $HOME/docker.log
   - docker images
+  - pwd
+  - "ls -l"
+  - "du -h ."
   - docker build -t yast-packager-image .
   - docker images
   - docker build -t yast-packager-image .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+sudo: false
+dist: xenial
 language: bash
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby
+FROM registry.opensuse.org/yast/head/containers/yast-ruby
 COPY . /usr/src/app
 


### PR DESCRIPTION
- Experimentally use the Docker image built by OBS (https://build.opensuse.org/package/show/YaST:Head/ci-ruby-container)
- Sources: https://github.com/yast/ci-ruby-container\
- See https://trello.com/c/sVVOXYbx/878-5-build-the-docker-images-for-travis-in-obs

## Advantages

- The image is rebuilt immediately when the RPM packages are built
- Does not wait for publishing the packages, does not wait for full rebuild (only for the needed packages)
- No extra accounts/permissions for the Docker Hub (just use your OBS account)
- The build in OBS is faster (6-7 minutes), that means the new package should be available in the Docker image in less than 15 minutes after merging a PR (for leaf packages)
- No need for extra Jenkins jobs periodically triggering the image rebuilds at the Docker Hub
