### PR TITLE
Fix changelog

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,10 +1,11 @@
 -------------------------------------------------------------------
-Tue Jun 18 08:59:39 UTC 2019 - David Diaz <dgonzalez@suse.com>
+Tue Jun 21 08:59:39 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Better handling of license agreement dialog, allowing to
   distinguish when the user is declining a license or aborting
   the installation (bsc#1114018)
 - 3.3.1
+
 -------------------------------------------------------------------
 Thu Jun 20 13:47:59 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 


### PR DESCRIPTION
## Problem

>  error: %changelog not in descending chronological

when trying to do a SR.

## Why?

I didn't realize about the wrong chronological order in the changelog entries at the time to [solve the conflicts](https://github.com/yast/yast-packager/compare/ee5561160fa27c40ad07f5758cb70e3197572f9b..250227ae0ac439df935d1eb562da63750b414eed) when merging https://github.com/yast/yast-packager/pull/452

## Solution

To modify the date of last entry.