### PR TITLE
[SLE-15-SP1] Allow to use "refuse" as a cancel action

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 20 14:11:46 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Better handling of license agreement dialog, allowing to
+  distinguish when the user is declining a license or aborting
+  the installation (bsc#1114018)
+- 4.1.47
+
+-------------------------------------------------------------------
 Mon Jun 17 17:15:29 CEST 2019 - schubi@suse.de
 
 - Package installation: Rebuild slide show dialog and enable

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.46
+Version:        4.1.47
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -186,12 +186,10 @@ module Yast
         try_again(url, scheme) ? :again : :cancel
       else
         Progress.NextStage
-        license_accepted = true
         Builtins.foreach(newSources) do |id|
           if !LicenseAccepted(id)
             log.info("License NOT accepted, removing the source")
             Pkg.SourceDelete(id)
-            license_accepted = false
           else
             src_data = Pkg.SourceGeneralData(id)
             log.info("Addded repository: #{src_data}")
@@ -207,7 +205,7 @@ module Yast
           end
         end
 
-        license_accepted ? :ok : :abort
+        :ok
       end
     ensure
       # relese (unmount) the medium

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -559,7 +559,7 @@ module Yast
       ret = ProductLicense.AskAddOnLicenseAgreement(src_id)
       return nil if ret.nil?
 
-      if ret == :abort || ret == :back
+      if [:refused, :abort, :back].include?(ret)
         Builtins.y2milestone("License confirmation failed")
         return false
       end

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -416,7 +416,7 @@ module Yast
         src_id,
         "",
         @license_patterns,
-        "abort",
+        "refuse",
         # back button is disabled
         false,
         false,

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -635,6 +635,8 @@ module Yast
           log.info "License has been declined."
 
           case action
+          when "refuse"
+            ret = :refused
           when "abort"
             ret = :abort
           when "halt"

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -146,28 +146,53 @@ describe Yast::ProductLicense do
       end
 
       context "while some license(s) have not been accepted" do
-        it "returns symbol :abort, :accepted, :refused, :halt according to the third function parameter" do
+        let(:base_prod) { false }
+
+        before do
           expect(Yast::ProductLicense).to receive(:AllLicensesAccepted).and_return(false)
             .at_least(:once)
           # :halt case
           allow(Yast::ProductLicense).to receive(:TimedOKCancel).and_return(true)
+        end
 
-          base_prod = false
-          expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "continue"))
-            .to eq(:accepted)
-          expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "refuse"))
-            .to eq(:refused)
-          expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "abort"))
-            .to eq(:abort)
-          expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "halt"))
-            .to eq(:halt)
-          expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "unknown"))
-            .to eq(:abort)
+        context "when cancel action is 'continue'" do
+          it "returns :accepted" do
+            expect(Yast::ProductLicense
+              .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "continue"))
+              .to eq(:accepted)
+          end
+        end
+
+        context "when cancel action is 'refuse'" do
+          it "returns :refused" do
+            expect(Yast::ProductLicense
+              .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "refuse"))
+              .to eq(:refused)
+          end
+        end
+
+        context "when cancel action is 'abort'" do
+          it "returns :abort" do
+            expect(Yast::ProductLicense
+              .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "abort"))
+              .to eq(:abort)
+          end
+        end
+
+        context "when cancel action is 'halt'" do
+          it "returns :halt" do
+            expect(Yast::ProductLicense
+              .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "halt"))
+              .to eq(:halt)
+          end
+        end
+
+        context "when cancel action is unknown" do
+          it "returns :abort" do
+            expect(Yast::ProductLicense
+              .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "whaterver"))
+              .to eq(:abort)
+          end
         end
       end
     end

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -146,7 +146,7 @@ describe Yast::ProductLicense do
       end
 
       context "while some license(s) have not been accepted" do
-        it "returns symbol :abort, :accepted, :halt according to the third function parameter" do
+        it "returns symbol :abort, :accepted, :refused, :halt according to the third function parameter" do
           expect(Yast::ProductLicense).to receive(:AllLicensesAccepted).and_return(false)
             .at_least(:once)
           # :halt case
@@ -154,11 +154,14 @@ describe Yast::ProductLicense do
 
           base_prod = false
           expect(Yast::ProductLicense
-            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "abort"))
-            .to eq(:abort)
-          expect(Yast::ProductLicense
             .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "continue"))
             .to eq(:accepted)
+          expect(Yast::ProductLicense
+            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "refuse"))
+            .to eq(:refused)
+          expect(Yast::ProductLicense
+            .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "abort"))
+            .to eq(:abort)
           expect(Yast::ProductLicense
             .send(:HandleLicenseDialogRet, licenses_ref, base_prod, "halt"))
             .to eq(:halt)

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -111,13 +111,12 @@ describe "PackagerRepositoriesIncludeInclude" do
       expect(ret).to eq(:ok)
     end
 
-    it "returns :abort and removes the repository if license is rejected" do
+    it "removes the repository if license is rejected" do
       expect(Yast::AddOnProduct).to receive(:AcceptedLicenseAndInfoFile)
         .with(repo_id).and_return(false)
       expect(Yast::Pkg).to receive(:SourceDelete).with(repo_id)
 
-      ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
-      expect(ret).to eq(:abort)
+      RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
     end
 
     context "more products available on the medium" do


### PR DESCRIPTION
#### :warning: Similar to #452, but for SLE-15-SP1 :warning: ####

## Problem

The `ProductLicense.HandleLicenseDialogRet` do not have a cancel action to indicate that the user wants to refuse an EULA.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1114018.

## Solution

To give support for a "refuse" cancel action, **and use it when asking for an AddOn license agreement** (see https://github.com/yast/yast-add-on/pull/78).

## Tests

* Added and updated some unit tests.
* Also tested manually via driver update.