### PR TITLE
Fixed failing unit test

### DIFF
--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -552,6 +552,11 @@ describe "Yast::Packages" do
       before do
         allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
           .and_return(suma_products)
+
+        suma_products.map { |p| p["name"] }.uniq.each do |prod_name|
+          allow(Yast::Pkg).to receive(:ResolvableProperties).with(prod_name, :product, "")
+            .and_return(suma_products.select { |p| p["name"] == prod_name })
+        end
       end
 
       # the SLES12-SP3 is replaced by the SUMA base product,


### PR DESCRIPTION
- No version update needed, Jenkins failed and did not submit the package
- Fixed this issue:
```
[   77s] Failures:
[   77s] 
[   77s]   1) Yast::Packages #product_update_warning SUSE Manager 3.2 upgrade does not report any upgrade problem
[   77s]      Failure/Error: expect(Yast::Packages.product_update_warning(suma_products)).to eq({})
[   77s] 
[   77s]        Yast::Pkg received :ResolvableProperties with unexpected arguments
[   77s]          expected: ("", :product, "")
[   77s]               got: ("sle-module-development-tools", :product, "")
[   77s]        Diff:
[   77s]        @@ -1,2 +1,2 @@
[   77s]        -["", :product, ""]
[   77s]        +["sle-module-development-tools", :product, ""]
[   77s] 
[   77s]         Please stub a default value first if message might be received with other args as well. 
```
