### PR TITLE
Sle 15 sp1 bsc 1136708

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,7 +2,7 @@
 Mon Jun 17 17:15:29 CEST 2019 - schubi@suse.de
 
 - Package installation: Rebuild slide show dialog and enable
-  realease tab (bsc#1136708).
+  realease notes tab (bsc#1136708).
 - 4.1.44
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 17 17:15:29 CEST 2019 - schubi@suse.de
+
+- Rebuild slide show dialog and enable realease tab.
+  (bsc#1136708)
+- 4.1.44
+
+-------------------------------------------------------------------
 Tue May 21 15:19:38 CEST 2019 - schubi@suse.de
 
 - List of Online Repositories: Overwrite already existing repos in

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Mon Jun 17 17:15:29 CEST 2019 - schubi@suse.de
 
-- Rebuild slide show dialog and enable realease tab.
-  (bsc#1136708)
+- Package installation: Rebuild slide show dialog and enable
+  realease tab (bsc#1136708).
 - 4.1.44
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -35,8 +35,8 @@ BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
 
-# Y2Packager::will_be_obsoleted_by
-BuildRequires:  yast2 >= 4.1.68
+# inst_rpmcopy.rb: SlideShow.RebuildDialog(true)
+BuildRequires:  yast2 >= 4.1.71
 
 # Pkg::PrdLicenseLocales
 BuildRequires:  yast2-pkg-bindings >= 4.0.8
@@ -50,8 +50,8 @@ Requires:       yast2-country-data >= 2.16.3
 # Pkg::PrdLicenseLocales
 Requires:       yast2-pkg-bindings >= 4.0.8
 
-# Y2Packager::will_be_obsoleted_by
-Requires:       yast2 >= 4.1.68
+# inst_rpmcopy.rb: SlideShow.RebuildDialog(true)
+Requires:       yast2 >= 4.1.71
 
 # unzipping license file
 Requires:       unzip

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.43
+Version:        4.1.44
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_rpmcopy.rb
+++ b/src/clients/inst_rpmcopy.rb
@@ -132,6 +132,9 @@ module Yast
       # move the progress to the packages stage
       SlideShow.MoveToStage("packages")
 
+      # (true) : Showing release tab if needed
+      SlideShow.RebuildDialog(true)
+
       # bnc#875350: Log the current user/app_high software selection
       Packages.log_software_selection
 

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -480,8 +480,6 @@ module Yast
         @total_pkg_count_per_cd_per_src
       )
 
-      # RebuildDialog(true);
-
       nil
     end
 
@@ -552,7 +550,8 @@ module Yast
 
       if Slides.HaveSlides && Slides.HaveSlideSupport
         if !SlideShow.HaveSlideWidget
-          SlideShow.RebuildDialog
+          # (true) : Showing release tab if needed
+          SlideShow.RebuildDialog(true)
 
           SlideShow.SwitchToDetailsView if SlideShow.user_switched_to_details
         end
@@ -560,7 +559,8 @@ module Yast
         # Don't override explicit user request!
         SlideShow.SwitchToSlideView if !SlideShow.user_switched_to_details
       elsif !SlideShow.ShowingDetails
-        SlideShow.RebuildDialog
+        # (true) : Showing release tab if needed
+        SlideShow.RebuildDialog(true)
       end
 
       nil


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1136708
- https://trello.com/c/hirlFUmw

While showing the slideshow different YAST modules will be called:
Calling YaST client inst_prepareprogress
Calling YaST client wrapper_slideshow_callbacks
Calling YaST client inst_prepdisk
Calling YaST client inst_instsys_cleanup
Calling YaST client inst_kickoff
Calling YaST client inst_bootloader
Calling YaST client inst_rpmcopy
...
..
.
The problem is that not each of these modules handles UI callbacks. Switching to another tab like the release notes tab will not be supported there.
With this fix the release tab will be shown only while RPM packages will be installed. So it will be shown 3-4 seconds after starting the installation.
