### PR TITLE
Add #summary method

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 23 10:25:51 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Add method to get the summary of a product (bsc#1142414).
+- 4.2.19
+
+-------------------------------------------------------------------
 Mon Jul 15 14:02:57 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed the unit test for the previous change to work also on

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -83,7 +83,7 @@ module Y2Packager
     #
     # @return [String, nil] nil if there is no details or details does not contain a summary
     def summary
-      return nil if details.nil? || details.summary.empty?
+      return nil if !details&.summary || details.summary.empty?
 
       details.summary
     end

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -78,5 +78,14 @@ module Y2Packager
       @dir = dir
       @details = product
     end
+
+    # Product summary taken from its details
+    #
+    # @return [String, nil] nil if there is no details or details does not contain a summary
+    def summary
+      return nil if details.nil? || details.summary.empty?
+
+      details.summary
+    end
   end
 end

--- a/test/product_location_test.rb
+++ b/test/product_location_test.rb
@@ -84,6 +84,14 @@ describe Y2Packager::ProductLocation do
     context "when there is details" do
       let(:product) { instance_double(Y2Packager::ProductLocationDetails, summary: summary) }
 
+      context "and the summary is nil" do
+        let(:summary) { nil }
+
+        it "returns nil" do
+          expect(subject.summary).to be_nil
+        end
+      end
+
       context "and the summary is empty" do
         let(:summary) { "" }
 

--- a/test/product_location_test.rb
+++ b/test/product_location_test.rb
@@ -69,4 +69,36 @@ describe Y2Packager::ProductLocation do
       )
     end
   end
+
+  describe "#summary" do
+    subject { described_class.new("foo", "/dir/foo", product: product) }
+
+    context "when there is no details" do
+      let(:product) { nil }
+
+      it "returns nil" do
+        expect(subject.summary).to be_nil
+      end
+    end
+
+    context "when there is details" do
+      let(:product) { instance_double(Y2Packager::ProductLocationDetails, summary: summary) }
+
+      context "and the summary is empty" do
+        let(:summary) { "" }
+
+        it "returns nil" do
+          expect(subject.summary).to be_nil
+        end
+      end
+
+      context "and the summary has content" do
+        let(:summary) { "a summary" }
+
+        it "returns the summary content" do
+          expect(subject.summary).to eq(summary)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Method `ProductLocation#summary` was missing.

https://bugzilla.suse.com/show_bug.cgi?id=1142414

Related to: https://github.com/yast/yast-packager/pull/459