### PR TITLE
Fixed base product at upgrade (bsc#1150856)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 18 06:40:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly initialize the used base product name at upgrade
+  (bsc#1150856)
+- 4.2.26
+
+-------------------------------------------------------------------
 Wed Sep  4 14:32:20 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added Y2Packager::MediumType class for detecting the installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.25
+Version:        4.2.26
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -343,8 +343,8 @@ module Yast
     # @return [Array<Y2Packager::ProductLocation>] Found products
     def scan_products(_expanded_url, original_url)
       # use the selected base product during installation,
-      # in installed system use the installed base product
-      base_product = if Stage.initial
+      # in installed system or during upgrade use the installed base product
+      base_product = if Stage.initial && !Mode.update
         Y2Packager::Product.selected_base&.name
       else
         Y2Packager::Product.installed_base_product&.name


### PR DESCRIPTION
## The Problem

- At upgrade the "SUSE Manager Server" product is automatically selected from the Packages DVD when selecting the "Basesystem" module.
- This results in a conflict with the installed SLES
- https://bugzilla.suse.com/show_bug.cgi?id=1150856

## The Fix

- For computing the module dependencies we need to set the preferred base product, in this case it was set to `nil` because no product is selected to install at this point. This means the solver can select any base product to install to satisfy the dependencies. In this case it (more or less randomly) selected the "SUSE Manager Server" product.
- At upgrade we need to use the installed base product, just like in an installed system.

## Screenshots

Tested manually, with the original code the "SUSE Manager Server" is reported as a dependency:

![upgrade_addon_selection_orig](https://user-images.githubusercontent.com/907998/65122475-5a7d0800-d9f1-11e9-9a05-f11e10cf98e6.png)

With the fix applied the "SLES" product is correctly used:

![upgrade_addon_selection](https://user-images.githubusercontent.com/907998/65122483-61a41600-d9f1-11e9-94b6-1255ff9f5d1d.png)
