### PR TITLE
Set the proper release version always

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 25 16:31:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Set the proper release version for newly added repos always, not
+  only during upgrade (bsc#1132748).
+- 4.1.48
+
+-------------------------------------------------------------------
 Thu Jun 20 14:11:46 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Better handling of license agreement dialog, allowing to

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.47
+Version:        4.1.48
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -140,9 +140,9 @@ module Yast
         return :auto
       end
 
-      # set release version for update as for newly added repositories
+      # Set the proper release version for newly added repositories
       # we want to use new product and not old
-      ENV[RELEASEVER_ENV] = Product.version if Mode.update
+      ENV[RELEASEVER_ENV] = Product.version
 
       # (Applicable only in inst-sys)
       @preselect_recommended = true

--- a/test/lib/clients/inst_productsources_test.rb
+++ b/test/lib/clients/inst_productsources_test.rb
@@ -17,6 +17,14 @@ describe Yast::InstProductsourcesClient do
       allow(Yast::Product).to receive(:version).and_return(product_version)
     end
 
+    around do |test|
+      previous_env = ENV.to_hash
+
+      test.run
+
+      ENV.replace(previous_env)
+    end
+
     it "returns :auto if AddOnProduct is set to skip" do
       allow(Yast::AddOnProduct).to receive(:skip_add_ons).and_return(true)
 

--- a/test/lib/clients/inst_productsources_test.rb
+++ b/test/lib/clients/inst_productsources_test.rb
@@ -50,14 +50,10 @@ describe Yast::InstProductsourcesClient do
       client.main
     end
 
-    it "sets the RELEASEVER_ENV to Product.version" do
-      stub_const("#{described_class}::RELEASEVER_ENV", "ZYPP_RELEASEVER_ENV")
-
-      expect(ENV[described_class::RELEASEVER_ENV]).to be_nil
+    it "sets the ZYPP_REPO_RELEASEVER environment variable to Product.version" do
+      expect(ENV).to receive(:[]=).with("ZYPP_REPO_RELEASEVER", "15.1")
 
       client.main
-
-      expect(ENV[described_class::RELEASEVER_ENV]).to eq(product_version)
     end
   end
 

--- a/test/lib/clients/inst_productsources_test.rb
+++ b/test/lib/clients/inst_productsources_test.rb
@@ -7,11 +7,14 @@ Yast.import "SourceManager"
 describe Yast::InstProductsourcesClient do
   subject(:client) { described_class.new }
 
+  let(:product_version) { "15.1" }
+
   describe "#main" do
     before do
       allow(Yast::Sequencer).to receive(:Run)
       allow(Yast::Wizard).to receive(:OpenDialog)
       allow(Yast::Wizard).to receive(:CloseDialog)
+      allow(Yast::Product).to receive(:version).and_return(product_version)
     end
 
     it "returns :auto if AddOnProduct is set to skip" do
@@ -45,6 +48,16 @@ describe Yast::InstProductsourcesClient do
       allow(Yast::Mode).to receive(:normal).and_return(true)
 
       client.main
+    end
+
+    it "sets the RELEASEVER_ENV to Product.version" do
+      stub_const("#{described_class}::RELEASEVER_ENV", "ZYPP_RELEASEVER_ENV")
+
+      expect(ENV[described_class::RELEASEVER_ENV]).to be_nil
+
+      client.main
+
+      expect(ENV[described_class::RELEASEVER_ENV]).to eq(product_version)
     end
   end
 


### PR DESCRIPTION
## Problem

> #TODO: explain the problem

* https://bugzilla.suse.com/show_bug.cgi?id=1132748
## Solution

Set the `RELEASEVER_ENV` environment variable **always**, not only during the upgrade.

## See also

[This comment](https://github.com/yast/yast-packager/pull/383#pullrequestreview-170590620) in #383,  where this _feature_ was introduced only for the `update` mode.
