### PR TITLE
Decrease the required memory limit back (bsc#1132650)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May 28 07:12:10 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- With the previous fix 1GB RAM is enough for using the online
+  repositories, decrease the required memory limit (remove the
+  workaround for bsc#1132650)
+- 4.2.9
+
+-------------------------------------------------------------------
 Thu May 23 12:03:23 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added new Y2packager::Resolvables class

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.8
+Version:        4.2.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -94,8 +94,8 @@ module Yast
     include Yast::Logger
 
     # too low memory for using online repositories (in MiB),
-    # at least 1.5GiB is recommended
-    LOW_MEMORY_MIB = 1536
+    # at least 1GiB is recommended
+    LOW_MEMORY_MIB = 1024
     # variable to set target release version ( useful during upgrade when
     # we want new target in releaseversion and not old one )
     RELEASEVER_ENV = "ZYPP_REPO_RELEASEVER".freeze


### PR DESCRIPTION
- Remove the workaround, after merging PR #442 1GB RAM is again enough
- 4.2.9