### PR TITLE
Fix the forced base product selection (2/3)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  5 08:23:58 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Select the forced base product during the repositories
+  initialization (bsc#1124590, bsc#1143943).
+- 4.2.23
+
+-------------------------------------------------------------------
 Fri Jul 26 11:28:16 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed product selection for single repositories: do not scan

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -47,8 +47,8 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # Pkg::Resolvables
 Requires:       yast2-pkg-bindings >= 4.2.0
-# inst_rpmcopy.rb: SlideShow.RebuildDialog(true)
-Requires:       yast2 >= 4.2.8
+# Y2Packager::Product.forced_base_product
+Requires:       yast2 >= 4.2.17
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.22
+Version:        4.2.23
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -88,7 +88,14 @@ module Y2Packager
       # @see https://github.com/yast/yast-packager/blob/7e1a0bbb90823b03c15d92f408036a560dca8aa3/src/modules/Packages.rb#L1876
       # @see https://github.com/yast/yast-packager/blob/fbc396df910e297915f9f785fc460e72e30d1948/src/modules/Packages.rb#L1905
       def adjust_base_product_selection
-        if products.size == 1
+        if forced_base_product
+          log.info("control.xml wants to force the #{forced_base_product.name} product")
+
+          forced_base_product.select
+          discarded_products = products.reject { |p| p == forced_base_product }
+
+          log.info("Ignoring the other products: #{discarded_products.map(&:name).join(", ")}")
+        elsif products.size == 1
           products.first.select
         else
           products.each(&:restore)
@@ -100,6 +107,13 @@ module Y2Packager
       # @return [Array<Y2Product>] Available base products
       def products
         @products ||= Y2Packager::Product.available_base_products
+      end
+
+      # Return the forced base product (if any)
+      #
+      # @return [Y2Product, nil]
+      def forced_base_product
+        @forced_base_product ||= Y2Packager::Product.forced_base_product
       end
     end
   end

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -88,13 +88,15 @@ module Y2Packager
       # @see https://github.com/yast/yast-packager/blob/7e1a0bbb90823b03c15d92f408036a560dca8aa3/src/modules/Packages.rb#L1876
       # @see https://github.com/yast/yast-packager/blob/fbc396df910e297915f9f785fc460e72e30d1948/src/modules/Packages.rb#L1905
       def adjust_base_product_selection
+        forced_base_product = Y2Packager::Product.forced_base_product
+
         if forced_base_product
           log.info("control.xml wants to force the #{forced_base_product.name} product")
 
           forced_base_product.select
           discarded_products = products.reject { |p| p == forced_base_product }
 
-          log.info("Ignoring the other products: #{discarded_products.map(&:name).join(", ")}")
+          log.info("Ignoring the other products: #{discarded_products.inspect}")
         elsif products.size == 1
           products.first.select
         else
@@ -107,13 +109,6 @@ module Y2Packager
       # @return [Array<Y2Product>] Available base products
       def products
         @products ||= Y2Packager::Product.available_base_products
-      end
-
-      # Return the forced base product (if any)
-      #
-      # @return [Y2Product, nil]
-      def forced_base_product
-        @forced_base_product ||= Y2Packager::Product.forced_base_product
       end
     end
   end

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -7,8 +7,8 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
   subject(:client) { described_class.new }
 
   let(:success) { true }
-  let(:prod1) { instance_double(Y2Packager::Product, select: nil) }
-  let(:prod2) { instance_double(Y2Packager::Product, select: nil) }
+  let(:prod1) { instance_double(Y2Packager::Product, name: "Prod1", select: nil) }
+  let(:prod2) { instance_double(Y2Packager::Product, name: "Prod2", select: nil) }
   let(:products) { [prod1] }
 
   describe "#main" do
@@ -16,6 +16,7 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       allow(Yast::Packages).to receive(:InitializeCatalogs)
       allow(Yast::Packages).to receive(:InitializeAddOnProducts)
       allow(Yast::Packages).to receive(:InitFailed).and_return(!success)
+      allow(Y2Packager::Product).to receive(:forced_base_product)
       allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
       allow(Y2Packager::SelfUpdateAddonRepo).to receive(:present?).and_return(false)
     end
@@ -59,6 +60,19 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
 
       it "selects the product for installation" do
         expect(prod1).to receive(:select)
+        client.main
+      end
+    end
+
+    context "when a product is forced to be used" do
+      let(:products) { [prod1, prod2] }
+
+      before do
+        allow(Y2Packager::Product).to receive(:forced_base_product).and_return(prod2)
+      end
+
+      it "selects the product for installation" do
+        expect(prod2).to receive(:select)
         client.main
       end
     end


### PR DESCRIPTION
## Problem

Recently, the `select_product` option was added to the control file to allow **forcing** the base product selection when having multiple products in a single repository (see https://github.com/yast/yast-installation/pull/790).

But seems that the feature was not fully implemented and the installer only avoids displaying the product selector, but not marking the forced product as selected, raising an internal error when trying to access to `#installation_package`.

* https://bugzilla.suse.com/show_bug.cgi?id=1143943
* https://trello.com/c/YuiJfYBt/1201-ostumbleweed-p1-1143943-build-20190801-undefined-method-installationpackage

## Solution

To select the **foced** product properly.

:warning: **Requires `yast2 4.2.17` - https://github.com/yast/yast-yast2/pull/954**

## Additional notes

See https://github.com/yast/yast-yast2/pull/954 for more information and screenshots.
