### PR TITLE
Aligned the language of the license text shown with the selected language (bsc#1152482)

### DIFF
--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -863,7 +863,7 @@ module Yast
       # by now (see bnc#504803, c#28). Language::Language does only
       # sysconfig reading, which is not too useful in cases like
       # 'LANG=foo_BAR yast repositories'
-      language = EnvLangToLangCode(Builtins.getenv("LANG"))
+      language = Language.language || EnvLangToLangCode(Builtins.getenv("LANG")) 
 
       # Preferencies how the client selects from available languages
       langs = [


### PR DESCRIPTION
Looks like that bug has been introduced in 2009 and nobody noticed since then.