### PR TITLE
Adapt memory limits (bsc#1132650)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,12 +1,4 @@
 -------------------------------------------------------------------
-Tue May  7 15:09:10 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
-
-- Memory optimizations, avoid freezing the installer when
-  running with 1GB RAM and using the online repositories
-  (bsc#1132650)
-- 4.1.41
-
--------------------------------------------------------------------
 Tue May  7 11:15:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly handle going back when selecting the modules from the

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 10 12:12:50 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Increase the memory limit warning for the online repositories to
+  1.5GiB to avoid freezing the installer (bsc#1132650)
+- 4.1.41
+
+-------------------------------------------------------------------
 Tue May  7 11:15:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly handle going back when selecting the modules from the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.41
+Version:        4.1.40
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.40
+Version:        4.1.41
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -93,8 +93,8 @@ module Yast
     include Yast::Logger
 
     # too low memory for using online repositories (in MiB),
-    # at least 1GiB is recommended
-    LOW_MEMORY_MIB = 1024
+    # at least 1.5GiB is recommended
+    LOW_MEMORY_MIB = 1536
     # variable to set target release version ( useful during upgrade when
     # we want new target in releaseversion and not old one )
     RELEASEVER_ENV = "ZYPP_REPO_RELEASEVER".freeze

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -821,16 +821,11 @@ module Yast
     # @param [Array<Symbol>] keep a list of symbols specifying type of objects to be kept selected
     def Reset(keep)
       restore = []
-      restore_packages = []
 
       # collect the currently selected resolvables
       keep.each do |type|
-        # handle packages differently, there might be tens of thousands packages,
-        # the package list might be HUGE (bsc#1132650)
-        # but there are usually just few dozens of products, patterns, etc.
-        next if type == :package
-
         resolvables = Pkg.ResolvableProperties("", type, "")
+
         resolvables.each do |resolvable|
           # only selected items but ignore the selections done by solver,
           # during restoration they would be changed to be selected by YaST and they
@@ -841,25 +836,10 @@ module Yast
         end
       end
 
-      # special handling for packages, there might be tens of thousands packages
-      # so we need to do it more effectively
-      if keep.include?(:package)
-        # first query the selected packages, then get the details for each selected
-        # package separately to avoid processing a huge list at once
-        # (true = names only without version)
-        Pkg.GetPackages(:selected, true).each do |pkg|
-          Pkg.ResolvableProperties(pkg, :package, "").each do |resolvable|
-            next if resolvable["status"] != :selected || resolvable["transact_by"] == :solver
-            restore_packages << pkg
-          end
-        end
-      end
-
       # This keeps the user-made changes (BNC#446406)
       Pkg.PkgApplReset
 
       restore.each { |name, type| Pkg.ResolvableInstall(name, type) }
-      restore_packages.each { |name| Pkg.ResolvableInstall(name, :package) }
 
       @system_packages_selected = false
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1212,13 +1212,11 @@ describe "Yast::Packages" do
   end
 
   describe "#Reset" do
-    before do
-      allow(Yast::Pkg).to receive(:PkgApplReset)
-    end
-
     # Reset all package changes done by YaST then re-select only the products
     # which previously were selected. (see bsc#963036).
     it "does not select previously unselected items" do
+      allow(Yast::Pkg).to receive(:PkgApplReset)
+
       allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
         [product("name" => "p1", "status" => :selected), product("name" => "p2")]
       )
@@ -1233,6 +1231,8 @@ describe "Yast::Packages" do
     # (to not change their "transact_by" value). They will be selected again by
     # solver if they are still needed.
     it "does not restore items selected by solver" do
+      allow(Yast::Pkg).to receive(:PkgApplReset)
+
       allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
         [product("name" => "p1", "status" => :selected, "transact_by" => :solver)]
       )
@@ -1240,31 +1240,6 @@ describe "Yast::Packages" do
       expect(Yast::Pkg).not_to receive(:ResolvableInstall).with("p1", :product)
 
       Yast::Packages.Reset([:product])
-    end
-
-    # do not use the Pkg.ResolvableProperties("", :package, "") call,
-    # it eats too much RAM (bsc#1132650)
-    it "does not use ineffective pkg calls" do
-      pkg1 = "package1"
-      pkg2 = "package2"
-
-      allow(Yast::Pkg).to receive(:GetPackages).with(:selected, true).and_return([pkg1, pkg2])
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with(pkg1, :package, "").and_return(
-        ["name" => pkg1, "status" => :selected, "transact_by" => :solver]
-      )
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with(pkg2, :package, "").and_return(
-        ["name" => pkg1, "status" => :selected, "transact_by" => :app_high]
-      )
-
-      # make sure this memory expensive call is not used
-      expect(Yast::Pkg).not_to receive(:ResolvableProperties).with("", :package, "")
-
-      # pkg1 was selected by solver, do not restore it
-      expect(Yast::Pkg).not_to receive(:ResolvableInstall).with(pkg1, :package)
-      # pkg2 was selected by YaST, restore it
-      expect(Yast::Pkg).to receive(:ResolvableInstall).with(pkg2, :package)
-
-      Yast::Packages.Reset([:package])
     end
   end
 


### PR DESCRIPTION
- Revert the *Memory optimizations* (PR yast/yast-packager#434), it is too intrusive for the GM release
- Just increase the memory limit for displaying the warning
- Tested manually with 1.5GiB RAM, it is enough, the system does not freeze