### PR TITLE
Memory optimizations (bsc#1132650)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May  7 15:09:10 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Memory optimizations, avoid freezing the installer when
+  running with 1GB RAM and using the online repositories
+  (bsc#1132650)
+- 4.1.41
+
+-------------------------------------------------------------------
 Tue May  7 11:15:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly handle going back when selecting the modules from the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.40
+Version:        4.1.41
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Avoid freezing the installer when running with 1GB RAM and using the online repositories.
- Do not use the `Pkg.ResolvableProperties("", :package, "")` call which requires huge amount of memory 
  - Replaced with `Pkg.GetPackages` and `Pkg.ResolvableProperties(<pkg>, :package, "")`
  - This skips the not selected packages and also queries the selected packages one-by-one, it avoids creating a huge list with all packages at once
- Tested manually, see the screencasts below.
- Added an unit test
- 4.1.41

## Screencasts

Tested in a VM with 1GB RAM with graphical installation using the NET ISO.

### The Original Code

After selecting a role the installer stopped responding and even the mouse cursor was lagging.

![low_memory_orig](https://user-images.githubusercontent.com/907998/57433732-7f8a8e80-7239-11e9-9744-62279ff6ebf4.gif)


### With the Fix Applied

With the fix the installation after a while normally continues to the partitioner proposal.

![low_memory_fix](https://user-images.githubusercontent.com/907998/57433786-a1841100-7239-11e9-8756-060b250533af.gif)
