### PR TITLE
Properly handle going back (bsc#1131968)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May  7 11:15:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly handle going back when selecting the modules from the
+  Packages DVD medium (bsc#1131968)
+- 4.1.40
+
+-------------------------------------------------------------------
 Thu May  2 12:10:07 UTC 2019 - mvidner@suse.com
 
 - Prefer control.xml to ProductFeatures for Community Repositories

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.39
+Version:        4.1.40
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -293,14 +293,14 @@ module Yast
       ret = createSource(url, plaindir, @download_meta, name)
 
       case ret
-      when :again
+      when :again, :back
         :back
       when :abort, :cancel
         :abort
       when :next
         :next
       else
-        log.warn "Received unknown result: #{ret}, using :next instead"
+        log.warn "Received unknown result: #{ret.inspect}, using :next instead"
         :next
       end
     end


### PR DESCRIPTION
- Properly handle going back when selecting the modules from the Packages DVD medium
- The `:back` symbol was not checked and the code returned the `:next` fallback in that case, completely breaking the workflow.
- See https://bugzilla.suse.com/show_bug.cgi?id=1131968#c24
- Tested manually, works correctly now
- 4.1.40