### PR TITLE
Aligned lang of license text with the selected language (bsc#1152482)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 30 18:45:05 UTC 2019 - Christopher Hofmann <cwh@suse.com>
+
+- Aligned the language of the license text shown with the selected
+  language (bsc#1152482)
+
+-------------------------------------------------------------------
 Mon Oct 14 14:04:55 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added new Y2packager::Resolvables class

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.3.3
+Version:        3.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -863,7 +863,7 @@ module Yast
       # by now (see bnc#504803, c#28). Language::Language does only
       # sysconfig reading, which is not too useful in cases like
       # 'LANG=foo_BAR yast repositories'
-      language = EnvLangToLangCode(Builtins.getenv("LANG"))
+      language = Language.language || EnvLangToLangCode(ENV["LANG"])
 
       # Preferencies how the client selects from available languages
       langs = [


### PR DESCRIPTION
Bug has been introduced because the license did not respect the LANG env variable. Unfortunately after that it *only* followed LANG.
That was introduced 10 years ago and no one noticed.