### PR TITLE
Fix message error

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 28 12:59:14 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Avoid error when generating some warnings (bsc#1148536).
+- 4.2.24
+
+-------------------------------------------------------------------
 Mon Aug  5 08:23:58 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Select the forced base product during the repositories

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/software_proposal.rb
+++ b/src/lib/packager/clients/software_proposal.rb
@@ -125,11 +125,13 @@ module Yast
   private
 
     # @param msg [String] warning message to be added
+    #
+    # @note The message could be a frozen string (e.g., translated messages).
     def add_warning_if_needed(msg)
       return if msg.empty?
 
       if @ret.key?("warning")
-        @ret["warning"] << "\n#{msg}"
+        @ret["warning"] += "\n#{msg}"
       else
         @ret["warning"] = msg
       end

--- a/test/lib/clients/software_proposal_test.rb
+++ b/test/lib/clients/software_proposal_test.rb
@@ -76,9 +76,17 @@ describe Yast::SoftwareProposalClient do
       end
 
       it "returns warning message if second stage is not possible" do
+        # Note that translated errors can be frozen strings
+        error_message1 = "first_error".freeze
+        error_message2 = "second_error".freeze
+
+        allow(Yast::Packages).to receive(:check_remote_installation_packages)
+          .and_return(error_message1)
+
         allow(Yast::AutoinstData).to receive(:autoyast_second_stage_error)
-          .and_return("second_error")
-        expect(subject.make_proposal({})["warning"]).to include("second_error")
+          .and_return(error_message2)
+
+        expect(subject.make_proposal({})["warning"]).to include(error_message2)
       end
 
       it "returns no warning if second stage is possible" do


### PR DESCRIPTION
### Problem

An exception is raised when there are AutoYaST errors. The problem is that frozen strings from translated error messages are modified.

* https://bugzilla.suse.com/show_bug.cgi?id=1148536

### Solution

Avoid modifications of frozen strings.


### Testing

* Added unit test.
* Manually tested
