### PR TITLE
Added Cirrus CI support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,29 @@
+container:
+  image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+Rubocop_task:
+  container:
+    cpu: 8
+  test_script: rake check:rubocop
+  only_if: "changesInclude('.cirrus.yml', '.rubocop.yml', 'Rakefile', '**/*.rake', '*.rb', '**/*.rb')"
+
+Unit Tests_task:
+  environment:
+    COVERAGE: 1
+    COVERALLS_REPO_TOKEN: ENCRYPTED[07f77b1412f23d9201d0255c60b61781b308a2db9af24f07e48f1331ee80460c2e3b858f39f737294de04f94e55cc52d]
+    # Fake a Travis build to send the code coverage to coveralls.io
+    TRAVIS: 1
+  test_script: rake test:unit && shellcheck src/bin/sw_single_wrapper
+
+yardoc_task:
+  yardoc_cache_cache:
+    folder: .yardoc
+  test_script: rake check:doc
+  only_if: "changesInclude('.cirrus.yml', 'Rakefile', '**/*.rake', '*.rb', '**/*.rb')"
+
+Package Build_task:
+  # run the other steps
+  test_script: yast-travis-ruby -x tests -x rubocop -x yardoc
+
+Debug_task:
+  test_script: "uname -a; echo '---------'; rpm -qa | sort; echo '---------'; df -h; echo '---------'; free -h"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
   # exclude the yardoc step, we run the more strict check:doc later
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image yast-travis-ruby -x yardoc
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image rake check:doc
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-packager-image shellcheck src/bin/sw_single_wrapper
+  - docker run --rm -it yast-packager-image yast-travis-ruby -x yardoc
+  - docker run --rm -it yast-packager-image rake check:doc
+  - docker run --rm -it yast-packager-image shellcheck src/bin/sw_single_wrapper

--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --no-private
+--use-cache
 --markup markdown
 --protected
 src/**/*.rb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YaST - The Package Management Libraries #
 
 [![Travis Build](https://travis-ci.org/yast/yast-packager.svg?branch=master)](https://travis-ci.org/yast/yast-packager)
-[![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-packager-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-packager-master/)
-[![Coverage Status](https://coveralls.io/repos/yast/yast-packager/badge.png)](https://coveralls.io/r/yast/yast-packager)
-
+[![Build Status](https://api.cirrus-ci.com/github/yast/yast-packager.svg?branch=master)](https://cirrus-ci.com/github/yast/yast-packager?branch=master)
+[![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-yast-packager-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-yast-packager-master/)
+[![Coverage Status](https://coveralls.io/repos/github/yast/yast-packager/badge.svg?branch=master)](https://coveralls.io/github/yast/yast-packager?branch=master)


### PR DESCRIPTION
- Similar to https://github.com/yast/yast-storage-ng/blob/master/.cirrus.yml
- This version additionally sends the code coverage to coveralls.io
- I have disabled sending the code coverage from Travis, we do not need to send it twice to the server. (That's done by removing the `TRAVIS=1` environment.)
- Enabled `yardoc` caching in the config (so the repeated runs should be faster)
- Added CirrusCI badge to README, updated the other badges