### PR TITLE
Allow to select the license language when running in text mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# 2 space indentation
+[*.rb]
+indent_style = space
+indent_size = 2

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -4,6 +4,7 @@ Wed May 22 14:33:54 UTC 2019 - David Diaz <dgonzalez@suse.com>
 - Allow to select the license language when running in textmode
   (bsc#1135901)
 - 4.1.44
+
 -------------------------------------------------------------------
 Tue May 21 15:19:38 CEST 2019 - schubi@suse.de
 

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 22 14:33:54 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Allow to select the license language when running in textmode
+  (bsc#1135901)
+- 4.1.44
+-------------------------------------------------------------------
 Tue May 21 15:19:38 CEST 2019 - schubi@suse.de
 
 - List of Online Repositories: Overwrite already existing repos in

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -137,6 +137,7 @@ rake install DESTDIR="%{buildroot}"
 %{yast_ybindir}/*
 %{yast_yncludedir}/checkmedia/*
 %{yast_yncludedir}/packager/*
+%{yast_libdir}/language_tag.rb
 %{yast_libdir}/packager/*
 %{yast_libdir}/packager/cfa/*
 %{yast_libdir}/y2packager/*

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.43
+Version:        4.1.44
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/language_tag.rb
+++ b/src/lib/language_tag.rb
@@ -81,9 +81,10 @@ class LanguageTag
     # FIXME: or self, find out what makes more sense
   end
 
-  # @return [String,nil]
+  # @return [String,nil] a translated name, eg. "Tschechisch" for "cs" or "cs_CZ"
   def name(lang_map_cache: nil)
-    lang_map_cache ||= Yast::Language.GetLanguagesMap(false)
+    force_retranslation = false
+    lang_map_cache ||= Yast::Language.GetLanguagesMap(force_retranslation)
     attrs = lang_map_cache[@tag]
     if attrs.nil?
       # we're en, find en_US

--- a/src/lib/language_tag.rb
+++ b/src/lib/language_tag.rb
@@ -1,0 +1,99 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+# {::Comparable} enforces a total ordering, contrary to its
+# documentation, WTF.
+module PartiallyComparable
+  def <(other)
+    cmp = self.<=>(other)
+    return nil if cmp.nil?
+    cmp < 0
+  end
+
+  def >(other)
+    cmp = self.<=>(other)
+    return nil if cmp.nil?
+    cmp > 0
+  end
+
+  def <=(other)
+    cmp = self.<=>(other)
+    return nil if cmp.nil?
+    cmp <= 0
+  end
+
+  def >=(other)
+    cmp = self.<=>(other)
+    return nil if cmp.nil?
+    cmp >= 0
+  end
+
+  def ==(other)
+    return true if equal?(other) # object identity
+    cmp = self.<=>(other)
+    return nil if cmp.nil?
+    cmp == 0
+  end
+end
+
+# Language tags like "cs" "cs_CZ" "cs_CZ.UTF-8".
+#
+# FIXME: improve the simplistic string comparisons
+class LanguageTag
+  include Yast::Logger
+
+  # @param s [String]
+  def initialize(s)
+    @tag = s
+  end
+
+  def to_s
+    @tag
+  end
+
+  include PartiallyComparable
+
+  # Like with classes (where Special < General) "en_US" < "en"
+  # Mnemonics: number of speakers
+  def <=>(other)
+    return 0 if to_s == other.to_s
+    return -1 if to_s.start_with?(other.to_s)
+    return 1 if other.to_s.start_with?(to_s)
+    nil
+  end
+
+  # A more general tag: "en_US" -> "en" (-> nil)
+  # @return [LanguageTag,nil]
+  def generalize
+    self.class.new(@tag.split("_").first) if @tag.include? "_"
+    # else nil
+    # FIXME: or self, find out what makes more sense
+  end
+
+  # @return [String,nil]
+  def name(lang_map_cache: nil)
+    lang_map_cache ||= Yast::Language.GetLanguagesMap(false)
+    attrs = lang_map_cache[@tag]
+    if attrs.nil?
+      # we're en, find en_US
+      _tag, attrs = lang_map_cache.find { |k, _v| self > LanguageTag.new(k) }
+    end
+    if attrs.nil?
+      log.warn "Could not find name for language '#{@tag}'"
+      return nil
+    end
+
+    attrs[4]
+  end
+end

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -90,7 +90,7 @@ module Y2Packager
       # @return [Array<String>] Locale codes of the available translations
       # @see #default_language
       def available_locales
-        Yast::UI.TextMode ? [default_language] : product.license_locales
+        supported_language? ? product.license_locales : [default_language]
       end
 
       # License translation language
@@ -101,7 +101,7 @@ module Y2Packager
       # @return [String] License content language
       # @see #default_language
       def content_language
-        Yast::UI.TextMode ? default_language : language
+        supported_language? ? language : default_language
       end
 
       # @return [String] Fallback language
@@ -125,6 +125,16 @@ module Y2Packager
         translated = product.license_locales.any? { |l| candidate_lang.start_with?(l) }
         return candidate_lang if translated
         DEFAULT_FALLBACK_LANGUAGE
+      end
+
+      # Whether the preselected language is supported
+      #
+      # It should not allow to change the language if it is a not fbiterm supported language.
+      #
+      # @return [Boolean]
+      # @see Yast::Language.supported_language?
+      def supported_language?
+        Yast::Language.supported_language?(Yast::Language.preselected)
       end
     end
   end

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -94,7 +94,7 @@ module Y2Packager
 
       # License translation language
       #
-      # If the wanted language is presant among those displayable, use it,
+      # If the wanted language is present among those displayable, use it,
       # otherwise use the default
       #
       # @return [String] License content language

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -12,6 +12,7 @@
 
 require "yast"
 require "cwm"
+require "language_tag"
 require "y2packager/widgets/simple_language_selection"
 require "y2packager/widgets/product_license"
 
@@ -99,7 +100,8 @@ module Y2Packager
       #
       # @return [String] License content language
       def content_language
-        l = selectable_locales.find { |loc| language.start_with?(loc) }
+        # this selects "en" if we want "en_US"
+        l = selectable_locales.find { |loc| LanguageTag.new(loc) >= language }
         l || DEFAULT_FALLBACK_LANGUAGE
       end
 

--- a/src/lib/y2packager/widgets/product_license_translations.rb
+++ b/src/lib/y2packager/widgets/product_license_translations.rb
@@ -71,7 +71,7 @@ module Y2Packager
       # @return [Y2Packager::Widgets::SimpleLanguageSelection]
       def language_selection
         @language_selection ||=
-          Y2Packager::Widgets::SimpleLanguageSelection.new(available_locales, content_language)
+          Y2Packager::Widgets::SimpleLanguageSelection.new(selectable_locales, content_language)
       end
 
       # Product selection widget
@@ -82,59 +82,37 @@ module Y2Packager
           Y2Packager::Widgets::ProductLicenseContent.new(product, content_language)
       end
 
-      # Available license translations
+      # Selectable license translations
       #
-      # When running on textmode, only the preselected/given language is considered.
+      # When running on textmode, the terminal is not able to display *some* languages
       # see #default_language for further details.
       #
       # @return [Array<String>] Locale codes of the available translations
-      # @see #default_language
-      def available_locales
-        supported_language? ? product.license_locales : [default_language]
+      def selectable_locales
+        product.license_locales.find_all { |loc| displayable_language?(loc) }
       end
 
       # License translation language
       #
-      # When running on textmode, it returns the preselected/default language.
-      # see #default_language for further details.
+      # If the wanted language is presant among those displayable, use it,
+      # otherwise use the default
       #
       # @return [String] License content language
-      # @see #default_language
       def content_language
-        supported_language? ? language : default_language
+        l = selectable_locales.find { |loc| language.start_with?(loc) }
+        l || DEFAULT_FALLBACK_LANGUAGE
       end
 
       # @return [String] Fallback language
       DEFAULT_FALLBACK_LANGUAGE = "en_US".freeze
 
-      # Default language
+      # Whether a language is displayable
       #
-      # For some languages (like Japanese, Chinese or Korean) YaST needs to use a fbiterm in order
-      # to display symbols correctly when running on textmode.  However, if none of those languages
-      # is selected on boot, this special terminal won't be used.
-      #
-      # So during 1st stage and when running in textmode, it returns the preselected language (from
-      # install.inf).
-      #
-      # On an installed system, it prefers the given language. Finally, if the license translation
-      # is not available, the fallback language is returned.
-      #
-      # @return [String] Language code
-      def default_language
-        candidate_lang = Yast::Stage.initial ? Yast::Language.preselected : language
-        translated = product.license_locales.any? { |l| candidate_lang.start_with?(l) }
-        return candidate_lang if translated
-        DEFAULT_FALLBACK_LANGUAGE
-      end
-
-      # Whether the preselected language is supported
-      #
-      # It should not allow to change the language if it is a not fbiterm supported language.
-      #
+      # @param lang [String] "cs" or "cs_CZ"
       # @return [Boolean]
       # @see Yast::Language.supported_language?
-      def supported_language?
-        Yast::Language.supported_language?(Yast::Language.preselected)
+      def displayable_language?(lang)
+        Yast::Language.supported_language?(lang)
       end
     end
   end

--- a/src/lib/y2packager/widgets/simple_language_selection.rb
+++ b/src/lib/y2packager/widgets/simple_language_selection.rb
@@ -69,14 +69,11 @@ module Y2Packager
       # initial value will be set to "en_US".
       def init
         languages = items.map(&:first)
-        new_value =
-          if languages.include?(default)
-            default
-          elsif default.include?("_")    # LC#generalize ???
-            short_code = default.split("_").first
-            languages.include?(short_code) ? short_code : nil
-          end
-
+        candidates = [
+          default,
+          LanguageTag.new(default).generalize.to_s
+        ]
+        new_value = candidates.compact.find { |c| languages.include?(c) }
         self.value = new_value || DEFAULT_LICENSE_LANG
       end
 
@@ -142,6 +139,14 @@ module Y2Packager
         return -1 if to_s.start_with?(other.to_s)
         return 1 if other.to_s.start_with?(to_s)
         nil
+      end
+
+      # A more general tag: "en_US" -> "en" (-> nil)
+      # @return [LanguageTag,nil]
+      def generalize
+        self.class.new(@tag.split("_").first) if @tag.include? "_"
+        # else nil
+        # FIXME: or self, find out what makes more sense
       end
 
       # @return [String,nil]

--- a/src/lib/y2packager/widgets/simple_language_selection.rb
+++ b/src/lib/y2packager/widgets/simple_language_selection.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/widget"
+require "language_tag"
 
 Yast.import "Language"
 
@@ -96,73 +97,6 @@ module Y2Packager
         @items.reject! { |_lang, name| name.nil? }
         @items.uniq!
         @items.sort_by!(&:last)
-      end
-    end
-
-    # {::Comparable} enforces a total ordering, contrary to its
-    # documentation, WTF.
-    module PartiallyComparable
-      def <(other)
-        cmp = self.<=>(other)
-        return nil if cmp.nil?
-        cmp < 0
-      end
-
-      def >(other)
-        cmp = self.<=>(other)
-        return nil if cmp.nil?
-        cmp > 0
-      end
-    end
-
-    # Language tags like "cs" "cs_CZ" "cs_CZ.UTF-8".
-    #
-    # FIXME: improve the simplistic string comparisons
-    class LanguageTag
-      include Yast::Logger
-
-      # @param s [String]
-      def initialize(s)
-        @tag = s
-      end
-
-      def to_s
-        @tag
-      end
-
-      include PartiallyComparable
-
-      # Like with classes (where Special < General) "en_US" < "en"
-      # Mnemonics: number of speakers
-      def <=>(other)
-        return 0 if to_s == other.to_s
-        return -1 if to_s.start_with?(other.to_s)
-        return 1 if other.to_s.start_with?(to_s)
-        nil
-      end
-
-      # A more general tag: "en_US" -> "en" (-> nil)
-      # @return [LanguageTag,nil]
-      def generalize
-        self.class.new(@tag.split("_").first) if @tag.include? "_"
-        # else nil
-        # FIXME: or self, find out what makes more sense
-      end
-
-      # @return [String,nil]
-      def name(lang_map_cache: nil)
-        lang_map_cache ||= Yast::Language.GetLanguagesMap(false)
-        attrs = lang_map_cache[@tag]
-        if attrs.nil?
-          # we're en, find en_US
-          _tag, attrs = lang_map_cache.find { |k, _v| self > LanguageTag.new(k) }
-        end
-        if attrs.nil?
-          log.warn "Could not find name for language '#{@tag}'"
-          return nil
-        end
-
-        attrs[4]
       end
     end
   end

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -569,6 +569,7 @@ module Yast
 
     # FIXME: this is needed only by yast2-registration, fix it later
     # and make this method private
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def HandleLicenseDialogRet(licenses, base_product, action)
       ret = nil
 
@@ -674,7 +675,7 @@ module Yast
     # @param [Array<String>] languages list of license translations
     # @param [Boolean] back enable "Back" button
     # @param [String] license_language default license language
-    # @param [Hash<String,String>] licenses licenses (mapping "language_code" => "license")
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     # @param [String] id unique license ID
     # @param [String] caption dialog title
     def DisplayLicenseDialogWithTitle(languages, back, license_language, licenses, id, caption)
@@ -766,7 +767,7 @@ module Yast
     # update license location displayed in the dialog (e.g. after license translation
     # is changed)
     # @param [String] lang language of the currently displayed license
-    # @param [Yast::ArgRef] licenses reference to the list of licenses
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def update_license_location(lang, licenses)
       return if !location_is_url?(license_file_print) || !UI.WidgetExists(:printing_hint)
 
@@ -845,6 +846,7 @@ module Yast
       Y2Packager::Product.from_h(product_h)
     end
 
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def GetLicenseContent(lic_lang, licenses, id)
       license_file = (
         licenses_ref = arg_ref(licenses.value)
@@ -932,6 +934,7 @@ module Yast
       nil
     end
 
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def WhichLicenceFile(license_language, licenses)
       license_file = Ops.get(licenses.value, license_language, "")
 
@@ -948,6 +951,7 @@ module Yast
       license_file
     end
 
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def GetLicenseDialogTerm(languages, license_language, licenses, id)
       languages = deep_copy(languages)
       rt = (
@@ -1081,7 +1085,7 @@ module Yast
 
     # @param [Array<String>] languages list of license translations
     # @param [String] license_language default license language
-    # @param [Ref<Hash<String,String>>] licenses licenses (mapping "language_code" => "license")
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     # @param [String] id unique license ID
     # @param [Boolean] spare_space
     def GetLicenseDialog(languages, license_language, licenses, id, spare_space)
@@ -1144,6 +1148,7 @@ module Yast
     end
 
     # Displays License dialog
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def DisplayLicenseDialog(languages, back, license_language, licenses, id)
       # dialog title
       DisplayLicenseDialogWithTitle(languages, back, license_language, licenses, id,
@@ -1167,7 +1172,7 @@ module Yast
     # @param [String] dir string directory to look into
     # @param [Array<String>] patterns a list of patterns for the files, regular expressions
     #   with %1 for the language
-    # @return a map $[ lang_code : filename ]
+    # @return [Hash{String, String}] a map $[ lang_code : filename ]
     def LicenseFiles(dir, patterns)
       patterns = deep_copy(patterns)
       ret = {}
@@ -1495,6 +1500,8 @@ module Yast
       SetAcceptanceNeeded(id, license_acceptance_needed)
     end
 
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
+    # @return [:cont,:auto]
     def InitLicenseData(src_id, dir, licenses, available_langs,
       _require_agreement, _license_ident, id)
       # Downloads and unpacks all licenses for a given source ID
@@ -1595,6 +1602,7 @@ module Yast
     end
 
     # Should have been named 'UpdateLicenseContentBasedOnSelectedLanguage' :->
+    # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]
     def UpdateLicenseContent(licenses, id)
       # read the selected language
       @lic_lang = Convert.to_string(

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1083,6 +1083,11 @@ module Yast
       current_sources.any? ? current_sources.first : 0
     end
 
+    # @param [Array<String>] languages list of license translations
+    # @param [String] license_language default license language
+    # @param [Ref<Hash<String,String>>] licenses licenses (mapping "language_code" => "license")
+    # @param [String] id unique license ID
+    # @param [Boolean] spare_space
     def GetLicenseDialog(languages, license_language, licenses, id, spare_space)
       space = UI.TextMode ? 1 : 3
 

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1713,8 +1713,7 @@ module Yast
         log.info("License locales for product #{product_name.inspect}: #{locales.inspect}")
 
         locales.each do |locale|
-          license_locale = (Yast::UI.TextMode && locale.empty?) ? default_language : locale
-          license = Pkg.PrdGetLicenseToConfirm(product_name, license_locale)
+          license = Pkg.PrdGetLicenseToConfirm(product_name, locale)
           next if license.nil? || license.empty?
 
           found_license = true

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -682,18 +682,12 @@ module Yast
       languages = languages.find_all { |lang| displayable_language?(lang) }
       log.info "Displayable languages: #{languages}, wanted: #{license_language}"
 
-
-      contents = (
-        licenses_ref = arg_ref(licenses.value)
-        result = GetLicenseDialog(
-          languages,
-          license_language,
-          licenses_ref,
-          id,
-          false
-        )
-        licenses.value = licenses_ref.value
-        result
+      contents = GetLicenseDialog(
+        languages,
+        license_language,
+        licenses,
+        id,
+        false
       )
 
       Wizard.SetContents(

--- a/test/lib/cfa/zypp_conf_test.rb
+++ b/test/lib/cfa/zypp_conf_test.rb
@@ -6,8 +6,8 @@ require "packager/cfa/zypp_conf"
 require "tmpdir"
 
 describe Yast::Packager::CFA::ZyppConf do
-  ZYPP_CONF_EXAMPLE = FIXTURES_PATH.join("zypp/zypp.conf").freeze
-  ZYPP_CONF_EXPECTED = FIXTURES_PATH.join("zypp/zypp.conf.expected").freeze
+  ZYPP_CONF_EXAMPLE = DATA_PATH.join("zypp/zypp.conf").freeze
+  ZYPP_CONF_EXPECTED = DATA_PATH.join("zypp/zypp.conf.expected").freeze
 
   subject(:config) { Yast::Packager::CFA::ZyppConf.new }
   let(:zypp_conf_path) { ZYPP_CONF_EXAMPLE }
@@ -31,7 +31,7 @@ describe Yast::Packager::CFA::ZyppConf do
   describe "#save" do
     let(:tmpdir) { Dir.mktmpdir }
     let(:zypp_conf_path) { File.join(tmpdir, "zypp.conf") }
-    let(:expected_content) { File.read(FIXTURES_PATH.join("zypp/zypp.conf.expected")) }
+    let(:expected_content) { File.read(DATA_PATH.join("zypp/zypp.conf.expected")) }
 
     before do
       FileUtils.cp(ZYPP_CONF_EXAMPLE, File.join(tmpdir, "zypp.conf"))

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -17,13 +17,6 @@ require "cwm/rspec"
 require "y2packager/widgets/product_license_translations"
 require "y2packager/product"
 
-RSpec::Matchers.define :array_not_including do |x|
-  match do |actual|
-    return false unless actual.is_a?(Array)
-    !actual.include?(x)
-  end
-end
-
 describe Y2Packager::Widgets::ProductLicenseTranslations do
   include_examples "CWM::CustomWidget"
 

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -20,9 +20,7 @@ require "y2packager/product"
 RSpec::Matchers.define :array_not_including do |x|
   match do |actual|
     return false unless actual.is_a?(Array)
-    return false if actual.include?(x)
-
-    true
+    !actual.include?(x)
   end
 end
 

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -17,92 +17,76 @@ require "cwm/rspec"
 require "y2packager/widgets/product_license_translations"
 require "y2packager/product"
 
+RSpec::Matchers.define :array_not_including do |x|
+  match do |actual|
+    return false unless actual.is_a?(Array)
+    return false if actual.include?(x)
+
+    true
+  end
+end
+
 describe Y2Packager::Widgets::ProductLicenseTranslations do
   include_examples "CWM::CustomWidget"
 
   subject(:widget) { described_class.new(product, language) }
 
   let(:language) { "de_DE" }
-  let(:preselected) { "de_DE" }
-  let(:supported_language) { true }
   let(:product) do
-    instance_double(Y2Packager::Product, license_locales: ["en_US", "ja"], license: "content")
+    instance_double(
+      Y2Packager::Product,
+      license_locales: ["en_US", "de_DE", "ja_JP"],
+      license:         "content"
+    )
   end
 
   before do
-    allow(Yast::Language).to receive(:supported_language?).and_return(supported_language)
-    allow(Yast::Language).to receive(:preselected).and_return(preselected)
+    allow(Yast::Language).to receive(:supported_language?).and_return(true)
   end
 
   describe "#contents" do
     it "includes a language selector" do
       expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
-        .with(product.license_locales, language)
       widget.contents
     end
 
     it "includes the product license text" do
       expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
-        .with(product, language)
       widget.contents
     end
 
-    context "when running on textmode" do
-      let(:preselected) { "ja_JP" }
-      let(:supported_language) { false }
-
+    context "when selected language cannot be displayed" do
       before do
-        allow(Yast::UI).to receive(:TextMode).and_return(true)
-        allow(Yast::Stage).to receive(:initial).and_return(initial)
+        allow(Yast::Language).to receive(:supported_language?)
+          .with(language).and_return(false)
       end
 
-      context "on installation" do
-        let(:initial) { true }
-
-        it "the language selector includes only the preselected language" do
-          expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
-            .with([preselected], preselected)
-          widget.contents
-        end
-
-        it "shows the product license in the preselected language" do
-          expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
-            .with(product, preselected)
-          widget.contents
-        end
-
-        context "when there is no translation for the preselected language" do
-          let(:preselected) { "hu_HU" }
-
-          it "the language selector includes only 'english'" do
-            expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
-              .with(["en_US"], "en_US")
-            widget.contents
-          end
-
-          it "shows the product license in 'english'" do
-            expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
-              .with(product, "en_US")
-            widget.contents
-          end
-        end
+      it "does not include it in the language selector" do
+        expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
+          .with(array_not_including("de_DE"), anything)
+        widget.contents
       end
 
-      context "on the installed system" do
-        let(:initial) { false }
-        let(:language) { "ja_JP" }
+      it "shows the product license in the default language (AmE)" do
+        expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+          .with(product, "en_US")
+        widget.contents
+      end
+    end
 
-        it "the language selector includes only the default language" do
-          expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
-            .with([language], language)
-          widget.contents
-        end
+    context "when there is no translation for the given language" do
+      let(:language) { "hu_HU" }
 
-        it "shows the product license in the default language" do
-          expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
-            .with(product, language)
-          widget.contents
-        end
+      it "does not include it in the language selector" do
+        expect(Y2Packager::Widgets::SimpleLanguageSelection).to receive(:new)
+          .with(array_not_including("hu_HU"), anything)
+        widget.contents
+      end
+
+      it "shows the product license in the default language (AmE)" do
+        expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
+          .with(product, "en_US")
+        widget.contents
       end
     end
   end

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -23,8 +23,15 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
   subject(:widget) { described_class.new(product, language) }
 
   let(:language) { "de_DE" }
+  let(:preselected) { "de_DE" }
+  let(:supported_language) { true }
   let(:product) do
     instance_double(Y2Packager::Product, license_locales: ["en_US", "ja"], license: "content")
+  end
+
+  before do
+    allow(Yast::Language).to receive(:supported_language?).and_return(supported_language)
+    allow(Yast::Language).to receive(:preselected).and_return(preselected)
   end
 
   describe "#contents" do
@@ -42,10 +49,10 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
 
     context "when running on textmode" do
       let(:preselected) { "ja_JP" }
+      let(:supported_language) { false }
 
       before do
         allow(Yast::UI).to receive(:TextMode).and_return(true)
-        allow(Yast::Language).to receive(:preselected).and_return(preselected)
         allow(Yast::Stage).to receive(:initial).and_return(initial)
       end
 

--- a/test/lib/widgets/product_license_translations_test.rb
+++ b/test/lib/widgets/product_license_translations_test.rb
@@ -81,7 +81,7 @@ describe Y2Packager::Widgets::ProductLicenseTranslations do
         widget.contents
       end
 
-      it "shows the product license in the default language (AmE)" do
+      it "shows the product license in the default language (en_US)" do
         expect(Y2Packager::Widgets::ProductLicenseContent).to receive(:new)
           .with(product, "en_US")
         widget.contents

--- a/test/mtab_test.rb
+++ b/test/mtab_test.rb
@@ -6,7 +6,6 @@ Yast.import "Mtab"
 Yast.import "WFM"
 Yast.import "SCR"
 
-DATA_PATH = File.join(File.expand_path(File.dirname(__FILE__)), "data")
 MTABNAME = "/etc/mtab".freeze
 DESTDIR = "/mnt".freeze
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -17,16 +17,12 @@ Yast.import "Pkg"
 require "packager/product_patterns"
 
 SCR_STRING_PATH = Yast::Path.new(".target.string")
-SCR_BASH_PATH = Yast::Path.new(".target.bash")
 SCR_PROC_CMDLINE_PATH = Yast::Path.new(".proc.cmdline")
 
 CHECK_FOR_DELL_SYSTEM = Regexp.new(
   "hwinfo .*bios .*grep .*vendor:.*dell inc",
   Regexp::IGNORECASE
 )
-
-# Path to a test data - service file - mocking the default data path
-DATA_PATH = File.join(File.expand_path(File.dirname(__FILE__)), "data")
 
 def load_zypp(file_name)
   file_name = File.join(DATA_PATH, "zypp", file_name)

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -13,71 +13,23 @@ describe Yast::ProductLicense do
   subject { Yast::ProductLicense }
 
   describe "#DisplayLicenseDialogWithTitle (partial test)" do
-    context "when running in text mode" do
-      let(:langs) { ["en_US", "ja"] }
-      let(:lang) { "es_ES" }
-      let(:licenses) { Yast.arg_ref("en_US" => "en_US license") }
-      let(:license_id) { "id" }
-      let(:preselected) { "ja_JP" }
+    let(:langs) { ["en_US", "ja"] }
+    let(:lang) { "en_US" }
+    let(:licenses) { Yast.arg_ref("en_US" => "en_US license") }
+    let(:license_id) { "id" }
 
-      before do
-        allow(Yast::Language).to receive(:GetLanguagesMap).and_return({})
-        allow(Yast::UI).to receive(:TextMode).and_return(true)
-        allow(Yast::Language).to receive(:preselected).and_return(preselected)
-        allow(Yast::Stage).to receive(:initial).and_return(initial)
-        allow(Yast::Language).to receive(:language).and_return(lang)
-      end
+    before do
+      allow(Yast::Language).to receive(:GetLanguagesMap).and_return({})
+      allow(Yast::Language).to receive(:supported_language?).and_return(true)
+    end
 
-      context "on the installation" do
-        let(:initial) { true }
-
-        it "uses the preselected language" do
-          expect(subject).to receive(:GetLicenseDialog)
-            .with(["ja"], "ja", anything, license_id, false)
-            .and_call_original
-          subject.DisplayLicenseDialogWithTitle(
-            langs, "Back", lang, licenses, license_id, "License"
-          )
-        end
-
-        context "when there is no translation for the preselected language" do
-          let(:preselected) { "es_ES" }
-
-          it "falls back to 'english'" do
-            expect(subject).to receive(:GetLicenseDialog)
-              .with(["en_US"], "en_US", anything, license_id, false)
-              .and_call_original
-            subject.DisplayLicenseDialogWithTitle(
-              langs, "Back", lang, licenses, license_id, "License"
-            )
-          end
-        end
-      end
-
-      context "on the installed system" do
-        let(:initial) { false }
-        let(:lang) { "ja_JP" }
-
-        it "uses the default language" do
-          expect(subject).to receive(:GetLicenseDialog)
-            .with(["ja"], "ja", anything, license_id, false)
-          subject.DisplayLicenseDialogWithTitle(
-            langs, "Back", lang, licenses, license_id, "License"
-          )
-        end
-
-        context "when there is no translation for the default language" do
-          let(:lang) { "es_ES" }
-
-          it "falls back to 'english'" do
-            expect(subject).to receive(:GetLicenseDialog)
-              .with(["en_US"], "en_US", anything, license_id, false)
-            subject.DisplayLicenseDialogWithTitle(
-              langs, "Back", lang, licenses, license_id, "License"
-            )
-          end
-        end
-      end
+    it "works" do
+      expect(subject).to receive(:GetLicenseDialog)
+        .with(["en_US", "ja"], "en_US", anything, license_id, false)
+        .and_call_original
+      subject.DisplayLicenseDialogWithTitle(
+        langs, "Back", lang, licenses, license_id, "License"
+      )
     end
   end
 

--- a/test/space_calculation_test.rb
+++ b/test/space_calculation_test.rb
@@ -9,9 +9,7 @@ Yast.import "Mode"
 Yast.import "SCR"
 Yast.import "SpaceCalculation"
 
-DATA_PATH = File.join(File.expand_path(File.dirname(__FILE__)), "data")
 SCR_TMPDIR_PATH = Yast::Path.new(".target.tmpdir")
-SCR_BASH_PATH = Yast::Path.new(".target.bash")
 SCR_BASH_OUTPUT_PATH = Yast::Path.new(".target.bash_output")
 
 def stub_devicegraph(name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,13 @@ RSpec.configure do |config|
   config.include Yast::I18n # available in it/let/before/...
 end
 
+RSpec::Matchers.define :array_not_including do |x|
+  match do |actual|
+    return false unless actual.is_a?(Array)
+    !actual.include?(x)
+  end
+end
+
 # stub module to prevent its Import
 # Useful for modules from different yast packages, to avoid build dependencies
 def stub_module(name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,9 @@ require "yast/rspec"
 require "pathname"
 
 TESTS_PATH = Pathname.new(File.dirname(__FILE__))
-FIXTURES_PATH = TESTS_PATH.join("data")
+DATA_PATH = TESTS_PATH.join("data")
+
+SCR_BASH_PATH = Yast::Path.new(".target.bash")
 
 RSpec.configure do |config|
   config.extend Yast::I18n  # available in context/describe


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1135901 (was P1)
- https://trello.com/c/pfv5PzvU

Problem: Only in the text mode installation, we cannot switch the language of a product license. Both for the main product and add-on products. [bsc#1135901](https://bugzilla.suse.com/show_bug.cgi?id=1135901)

Reason: That's on purpose, since on the Linux console we're not able to display the characters of most languages, [bsc#1094793](https://bugzilla.suse.com/show_bug.cgi?id=1094793). But wait, recently we have switched to starting fbiterm unconditionally, so we are in fact able to display all languages that currently have license translations. So let's enable the language switch.
