### PR TITLE
Fixed an unit test to work also on non-x86_64 archs

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 15 14:02:57 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed the unit test for the previous change to work also on
+  other architectures than x86_64 (related to bsc#1141414)
+- 4.2.18
+
+-------------------------------------------------------------------
 Thu Jul 11 07:17:45 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improved product selection for multi-repositories media

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.17
+Version:        4.2.18
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/product_location_test.rb
+++ b/test/product_location_test.rb
@@ -10,14 +10,24 @@ def find_product(arr, product)
   arr.find { |p| p.details.product == product }
 end
 
-# loading all repositories and evaluating the product dependencies
-# using the solver takes some time, run it only once and cache
-# the result for all tests
-dir = File.join(__dir__, "data/zypp/test_offline_repo")
-repo_url = "dir://#{URI.escape(dir)}"
-scan_result = Y2Packager::ProductLocation.scan(repo_url)
+# URL of the local testing repository
+REPO_URL = "dir://#{URI.escape(File.join(DATA_PATH, "zypp/test_offline_repo"))}".freeze
 
 describe Y2Packager::ProductLocation do
+  let(:scan_result) { Y2Packager::ProductLocation.scan(REPO_URL) }
+
+  before do
+    # the testing repository only contains the x86_64 packages/products
+    # and the solver ignores the packages for incompatible architectures,
+    # that means the test would fail anywhere except on x86_64.
+    #
+    # So we modify the "setarch" call to always pass the "x86_64" parameter.
+    allow_any_instance_of(::Solv::Pool).to receive(:setarch)
+      .and_wrap_original do |method, *_args|
+        method.call("x86_64")
+      end
+  end
+
   describe ".scan" do
     it "finds all product repositories" do
       # there are 3 testing product repositories


### PR DESCRIPTION
- The testing repository metadata contains only the x86_64 packages.
- Because the solver ignores the incompatible packages the test failed on archs other than x86_64.
- We need to mock the `Solv::Poll.setarch` call to always pass the `x86_64` string to always set the x86_64 architecture during the tests.
- That required a small refactoring in the test and we cannot cache the call (we need to add the mock before running the tests), it's a bit slower now. But not much, on my fast machine it's about from 0.4s to 1.3s, that's acceptable.
- Tested manually with the `osc build openSUSE_Tumbleweed i586` command
- Travis still fails as OBS has not rebuilt the packages yet. :worried:  Works fine locally.