### PR TITLE
Pattern deselection (SP5)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  5 18:36:42 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Better handle unselecting the default pre-selected patterns
+  by the user (bsc#1140735)
+- 3.3.2
+
+-------------------------------------------------------------------
 Tue Jun 21 08:59:39 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Better handling of license agreement dialog, allowing to

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.3.1
+Version:        3.3.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_sw_select.rb
+++ b/src/clients/inst_sw_select.rb
@@ -48,6 +48,9 @@ module Yast
             # from scratch. See BNC #436925.
             Packages.ResetProposalCache
 
+            # avoid selecting again the unselected patterns
+            Packages.RememberNotSelectedPatterns
+
             Packages.base_selection_modified = true
             @ret = :next
             Packages.solve_errors = 0 # all have been either solved


### PR DESCRIPTION
## Problem

- After deselecting the X11 and the GNOME patterns (in this order!) YaST selects the X11 pattern back when confirming the changes and going back to the installation proposal.
- The YaST code already does not select again the patterns which have been unselected byt the user. However, the problem is that the solver looses the information that the X11 pattern was unselected by the user, it becomes unselected by the solver (because of the GNOME -> X11 dependency).

![pattern_deselection](https://user-images.githubusercontent.com/907998/62487591-88e8b000-b7c2-11e9-9aa6-bf6f7f7d0ab1.png)

![pattern_deselection_broken](https://user-images.githubusercontent.com/907998/62487710-cbaa8800-b7c2-11e9-89c8-87ade01367d8.png)


## Fix

- Because the package manager is reset at some point we have to call the pattern selection again. (My first attempt was to select the patterns only once and dot select them again. But that did not work well, in the end no pattern was selected.)
- To avoid selecting the unselected patterns we need to remember the unselected patterns when leaving the package manager UI. Later we do not select them again.
- Tested manually, after unselecting both patterns the X11 pattern is not selected again and the other default patterns are correctly selected.

![pattern_deselection_fixed](https://user-images.githubusercontent.com/907998/62487850-293ed480-b7c3-11e9-8f4c-27cf407425ed.png)

