### PR TITLE
Support for the online installation medium (jsc#SLE-7214)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 18 11:28:23 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support for the online installation medium (jsc#SLE-7214)
+- 4.2.27
+
+-------------------------------------------------------------------
 Wed Sep 18 06:40:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly initialize the used base product name at upgrade

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.26
+Version:        4.2.27
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -35,8 +35,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
-# inst_rpmcopy.rb: SlideShow.RebuildDialog(true)
-BuildRequires:  yast2 >= 4.2.8
+# Y2Packager::ProductControlProduct
+BuildRequires:  yast2 >= 4.2.22
 # Pkg::Resolvables
 BuildRequires:  yast2-pkg-bindings >= 4.2.0
 # Augeas lenses
@@ -47,8 +47,8 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # Pkg::Resolvables
 Requires:       yast2-pkg-bindings >= 4.2.0
-# Y2Packager::Product.forced_base_product
-Requires:       yast2 >= 4.2.17
+# Y2Packager::ProductControlProduct
+Requires:       yast2 >= 4.2.22
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -22,6 +22,7 @@ module Yast
       Yast.import "PackageSystem"
       Yast.import "Popup"
       Yast.import "Label"
+      Yast.import "Mode"
       Yast.import "SourceDialogs"
       Yast.import "Report"
       Yast.import "Progress"

--- a/src/lib/y2packager/clients/inst_product_license.rb
+++ b/src/lib/y2packager/clients/inst_product_license.rb
@@ -12,7 +12,9 @@
 
 require "yast"
 require "y2packager/dialogs/inst_product_license"
+require "y2packager/medium_type"
 require "y2packager/product"
+require "y2packager/product_control_product"
 Yast.import "Language"
 Yast.import "GetInstArgs"
 Yast.import "Mode"
@@ -57,7 +59,14 @@ module Y2Packager
       def product
         return @product if @product
 
-        @product = Y2Packager::Product.selected_base
+        @product = if Y2Packager::MediumType.online?
+          # in an online installation read the products from the control.xml
+          Y2Packager::ProductControlProduct.selected
+        else
+          # otherwise read the product from the medium
+          Y2Packager::Product.selected_base
+        end
+
         log.warn "No base product is selected for installation" unless @product
         @product
       end
@@ -68,7 +77,13 @@ module Y2Packager
       #
       # @return [Boolean]
       def multi_product_media?
-        Y2Packager::Product.available_base_products.size > 1
+        if Y2Packager::MediumType.online?
+          # in an online installation read the products from the control.xml
+          Y2Packager::ProductControlProduct.products.size > 1
+        else
+          # otherwise read the products from the medium
+          Y2Packager::Product.available_base_products.size > 1
+        end
       end
 
       # Determine whether the product's license should be shown

--- a/src/lib/y2packager/medium_type.rb
+++ b/src/lib/y2packager/medium_type.rb
@@ -58,6 +58,21 @@ module Y2Packager
         type == :standard
       end
 
+      # Helper method which evaluates the client arguments and the installation
+      # medium type and returns whether the client should be skipped.
+      #
+      # @return [Boolean] True if the client should be skipped.
+      #
+      def skip_step?
+        skip = Yast::WFM.Args(0) && Yast::WFM.Args(0)["skip"]
+        return true if skip&.split(",")&.include?(type.to_s)
+
+        only = Yast::WFM.Args(0) && Yast::WFM.Args(0)["only"]
+        return true if only && !only.split(",").include?(type.to_s)
+
+        false
+      end
+
     private
 
       #

--- a/src/lib/y2packager/storage_manager_proxy.rb
+++ b/src/lib/y2packager/storage_manager_proxy.rb
@@ -1,7 +1,3 @@
-#!/usr/bin/env ruby
-#
-# encoding: utf-8
-
 # Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.

--- a/test/lib/clients/inst_product_license_test.rb
+++ b/test/lib/clients/inst_product_license_test.rb
@@ -31,6 +31,7 @@ describe Y2Packager::Clients::InstProductLicense do
     allow(Y2Packager::Product).to receive(:selected_base).and_return(product)
     allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
     allow(Yast::Mode).to receive(:auto).and_return(auto)
+    allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
     stub_const("Yast::Language", language)
   end
 

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -19,6 +19,7 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       allow(Y2Packager::Product).to receive(:forced_base_product)
       allow(Y2Packager::Product).to receive(:available_base_products).and_return(products)
       allow(Y2Packager::SelfUpdateAddonRepo).to receive(:present?).and_return(false)
+      allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
     end
 
     it "initializes Packages subsystem" do

--- a/test/medium_type_test.rb
+++ b/test/medium_type_test.rb
@@ -75,4 +75,37 @@ describe Y2Packager::MediumType do
       end
     end
   end
+
+  describe "#skip_step?" do
+    context "online installation medium" do
+      before do
+        allow(Y2Packager::MediumType).to receive(:type).and_return(:online)
+      end
+
+      it "returns true if the client args contain \"skip\" => \"online\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return("skip" => "online")
+        expect(Y2Packager::MediumType.skip_step?).to eq(true)
+      end
+      it "returns true if the client args contain \"skip\" => \"standard,online\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return("skip" => "standard,online")
+        expect(Y2Packager::MediumType.skip_step?).to eq(true)
+      end
+      it "returns false if the client args do not contain \"skip\" => \"online\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return({})
+        expect(Y2Packager::MediumType.skip_step?).to eq(false)
+      end
+      it "returns false if the client args contain \"only\" => \"online\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return("only" => "online")
+        expect(Y2Packager::MediumType.skip_step?).to eq(false)
+      end
+      it "returns false if the client args contain \"only\" => \"online,standard\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return("only" => "standard,online")
+        expect(Y2Packager::MediumType.skip_step?).to eq(false)
+      end
+      it "returns false if the client args do not contain \"only\" => \"online\"" do
+        allow(Yast::WFM).to receive(:Args).with(0).and_return({})
+        expect(Y2Packager::MediumType.skip_step?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Adjust the installation steps for the online medium installation
  - The online installation reads the products from `control.xml`
  - Additionally needs to initialize the workflow after registering the base product and adjust repository initialization
- https://jira.suse.com/browse/SLE-7214
- Tested manually
- 4.2.27

The installation workflow step can be skipped in a specific installation this way in the `control.xml` file:

```xml
<module>
    <label>Repositories Initialization</label>
    <name>repositories_initialization</name>
    <arguments>
        <only>online</only>
    </arguments>
</module>
```

This will run the step only in the online installation medium, for the other media it will be skipped.