### PR TITLE
Fixed product selection for single repositories (related to bsc#1141414)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul 26 11:28:16 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed product selection for single repositories: do not scan
+  the products when there is only one repository, the scan is not
+  needed (related to bsc#1141414)
+- 4.2.22
+
+-------------------------------------------------------------------
 Thu Jul 25 16:31:05 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Set the proper release version for newly added repos always, not

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -33,8 +33,10 @@ module Y2Packager
     attr_reader :details
 
     #
-    # Scan the URL for the available product subdirectories
-    # and their products.
+    # Scan the URL for the available product subdirectories and their products.
+    # If there is none or only one repository at the URL it returns empty list.
+    # Scanning the product details is not needed because there is nothing to
+    # select from, that one repository will be used without asking.
     #
     # @param url [String] The base repository URL
     # @param base_product [String,nil]  The base product used for evaluating the
@@ -47,6 +49,10 @@ module Y2Packager
       log.info "Scanning #{Yast::URL.HidePassword(url)} for products..."
 
       downloader = Y2Packager::RepomdDownloader.new(url)
+      # Skip the scan if there is none or just one repository, the repository selection
+      # is displayed only when there are at least 2 repositories.
+      return [] if downloader.product_repos.size < 2
+
       pool = Y2Packager::SolvablePool.new
 
       repomd_files = downloader.primary_xmls

--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -34,14 +34,15 @@ module Y2Packager
     #
     # Scan the product directories at the URL
     #
-    # @return [Array<Array<String,String>>] List of pairs [<product_name>, <directory>]
+    # @return [Array<Array<String,String>>] List of pairs [<product_name>, <directory>],
+    #   returns empty list if the repository scan fails
     #
     def product_repos
       return @product_repos if @product_repos
 
       # expand the URL and scan the repositories on the medium
       expanded_url = Yast::Pkg.ExpandedUrl(url)
-      @product_repos = Yast::Pkg.RepositoryScan(expanded_url)
+      @product_repos = Yast::Pkg.RepositoryScan(expanded_url) || []
     end
 
     #
@@ -61,7 +62,7 @@ module Y2Packager
     #   returns an empty list if the URL or the repository is not valid.
     #
     def primary_xmls
-      return [] if product_repos.nil? || product_repos.empty?
+      return [] if product_repos.empty?
 
       # add a temporary repository for downloading the files via libzypp
       src = Yast::Pkg.RepositoryAdd("base_urls" => [url])

--- a/test/product_location_test.rb
+++ b/test/product_location_test.rb
@@ -68,6 +68,16 @@ describe Y2Packager::ProductLocation do
         ["/Module-Basesystem", "/Product-SLES"]
       )
     end
+
+    it "return empty list when there is only one repository" do
+      expect(Yast::Pkg).to receive(:RepositoryScan).and_return([["/", "Foo product"]])
+      expect(described_class.scan(REPO_URL)).to eq([])
+    end
+
+    it "return empty list when there is none repository found" do
+      expect(Yast::Pkg).to receive(:RepositoryScan).and_return([])
+      expect(described_class.scan(REPO_URL)).to eq([])
+    end
   end
 
   describe "#summary" do


### PR DESCRIPTION
## The Problem

- This openQA test failed: https://openqa.suse.de/tests/3132341#step/addon_products_sle/48
- The problem is that the Baseproduct module is displayed twice
- Actually the dialog should not be displayed at the first place. When there is only one repository/product at  the URL is should be used automatically without asking the user 

![add_selection_broken](https://user-images.githubusercontent.com/907998/61949285-9cb63a00-afaa-11e9-92ea-e585556227fb.png)

## The Solution

- Do not scan the products when there is only one repository,  the scan is not needed, user is not asked to select a product/repository in that case anyway.

## Tests

- Added unit tests
- Tested manually with the same testing repository as used by openQA, the dialog is skipped
