### PR TITLE
 Decreasing required memory

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 31 17:28:57 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650).
+- 4.2.31
+
+-------------------------------------------------------------------
 Tue Oct  1 17:13:42 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not add an empty repository from the offline medium root

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,7 +2,8 @@
 Fri Nov  8 19:28:57 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
-  in order to decrease the required memory (bsc#1132650).
+  in order to decrease the required memory (bsc#1132650,
+  bsc#1140037).
 - 4.2.33
 
 -------------------------------------------------------------------  

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/clients/inst_rpmcopy.rb
+++ b/src/clients/inst_rpmcopy.rb
@@ -1,3 +1,5 @@
+require "y2packager/resolvable"
+
 module Yast
   # Install all the RPM packages the user has selected.
   # Show installation dialogue. Show progress bars.
@@ -322,8 +324,8 @@ module Yast
       failed = []
       patterns = deep_copy(AutoinstData.post_patterns)
       # set SoftLock to avoid the installation of recommended patterns (#159466)
-      Builtins.foreach(Pkg.ResolvableProperties("", :pattern, "")) do |p|
-        Pkg.ResolvableSetSoftLock(Ops.get_string(p, "name", ""), :pattern)
+      Y2Packager::Resolvable.find(kind: :pattern).each do |p|
+        Pkg.ResolvableSetSoftLock(p.name, :pattern)
       end
       Builtins.foreach(Builtins.toset(patterns)) do |p|
         failed = Builtins.add(failed, p) if !Pkg.ResolvableInstall(p, :pattern)

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -416,7 +416,7 @@ module Yast
         if VersionALtB(max_ver, cur_ver)
           max_ver = cur_ver
           # `installed or `selected is ok
-          max_is_installed = (prop.status || :available) != :available
+          max_is_installed = prop.status != :available
           Builtins.y2milestone("new max: installed: %1", max_is_installed)
         end
       end

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -406,7 +406,7 @@ module Yast
     # higher version. Otherwise we would forcefully reinstall it. #222757#c9
     def CanBeUpdated(package)
       props = Y2Packager::Resolvable.find(kind: :package, name: package)
-      
+
       # find maximum version and remember
       # if it is installed
       max_ver = "0"

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -364,6 +364,7 @@ module Yast
     # @param a_version [String] first version
     # @param b_version [String] second version
     # @return [Boolean] true if the second one is newer than the first one
+    # @deprecated Use {#Pkg.CompareVersions} instead.
     def VersionALtB(a_version, b_version)
       a_version_l = Builtins.filter(Builtins.splitstring(a_version, "-.")) do |s|
         Builtins.regexpmatch(s, "^[0123456789]+$")

--- a/src/lib/packager/product_patterns.rb
+++ b/src/lib/packager/product_patterns.rb
@@ -56,7 +56,7 @@ module Yast
     def find
       products = Y2Packager::Resolvable.find(kind: :product)
       remove_unselected(products)
-      products.map! { |product| product.name }
+      products.map!(&:name)
       log.info "Found selected products: #{products}"
 
       patterns = products.map { |p| product_patterns(p) }.flatten.uniq

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -147,9 +147,7 @@ module Y2Packager
       return @products unless @products.nil?
 
       # Filter products from this repository
-      candidates = Y2Packager::Resolvable.find(kind: :product).select do |pro|
-        pro.source == repo_id
-      end
+      candidates = Y2Packager::Resolvable.find(kind: :product, source: repo_id)
 
       # Build an array of Y2Packager::Product objects
       @products = candidates.map do |data|

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -12,6 +12,7 @@
 
 require "uri"
 require "y2packager/product"
+require "y2packager/resolvable"
 
 module Y2Packager
   # This class represents a libzypp repository
@@ -146,14 +147,14 @@ module Y2Packager
       return @products unless @products.nil?
 
       # Filter products from this repository
-      candidates = Yast::Pkg.ResolvableProperties("", :product, "").select do |pro|
-        pro["source"] == repo_id
+      candidates = Y2Packager::Resolvable.find(kind: :product).select do |pro|
+        pro.source == repo_id
       end
 
       # Build an array of Y2Packager::Product objects
       @products = candidates.map do |data|
-        Y2Packager::Product.new(name: data["name"], version: data["version"],
-          arch: data["arch"], category: data["category"], vendor: data["vendor"])
+        Y2Packager::Product.new(name: data.name, version: data.version,
+          arch: data.arch, category: data.category, vendor: data.vendor)
       end
     end
 

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -141,7 +141,6 @@ module Y2Packager
     #
     # @return [Array<Y2Packager::Product>] Products in the repository
     #
-    # @see Yast::Pkg.ResolvableProperties
     # @see Y2Packager::Product
     def products
       return @products unless @products.nil?

--- a/src/lib/y2packager/self_update_addon_filter.rb
+++ b/src/lib/y2packager/self_update_addon_filter.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "y2packager/resolvable"
 
 Yast.import "Pkg"
 
@@ -57,8 +58,7 @@ module Y2Packager
       # but rather be safe than sorry...
 
       pkgs.select! do |pkg|
-        props = Yast::Pkg.ResolvableProperties(pkg, :package, "")
-        props.any? { |p| p["source"] == repo_id }
+        Y2Packager::Resolvable.any?(kind: :package, name: pkg, source: repo_id)
       end
 
       log.info "Found addon packages in the self update repository: #{pkgs}"

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -76,9 +76,9 @@ module Y2Packager
 
       ids = repo_ids(repositories)
 
-      pkgs = Y2Packager::Resolvable.find(kind: :package,
+      pkgs = Y2Packager::Resolvable.find(kind:        :package,
                                          transact_by: :solver,
-                                         status: :selected)
+                                         status:      :selected)
       pkgs.select! do |p|
         # the packages from the specified repositories
         ids.include?(p.source)

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -77,7 +77,8 @@ module Y2Packager
       ids = repo_ids(repositories)
 
       pkgs = Y2Packager::Resolvable.find(kind: :package,
-                                         transact_by: == :solver, status: == :selected)
+                                         transact_by: :solver,
+                                         status: :selected)
       pkgs.select! do |p|
         # the packages from the specified repositories
         ids.include?(p.source)

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -76,10 +76,11 @@ module Y2Packager
 
       ids = repo_ids(repositories)
 
-      pkgs = Y2Packager::Resolvable.find(kind: :package)
+      pkgs = Y2Packager::Resolvable.find(kind: :package,
+                                         transact_by: == :solver, status: == :selected)
       pkgs.select! do |p|
-        # the packages from the specified repositories selected by the solver
-        p.status == :selected && ids.include?(p.source) && p.transact_by == :solver
+        # the packages from the specified repositories
+        ids.include?(p.source)
       end
 
       # set back the original solver flags

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------------
 
 require "yast"
+require "y2packager/resolvable"
 
 module Y2Packager
   # Preselect the system packages (drivers) from the specified repositories.
@@ -75,16 +76,16 @@ module Y2Packager
 
       ids = repo_ids(repositories)
 
-      pkgs = Yast::Pkg.ResolvableProperties("", :package, "")
-      pkgs = pkgs.select do |p|
+      pkgs = Y2Packager::Resolvable.find(kind: :package)
+      pkgs.select! do |p|
         # the packages from the specified repositories selected by the solver
-        p["status"] == :selected && ids.include?(p["source"]) && p["transact_by"] == :solver
+        p.status == :selected && ids.include?(p.source) && p.transact_by == :solver
       end
 
       # set back the original solver flags
       Yast::Pkg.SetSolverFlags(original_solver_flags)
 
-      pkgs.map! { |p| p["name"] }
+      pkgs.map! { |p| p.name }
       log.info "Found system packages: #{pkgs}"
 
       pkgs

--- a/src/lib/y2packager/system_packages.rb
+++ b/src/lib/y2packager/system_packages.rb
@@ -85,7 +85,7 @@ module Y2Packager
       # set back the original solver flags
       Yast::Pkg.SetSolverFlags(original_solver_flags)
 
-      pkgs.map! { |p| p.name }
+      pkgs.map!(&:name)
       log.info "Found system packages: #{pkgs}"
 
       pkgs

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -310,7 +310,7 @@ module Yast
       already_found = false
 
       # Found the
-      if check_add_on != nil
+      if !check_add_on.nil?
         product_replaces = Ops.get_list(check_add_on, "replaces", [])
 
         # Run through through all products that the add-on can replace

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -298,7 +298,7 @@ module Yast
 
       # Search for an add-on using source ID
       Builtins.foreach(all_products) do |one_product|
-        if (one_product.source || -1) == source_id
+        if one_product.source == source_id
           check_add_on = deep_copy(one_product)
           raise Break
         end
@@ -1267,7 +1267,7 @@ module Yast
         products = Y2Packager::Resolvable.find(kind: :product)
         # only those that come from the new source
         products = Builtins.filter(products) do |p|
-          (p.source || -1) == src
+          p.source == src
         end
 
         Builtins.foreach(products) do |p|

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2539,7 +2539,7 @@ module Yast
           statuses = Y2Packager::Resolvable.find(kind: type, name: item)
 
           # :selected = selected to install/update, :installed = keep installed (at upgrade)
-          next !statuses.nil? && statuses.find { |s| [:selected, :installed].include?(s.status) }
+          next if !statuses.nil? && statuses.find {|s|[:selected, :installed].include?(s.status)}
 
           missing[type] = [] unless missing[type]
           # use quoted "summary" value for patterns as they usually contain spaces

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1873,7 +1873,7 @@ module Yast
           log.info "Optional pattern #{pattern_name} does not exist, skipping..."
         when :skipped_by_user
           log.info "Skipping pattern #{pattern_name} deselected by user"
-        when :skipped_reselection # rubocop:disable Lint/EmptyWhen
+        when :skipped_reselection
           # not logged
         else
           raise ArgumentError, "Unhandled action #{action}"

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2317,7 +2317,7 @@ module Yast
   private
 
     def fetch_selected(category)
-      items = Y2Packager::Resolvable.find(kind: category).select { |i| i.status == :selected }
+      items = Y2Packager::Resolvable.find(kind: category, status: :selected)
       items.map(&:name).sort
     end
 

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2539,7 +2539,7 @@ module Yast
           statuses = Y2Packager::Resolvable.find(kind: type, name: item)
 
           # :selected = selected to install/update, :installed = keep installed (at upgrade)
-          next if !statuses.nil? && statuses.find {|s|[:selected, :installed].include?(s.status)}
+          next if !statuses.nil? && statuses.find { |s| [:selected, :installed].include?(s.status) }
 
           missing[type] = [] unless missing[type]
           # use quoted "summary" value for patterns as they usually contain spaces

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -167,9 +167,7 @@ module Yast
     # @param [String] format string format string to print summaries in
     # @return a list of selected resolvables
     def ListSelected(what, format)
-      selected = Y2Packager::Resolvable.find(kind: what)
-
-      selected.select! { |r| r.status == :selected }
+      selected = Y2Packager::Resolvable.find(kind: what, status: :selected)
 
       selected.select!(&:user_visible) if what == :pattern
 

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -583,7 +583,7 @@ module Yast
     end
 
     # group products according to the current state
-    # @param [Array<Hash>] products list of products (returned by Pkg.ResolvableProperties call)
+    # @param [Array<Y2Packager::Resolvable>] products list of products
     # @return [Hash<Symbol,Object>] grouped products
     #   the keys are :new, :removed, :kept, :updated
     #   For each key the value is a list of products, except for :updated
@@ -612,7 +612,7 @@ module Yast
     # create a product update summary (in rich text format)
     # usable in update proposal
     # @see #product_update_warning how to set and display possible issues
-    # @param [Array<Hash>] products list of products (returned by Pkg.ResolvableProperties call)
+    # @param [Array<Y2Packager::Resolvable>] products list of products
     # @return [Array<String>] list of rich text descriptions
     def product_update_summary(products)
       status = group_products_by_status(products)
@@ -647,10 +647,10 @@ module Yast
       end
 
       ret += status[:removed].map do |product|
-        obsolete = Y2Packager::ProductUpgrade.will_be_obsoleted_by(product["name"])
-        log.info "Product #{product["name"].inspect} will be obsoleted by #{obsolete.inspect}"
+        obsolete = Y2Packager::ProductUpgrade.will_be_obsoleted_by(product.name)
+        log.info "Product #{product.name} will be obsoleted by #{obsolete.inspect}"
         if obsolete.empty?
-          transact_by = product["transact_by"]
+          transact_by = product.transact_by
           log.warn "Product will be removed (by #{transact_by}): #{product}"
 
           # Removing another product might be an issue
@@ -683,14 +683,14 @@ module Yast
     # create a warning for product update summary (in rich text format) if
     # there is an update problem
     # @see #product_update_summary how to get the summary text
-    # @param [Array<Hash>] products list of products (returned by Pkg.ResolvableProperties call)
+    # @param [Array<Y2Packager::Resolvable>] products list of products
     # @return [Hash] hash with warning attributes or empty if there is no problem
     def product_update_warning(products)
       status = group_products_by_status(products)
 
       ret = status[:removed].all? do |product|
-        product["transact_by"] != :solver ||
-          !Y2Packager::ProductUpgrade.will_be_obsoleted_by(product["name"]).empty?
+        product.transact_by != :solver ||
+          !Y2Packager::ProductUpgrade.will_be_obsoleted_by(product.name).empty?
       end
 
       return {} if ret
@@ -713,16 +713,16 @@ module Yast
     end
 
     # return a printable name of product resolvable
-    # @param [Hash] product the product (returned by Pkg.ResolvableProperties call)
+    # @param [Y2Packager::Resolvable] product the product
     # @return [String] product name
     def product_label(product)
-      display_name = product["display_name"]
+      display_name = product.display_name
       return display_name if display_name && !display_name.empty?
 
-      short_name = product["short_name"]
+      short_name = product.short_name
       return short_name if short_name && !short_name.empty?
 
-      product["name"]
+      product.name
     end
 
     # proposal control functions
@@ -2196,10 +2196,10 @@ module Yast
     #   - if the FIPS mode is active "1\n" is read
     FIPS_FILE = "/proc/sys/crypto/fips_enabled".freeze
 
-    # Log only resolvables with resolvable["status"] matching these below
+    # Log only resolvables with resolvable.status matching these below
     LOG_RESOLVABLE_STATUS = [:selected, :removed].freeze
 
-    # Log only resolvables with resolvable["transact_by"] matching these below
+    # Log only resolvables with resolvable.transact_by matching these below
     LOG_RESOLVABLE_TRANSACT_BY = [:user, :app_high].freeze
 
     # Reads the current user selection and dumps it to log
@@ -2485,12 +2485,12 @@ module Yast
 
     # list of all products that will be installed (are selected)
     def products_to_install(products)
-      products.select { |product| product["status"] == :selected }
+      products.select { |product| product.status == :selected }
     end
 
     # list of all products that will be removed
     def products_to_remove(products)
-      products.select { |product| product["status"] == :removed }
+      products.select { |product| product.status == :removed }
     end
 
     def products_to_update(installed_products, removed_products)
@@ -2499,8 +2499,8 @@ module Yast
       updated_products = {}
       installed_products.each do |installed_product|
         removed = removed_products.select do |removed_product|
-          installed_name = installed_product["name"]
-          removed_name = removed_product["name"]
+          installed_name = installed_product.name
+          removed_name = removed_product.name
 
           # check the current product names or product renames
           removed_name == installed_name ||
@@ -2515,7 +2515,7 @@ module Yast
 
     # list of all products that will be unchanged (kept installed)
     def kept_products(products)
-      products.select { |product| product["status"] == :installed }
+      products.select { |product| product.status == :installed }
     end
 
     # Checks if a window manager is installed or selected for installation

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -426,7 +426,7 @@ module Yast
     # Checks which products have been selected for removal and modifies
     # the warning messages accordingly.
     #
-    # @param [Yast::ArgRef] ret reference to map MakeProposal->Summary
+    # @param [Yast::ArgRef] _ret reference to map MakeProposal->Summary
     def CheckOldAddOns(_ret)
       Builtins.y2milestone("Currenly there is no check for old add ons")
     end

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2371,7 +2371,7 @@ module Yast
       log.info text
 
       resolvables.each do |r|
-        r_info = { name: r["name"], version: r["version"], arch: r["arch"], status: r["status"] }
+        r_info = { name: r.name, version: r.version, arch: r.arch, status: r.status }
         log.info "- #{r_info}"
       end
     end

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2319,7 +2319,7 @@ module Yast
 
     def fetch_selected(category)
       items = Y2Packager::Resolvable.find(kind: category).select { |i| i.status == :selected }
-      items.map { |i| i["name"] }.sort
+      items.map { |i| i.name }.sort
     end
 
     # Current package, pattern, product, patch and language selection.

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1536,10 +1536,9 @@ module Yast
       new_name = nil
       Builtins.foreach(all_products) do |one_product|
         # source ID matches
-        if (one_product.source || -1) == src_id
-          name = one_product.name || ""
-          if name != ""
-            new_name = name
+        if one_product.source == src_id
+          if one_product.name != ""
+            new_name = one_product.name
             Builtins.y2milestone("Product name found: %1", new_name)
             raise Break
           end
@@ -2384,7 +2383,7 @@ module Yast
 
       Builtins.maplist(selected) do |r|
         disp = r.summary
-        disp = r.name || "" if !disp || disp.empty?
+        disp = r.name if disp.empty?
         Builtins.sformat(format, disp)
       end
     end
@@ -2539,7 +2538,7 @@ module Yast
           statuses = Y2Packager::Resolvable.find(kind: type, name: item)
 
           # :selected = selected to install/update, :installed = keep installed (at upgrade)
-          next if !statuses.nil? && statuses.find { |s| [:selected, :installed].include?(s.status) }
+          next if statuses.find { |s| [:selected, :installed].include?(s.status) }
 
           missing[type] = [] unless missing[type]
           # use quoted "summary" value for patterns as they usually contain spaces

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2378,7 +2378,7 @@ module Yast
 
     # Prepares a list of formatted selected resolvables
     #
-    # @param [Array<Hash>] selected list of selected resolvables to format
+    # @param [Array<Y2Packager::Resolvable>] selected list of selected resolvables to format
     # @param [String] format string format to use
     def formatted_resolvables(selected, format)
       format = "%1" if format == "" || format.nil?
@@ -2394,7 +2394,7 @@ module Yast
     # :pattern resolvables are sorted by "order"
     # :product resolvables are sorted by "source"
     #
-    # @param [Array<Hash>] selected list of selected resolvables to sort
+    # @param [Array<Y2Packager::Resolvable>] selected list of selected resolvables to sort
     # @param [Symbol] what symbol specifying the type of resolvables to select
     # @see RESOLVABLE_SORT_ORDER
     def sort_resolvable!(selected, what)

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2384,7 +2384,8 @@ module Yast
       format = "%1" if format == "" || format.nil?
 
       Builtins.maplist(selected) do |r|
-        disp = r.summary || r.name || ""
+        disp = r.summary
+        disp = r.name || "" if !disp || disp.empty?
         Builtins.sformat(format, disp)
       end
     end

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -5,6 +5,7 @@ require "shellwords"
 
 require "y2packager/product"
 require "y2packager/product_license"
+require "y2packager/resolvable"
 
 # Yast namespace
 module Yast
@@ -836,10 +837,10 @@ module Yast
     # @param src_id [Integer] Repository ID
     # @return [Y2Packager::Product,nil] Product or nil if it was not found
     def repository_product(src_id)
-      product_h = Yast::Pkg.ResolvableProperties("", :product, "").find do |properties|
-        properties["source"] == src_id
+      product_h = Y2Packager::Resolvable.find(kind: :product).find do |properties|
+        properties.source == src_id
       end
-      if product_h.nil?
+      if product_h.nil? || product_h.empty?
         log.error "No product found in the repository (#{src_id})"
         return
       end
@@ -1702,9 +1703,9 @@ module Yast
       Pkg.SourceLoad
       ::FileUtils.mkdir_p(tmpdir)
 
-      products = Pkg.ResolvableProperties("", :product, "")
-      products.select! { |p| p["source"] == id }
-      product_names = products.map { |p| p["name"] }.uniq
+      products = Y2Packager::Resolvable.find(kind: :product)
+      products.select! { |p| p.source == id }
+      product_names = products.map { |p| p.name }.uniq
       log.info("Found products from source #{id}: #{product_names.inspect}")
       found_license = false
 

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -837,14 +837,20 @@ module Yast
     # @param src_id [Integer] Repository ID
     # @return [Y2Packager::Product,nil] Product or nil if it was not found
     def repository_product(src_id)
-      product_h = Y2Packager::Resolvable.find(kind: :product).find do |properties|
-        properties.source == src_id
-      end
-      if product_h.nil? || product_h.empty?
+      products = Y2Packager::Resolvable.find(kind: :product, source: src_id)
+      if products.nil? || products.empty?
         log.error "No product found in the repository (#{src_id})"
         return
       end
-      Y2Packager::Product.from_h(product_h)
+      product = products.first
+      Y2Packager::Product.new(
+        name:                 product.name,
+        short_name:           product.short_name,
+        display_name:         product.display_name,
+        version:              product.version,
+        arch:                 product.arch,
+        category:             product.category,
+        vendor:               product.vendor)
     end
 
     # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -838,7 +838,7 @@ module Yast
     # @return [Y2Packager::Product,nil] Product or nil if it was not found
     def repository_product(src_id)
       products = Y2Packager::Resolvable.find(kind: :product, source: src_id)
-      if products.nil? || products.empty?
+      if products.empty?
         log.error "No product found in the repository (#{src_id})"
         return
       end
@@ -1704,7 +1704,7 @@ module Yast
       Pkg.SourceLoad
       ::FileUtils.mkdir_p(tmpdir)
 
-      products = Y2Packager::Resolvable.find(kind: :product)
+      products = Y2Packager::Resolvable.find(kind: :product, source: id)
       products.select! { |p| p.source == id }
       product_names = products.map(&:name).uniq
       log.info("Found products from source #{id}: #{product_names.inspect}")

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1705,7 +1705,6 @@ module Yast
       ::FileUtils.mkdir_p(tmpdir)
 
       products = Y2Packager::Resolvable.find(kind: :product, source: id)
-      products.select! { |p| p.source == id }
       product_names = products.map(&:name).uniq
       log.info("Found products from source #{id}: #{product_names.inspect}")
       found_license = false

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -843,14 +843,9 @@ module Yast
         return
       end
       product = products.first
-      Y2Packager::Product.new(
-        name:                 product.name,
-        short_name:           product.short_name,
-        display_name:         product.display_name,
-        version:              product.version,
-        arch:                 product.arch,
-        category:             product.category,
-        vendor:               product.vendor)
+      Y2Packager::Product.new( name: product.name, short_name: product.short_name,
+        display_name: product.display_name, version: product.version,
+        arch: product.arch, category: product.category, vendor: product.vendor)
     end
 
     # @param licenses [ArgRef<Hash{String, String}>] a map $[ lang_code : filename ]

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -843,7 +843,7 @@ module Yast
         return
       end
       product = products.first
-      Y2Packager::Product.new( name: product.name, short_name: product.short_name,
+      Y2Packager::Product.new(name: product.name, short_name: product.short_name,
         display_name: product.display_name, version: product.version,
         arch: product.arch, category: product.category, vendor: product.vendor)
     end
@@ -1706,7 +1706,7 @@ module Yast
 
       products = Y2Packager::Resolvable.find(kind: :product)
       products.select! { |p| p.source == id }
-      product_names = products.map { |p| p.name }.uniq
+      product_names = products.map { &:name }.uniq
       log.info("Found products from source #{id}: #{product_names.inspect}")
       found_license = false
 

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1706,7 +1706,7 @@ module Yast
 
       products = Y2Packager::Resolvable.find(kind: :product)
       products.select! { |p| p.source == id }
-      product_names = products.map { &:name }.uniq
+      product_names = products.map(&:name).uniq
       log.info("Found products from source #{id}: #{product_names.inspect}")
       found_license = false
 

--- a/src/modules/SourceManager.rb
+++ b/src/modules/SourceManager.rb
@@ -1,6 +1,7 @@
 require "yast"
 
 require "shellwords"
+require "y2packager/resolvable"
 
 # Yast namespace
 module Yast
@@ -580,7 +581,7 @@ module Yast
           ret = Builtins.add(ret, url) # #180820#c26
 
           # is there any patch available?
-          patches = Pkg.ResolvableProperties("", :patch, "")
+          patches = Y2Packager::Resolvable.find(kind: :patch)
 
           if Ops.greater_than(Builtins.size(patches), 0)
             # loaded target is required to get list of applicable patches (#270919)

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -45,14 +45,12 @@ describe Yast::AddOnProduct do
       end
 
       let(:new_product) do
-        Y2Packager::Resolvable.new(ProductFactory.create_product(
-                                     "kind"            => :product,
-                                     "name"            => "new_product",
-                                     "version"         => "1.0",
-                                     "arch"            => "x86_64",
-                                     "source"          => "1",
-                                     "product_package" => "new_product-release"
-        ))
+        Y2Packager::Resolvable.new(
+          ProductFactory.create_product("kind" => :product,
+           "name" => "new_product", "version" => "1.0",
+           "arch" => "x86_64", "source" => "1",
+           "product_package" => "new_product-release")
+        )
       end
 
       let(:new_product_package) do

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -10,9 +10,11 @@ describe Yast::AddOnProduct do
   subject { Yast::AddOnProduct }
 
   describe "#renamed?" do
-    let(:other_product) {
+    let(:other_product) do
       Y2Packager::Resolvable.new(
-        ProductFactory.create_product( "kind" => :product, "deps" => [])) }
+        ProductFactory.create_product("kind" => :product, "deps" => [])
+      )
+    end
     let(:products) { [other_product] }
 
     before do
@@ -45,39 +47,42 @@ describe Yast::AddOnProduct do
 
       let(:new_product) do
         Y2Packager::Resolvable.new(ProductFactory.create_product(
-          "kind"            => :product,
-          "name"            => "new_product",
-          "version"         => "1.0",
-          "arch"            => "x86_64",
-          "source"          => "1",
-          "product_package" => "new_product-release"))
+                                     "kind"            => :product,
+                                     "name"            => "new_product",
+                                     "version"         => "1.0",
+                                     "arch"            => "x86_64",
+                                     "source"          => "1",
+                                     "product_package" => "new_product-release"
+        ))
       end
 
       let(:new_product_package) do
         Y2Packager::Resolvable.new(
-          { "kind"    => :package,
-            "name"    => "new_product-release",
-            "version" => "1.0",
-            "arch"    => "x86_64",
-            "source"  => "1",
-            "deps" => deps })
+          "kind"    => :package,
+          "name"    => "new_product-release",
+          "version" => "1.0",
+          "arch"    => "x86_64",
+          "source"  => "1",
+          "deps"    => deps
+        )
       end
 
       let(:installed_product_package) do
         Y2Packager::Resolvable.new(
-          { "kind" => :package,
-            "name" => "installed_product-release",
-            "version" => "1.0",
-            "arch"    => "x86_64",
-            "source"  => "1",
-            "deps" => []})
+          "kind"    => :package,
+          "name"    => "installed_product-release",
+          "version" => "1.0",
+          "arch"    => "x86_64",
+          "source"  => "1",
+          "deps"    => []
+        )
       end
 
       let(:products) { [new_product] }
 
       it "returns true" do
         allow(Y2Packager::Resolvable).to receive(:find)
-          .with(kind: :package ,name: new_product.product_package)
+          .with(kind: :package, name: new_product.product_package)
           .and_return([installed_product_package, new_product_package])
         expect(subject.renamed?("old_product1", new_product.name)).to eq(true)
         expect(subject.renamed?("old_product2", new_product.name)).to eq(true)

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env rspec
-# coding: utf-8
 
 require_relative "./test_helper"
 require_relative "product_factory"

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1291,7 +1291,6 @@ describe Yast::Packages do
     let(:unordered_products) do
       [
         product("name" => "p3", "status" => :selected, "source" => 15),
-        product("name" => "p4", "status" => :available, "source" => 40),
         product("name" => "p1", "status" => :selected, "source" => 10)
       ]
     end
@@ -1313,8 +1312,7 @@ describe Yast::Packages do
     let(:unordered_patterns) do
       [
         pattern("name" => "p3", "status" => :selected, "order" => "3", "user_visible" => true),
-        pattern("name" => "p1", "status" => :selected, "order" => "1", "user_visible" => false),
-        pattern("name" => "p2", "status" => :available, "order" => "2", "user_visible" => true)
+        pattern("name" => "p1", "status" => :selected, "order" => "1", "user_visible" => false)
       ]
     end
 
@@ -1325,12 +1323,12 @@ describe Yast::Packages do
     end
 
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
         .and_return(unordered_products)
     end
 
     it "obtains a list of resolvables of the given type" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
 
       subject.ListSelected(:product, "")
     end
@@ -1340,13 +1338,13 @@ describe Yast::Packages do
     end
 
     it "filters and sorts not user visible resolvables from the list for type pattern" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern)
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, :status=>:selected)
         .and_return(unordered_patterns)
       expect(subject.ListSelected(:pattern, "")).to eq(filtered_patterns.map(&:name).sort)
     end
 
     it "returns an empty list if no resolvables selected" do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
         .and_return([])
 
       expect(subject.ListSelected(:product, "Product: %1")).to eql([])

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -470,7 +470,10 @@ describe Yast::Packages do
   describe "#product_update_summary" do
     let(:products) { load_zypp("products_update.yml") }
     let(:suma_products_map) { load_zypp("products_update_suma_branch_server.yml") }
-    let(:suma_products) { suma_products_map.map {|p| Y2Packager::Resolvable.new(p)} }
+    let(:suma_products) { suma_products_map.map do |p|
+                            p["kind"] = :product
+                            Y2Packager::Resolvable.new(p)
+                          end }
 
     before do
       allow(Y2Packager::ProductUpgrade).to receive(:will_be_obsoleted_by).and_return([])
@@ -511,6 +514,8 @@ describe Yast::Packages do
         .and_return(["SUSE-Manager-Retail-Branch-Server"])
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return(suma_products)
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: /sle/ )
+        .and_return([])
       allow(Y2Packager::Product).to receive(:with_status).with(:selected).and_return(
         suma_products_map.select { |p| p["status"] == :selected }
         .map { |p| Y2Packager::Product.from_h(p) }

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -585,6 +585,11 @@ describe Yast::Packages do
           allow(Y2Packager::Resolvable).to receive(:find).with(name: prod_name, kind: :product)
             .and_return(suma_products.select { |p| p.name == prod_name })
         end
+
+        allow(Y2Packager::ProductUpgrade).to receive(:will_be_obsoleted_by)
+          .and_return(["new_product"])
+        allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: // )
+          .and_return([])
       end
 
       # the SLES12-SP3 is replaced by the SUMA base product,

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -29,7 +29,7 @@ def load_zypp(file_name)
 end
 
 def product_from_zypp
-  load_zypp("products.yml").map {|p| Y2Packager::Resolvable.new(p)}
+  load_zypp("products.yml").map { |p| Y2Packager::Resolvable.new(p) }
 end
 
 PRODUCTS_FROM_ZYPP = load_zypp("products.yml").freeze
@@ -190,14 +190,14 @@ describe Yast::Packages do
   end
 
   DEFAULT_PRODUCT = {
-    "kind"        => :product,
-    "name"        => "name",
-    "version"     => "1.0.0",
-    "arch"        => "x86_64",
-    "source"      => 1,
-    "summary"     => "",
-    "status"      => :available,
-    "transact_by" => :app_high,
+    "kind"            => :product,
+    "name"            => "name",
+    "version"         => "1.0.0",
+    "arch"            => "x86_64",
+    "source"          => 1,
+    "summary"         => "",
+    "status"          => :available,
+    "transact_by"     => :app_high,
     "product_package" => "product_package"
   }.freeze
 
@@ -319,7 +319,7 @@ describe Yast::Packages do
       allow(Yast::Packages).to receive(:ComputeSystemPatternList).and_return([])
       allow(Yast::Packages).to receive(:default_patterns).and_return([])
       allow(Yast::Packages).to receive(:optional_default_patterns).and_return([])
-      allow(Y2Packager::Resolvable).to receive(:find).and_return([pattern()])
+      allow(Y2Packager::Resolvable).to receive(:find).and_return([pattern])
 
       product_patterns = ["default_pattern_1", "default_pattern_2"]
       expect_any_instance_of(Yast::ProductPatterns).to receive(:names).at_least(:once)
@@ -471,9 +471,11 @@ describe Yast::Packages do
   describe "#product_update_summary" do
     let(:products) { load_zypp("products_update.yml") }
     let(:suma_products_map) { load_zypp("products_update_suma_branch_server.yml") }
-    let(:suma_products) { suma_products_map.map do |p|
-                            product(p)
-                          end }
+    let(:suma_products) do
+      suma_products_map.map do |p|
+        product(p)
+      end
+    end
 
     before do
       allow(Y2Packager::ProductUpgrade).to receive(:will_be_obsoleted_by).and_return([])
@@ -514,7 +516,7 @@ describe Yast::Packages do
         .and_return(["SUSE-Manager-Retail-Branch-Server"])
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return(suma_products)
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: // )
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: //)
         .and_return([])
       allow(Y2Packager::Product).to receive(:with_status).with(:selected).and_return(
         suma_products_map.select { |p| p["status"] == :selected }
@@ -575,19 +577,19 @@ describe Yast::Packages do
     context "SUSE Manager 3.2 upgrade" do
       # upgrade SLES12-SP3 + SUMA-3.2 to SLE15-SP1 (actually SUMA 4.0)
       let(:suma_products_map) { load_zypp("products_update_suma.yml") }
-      let(:suma_products) { suma_products_map.map {|p| product(p)} }
+      let(:suma_products) { suma_products_map.map { |p| product(p) } }
 
       before do
         allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
           .and_return(suma_products)
 
-        suma_products.map { |p| p.name }.uniq.each do |prod_name|
+        suma_products.map(&:name).uniq.each do |prod_name|
           allow(Y2Packager::Resolvable).to receive(:find).with(name: prod_name, kind: :product)
             .and_return(suma_products.select { |p| p.name == prod_name })
         end
         allow(Y2Packager::ProductUpgrade).to receive(:will_be_obsoleted_by)
           .and_return(["new_product"])
-        allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: // )
+        allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: //)
           .and_return([])
       end
 
@@ -1051,10 +1053,10 @@ describe Yast::Packages do
     end
 
     let(:packages) { Yast::Packages.modePackages.sort.uniq }
-    let(:vnc_packages) { %w[some-vnc-packages] }
-    let(:remote_x11_packages) { %w[some-x11-packages] }
-    let(:ssh_packages) { %w[openssh iproute2] }
-    let(:braille_packages) { %w[sbl] }
+    let(:vnc_packages) { %w(some-vnc-packages) }
+    let(:remote_x11_packages) { %w(some-x11-packages) }
+    let(:ssh_packages) { %w(openssh iproute2) }
+    let(:braille_packages) { %w(sbl) }
 
     context "on a boring local regular installation" do
       let(:vnc) { false }
@@ -1114,10 +1116,10 @@ describe Yast::Packages do
       allow(Yast::Packages).to receive(:braille_packages).and_return(braille_packages)
     end
 
-    let(:vnc_packages) { %w[some-vnc-packages] }
-    let(:remote_x11_packages) { %w[some-x11-packages] }
-    let(:ssh_packages) { %w[openssh iproute2] }
-    let(:braille_packages) { %w[sbl] }
+    let(:vnc_packages) { %w(some-vnc-packages) }
+    let(:remote_x11_packages) { %w(some-x11-packages) }
+    let(:ssh_packages) { %w(openssh iproute2) }
+    let(:braille_packages) { %w(sbl) }
 
     context "on a boring local regular installation" do
       let(:vnc) { false }
@@ -1329,13 +1331,13 @@ describe Yast::Packages do
     end
 
     it "filters and sorts not selected resolvables from the list" do
-      expect(subject.ListSelected(:product, "")).to eq(filtered_products.map {|t| t.name}.sort)
+      expect(subject.ListSelected(:product, "")).to eq(filtered_products.map(&:name).sort)
     end
 
     it "filters and sorts not user visible resolvables from the list for type pattern" do
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern)
         .and_return(unordered_patterns)
-      expect(subject.ListSelected(:pattern, "")).to eq(filtered_patterns.map {|t| t.name}.sort)
+      expect(subject.ListSelected(:pattern, "")).to eq(filtered_patterns.map(&:name).sort)
     end
 
     it "returns an empty list if no resolvables selected" do
@@ -1369,9 +1371,9 @@ describe Yast::Packages do
     context "YaST preselected items are deselected by user" do
       before do
         expect(Y2Packager::Resolvable).to receive(:find).with(name: "grub2", kind: :package)
-          .and_return([package({"status" => :available})])
+          .and_return([package("status" => :available)])
         expect(Y2Packager::Resolvable).to receive(:find).with(name: "kde", kind: :pattern)
-          .and_return([package({"status" => :available, "summary" => "KDE Desktop Environment"})])
+          .and_return([package("status" => :available, "summary" => "KDE Desktop Environment")])
       end
 
       it "Reports missing pre-selected packages" do
@@ -1393,9 +1395,9 @@ describe Yast::Packages do
     context "YaST preselected items are not deselected by user" do
       before do
         expect(Y2Packager::Resolvable).to receive(:find).with(name: "grub2", kind: :package)
-          .and_return([package({"status" => :selected})])
+          .and_return([package("status" => :selected)])
         expect(Y2Packager::Resolvable).to receive(:find).with(name: "kde", kind: :pattern)
-          .and_return([package({"status" => :selected})])
+          .and_return([package("status" => :selected)])
       end
 
       it "Does not report missing pre-selected packages" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -472,8 +472,7 @@ describe Yast::Packages do
     let(:products) { load_zypp("products_update.yml") }
     let(:suma_products_map) { load_zypp("products_update_suma_branch_server.yml") }
     let(:suma_products) { suma_products_map.map do |p|
-                            p["kind"] = :product
-                            Y2Packager::Resolvable.new(p)
+                            product(p)
                           end }
 
     before do
@@ -515,7 +514,7 @@ describe Yast::Packages do
         .and_return(["SUSE-Manager-Retail-Branch-Server"])
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return(suma_products)
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: /sle/ )
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: // )
         .and_return([])
       allow(Y2Packager::Product).to receive(:with_status).with(:selected).and_return(
         suma_products_map.select { |p| p["status"] == :selected }

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1323,12 +1323,12 @@ describe Yast::Packages do
     end
 
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :selected)
         .and_return(unordered_products)
     end
 
     it "obtains a list of resolvables of the given type" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :selected)
 
       subject.ListSelected(:product, "")
     end
@@ -1338,13 +1338,13 @@ describe Yast::Packages do
     end
 
     it "filters and sorts not user visible resolvables from the list for type pattern" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, :status=>:selected)
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, status: :selected)
         .and_return(unordered_patterns)
       expect(subject.ListSelected(:pattern, "")).to eq(filtered_patterns.map(&:name).sort)
     end
 
     it "returns an empty list if no resolvables selected" do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :selected)
         .and_return([])
 
       expect(subject.ListSelected(:product, "Product: %1")).to eql([])

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -379,8 +379,8 @@ describe Yast::Packages do
     let(:product_hash) { load_zypp("products_update.yml").first }
 
     it "returns display_name if available" do
-      expect(Yast::Packages.product_label(product(product_hash))).to
-      eq("SUSE Linux Enterprise Server 12")
+      expect(Yast::Packages.product_label(product(product_hash)))
+        .to eq("SUSE Linux Enterprise Server 12")
     end
 
     it "return short_name if display_name is not available" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -197,7 +197,8 @@ describe Yast::Packages do
     "source"      => 1,
     "summary"     => "",
     "status"      => :available,
-    "transact_by" => :app_high
+    "transact_by" => :app_high,
+    "product_package" => "product_package"
   }.freeze
 
   def product(properties = {})

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -180,7 +180,7 @@ describe Yast::Packages do
     "version"     => "1.0.0",
     "arch"        => "x86_64",
     "source"      => 1,
-    "summary"     => "summary string",
+    "summary"     => "",
     "status"      => :available,
     "transact_by" => :app_high
   }.freeze
@@ -195,7 +195,7 @@ describe Yast::Packages do
     "version"     => "1.0.0",
     "arch"        => "x86_64",
     "source"      => 1,
-    "summary"     => "summary string",    
+    "summary"     => "",
     "status"      => :available,
     "transact_by" => :app_high
   }.freeze
@@ -210,7 +210,7 @@ describe Yast::Packages do
     "version"     => "1.0.0",
     "arch"        => "x86_64",
     "source"      => 1,
-    "summary"     => "summary string",    
+    "summary"     => "",
     "status"      => :available,
     "transact_by" => :app_high
   }.freeze
@@ -1320,10 +1320,8 @@ describe Yast::Packages do
     end
 
     it "filters not selected resolvables from the list" do
-      expect(subject).to receive(:sort_resolvable!)
-        .with(filtered_products, :product)
-
-      subject.ListSelected(:product, "")
+      expect(subject.ListSelected(:product, "")).to
+        eq(filtered_products.map {|t| t.name}.sort)
     end
 
     it "filters not user visible resolvables from the list for type pattern" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -575,7 +575,7 @@ describe Yast::Packages do
     context "SUSE Manager 3.2 upgrade" do
       # upgrade SLES12-SP3 + SUMA-3.2 to SLE15-SP1 (actually SUMA 4.0)
       let(:suma_products_map) { load_zypp("products_update_suma.yml") }
-      let(:suma_products) { suma_products_map.map {|p| Y2Packager::Resolvable.new(p)} }
+      let(:suma_products) { suma_products_map.map {|p| product(p)} }
 
       before do
         allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
@@ -585,7 +585,6 @@ describe Yast::Packages do
           allow(Y2Packager::Resolvable).to receive(:find).with(name: prod_name, kind: :product)
             .and_return(suma_products.select { |p| p.name == prod_name })
         end
-
         allow(Y2Packager::ProductUpgrade).to receive(:will_be_obsoleted_by)
           .and_return(["new_product"])
         allow(Y2Packager::Resolvable).to receive(:find).with(kind: :package, name: // )

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1055,7 +1055,7 @@ describe Yast::Packages do
     let(:packages) { Yast::Packages.modePackages.sort.uniq }
     let(:vnc_packages) { ["some-vnc-packages"] }
     let(:remote_x11_packages) { ["some-x11-packages"] }
-    let(:ssh_packages) { ["openssh iproute2"] }
+    let(:ssh_packages) { ["openssh", "iproute2"] }
     let(:braille_packages) { ["sbl"] }
 
     context "on a boring local regular installation" do
@@ -1118,7 +1118,7 @@ describe Yast::Packages do
 
     let(:vnc_packages) { ["some-vnc-packages"] }
     let(:remote_x11_packages) { ["some-x11-packages"] }
-    let(:ssh_packages) { ["openssh iproute2"] }
+    let(:ssh_packages) { ["openssh", "iproute2"] }
     let(:braille_packages) { ["sbl"] }
 
     context "on a boring local regular installation" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -318,7 +318,7 @@ describe Yast::Packages do
       allow(Yast::Packages).to receive(:ComputeSystemPatternList).and_return([])
       allow(Yast::Packages).to receive(:default_patterns).and_return([])
       allow(Yast::Packages).to receive(:optional_default_patterns).and_return([])
-      allow(Y2Packager::Resolvable).to receive(:find).and_return([])
+      allow(Y2Packager::Resolvable).to receive(:find).and_return([pattern()])
 
       product_patterns = ["default_pattern_1", "default_pattern_2"]
       expect_any_instance_of(Yast::ProductPatterns).to receive(:names).at_least(:once)
@@ -1319,24 +1319,14 @@ describe Yast::Packages do
       subject.ListSelected(:product, "")
     end
 
-    it "filters not selected resolvables from the list" do
-      expect(subject.ListSelected(:product, "")).to
-        eq(filtered_products.map {|t| t.name}.sort)
+    it "filters and sorts not selected resolvables from the list" do
+      expect(subject.ListSelected(:product, "")).to eq(filtered_products.map {|t| t.name}.sort)
     end
 
-    it "filters not user visible resolvables from the list for type pattern" do
+    it "filters and sorts not user visible resolvables from the list for type pattern" do
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern)
         .and_return(unordered_patterns)
-      expect(subject).to receive(:sort_resolvable!)
-        .with(filtered_patterns, :pattern)
-
-      subject.ListSelected(:pattern, "")
-    end
-
-    it "sorts resultant list depending on resolvable type" do
-      expect(subject).to receive(:formatted_resolvables).with(ordered_products, "")
-
-      subject.ListSelected(:product, "")
+      expect(subject.ListSelected(:pattern, "")).to eq(filtered_patterns.map {|t| t.name}.sort)
     end
 
     it "returns an empty list if no resolvables selected" do

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1815,15 +1815,15 @@ describe Yast::Packages do
 
   describe "#proposal_changed?" do
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :patch, :status=>:selected)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :patch, status: :selected)
         .and_return([])
 
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, :status=>:selected)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, status: :selected)
         .and_return(
           [pattern("name" => "minimal_base", "status" => :selected),
            pattern("name" => "base", "status" => :selected)]
         )
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, status: :selected)
         .and_return([product("name" => "SLES", "status" => :selected)])
       allow(Yast::Pkg).to receive(:GetAdditionalLocales).and_return([])
       allow(Yast::Pkg).to receive(:GetPackageLocale).and_return("en_US")

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1053,10 +1053,10 @@ describe Yast::Packages do
     end
 
     let(:packages) { Yast::Packages.modePackages.sort.uniq }
-    let(:vnc_packages) { %w(some-vnc-packages) }
-    let(:remote_x11_packages) { %w(some-x11-packages) }
-    let(:ssh_packages) { %w(openssh iproute2) }
-    let(:braille_packages) { %w(sbl) }
+    let(:vnc_packages) { ["some-vnc-packages"] }
+    let(:remote_x11_packages) { ["some-x11-packages"] }
+    let(:ssh_packages) { ["openssh iproute2"] }
+    let(:braille_packages) { ["sbl"] }
 
     context "on a boring local regular installation" do
       let(:vnc) { false }
@@ -1116,10 +1116,10 @@ describe Yast::Packages do
       allow(Yast::Packages).to receive(:braille_packages).and_return(braille_packages)
     end
 
-    let(:vnc_packages) { %w(some-vnc-packages) }
-    let(:remote_x11_packages) { %w(some-x11-packages) }
-    let(:ssh_packages) { %w(openssh iproute2) }
-    let(:braille_packages) { %w(sbl) }
+    let(:vnc_packages) { ["some-vnc-packages"] }
+    let(:remote_x11_packages) { ["some-x11-packages"] }
+    let(:ssh_packages) { ["openssh iproute2"] }
+    let(:braille_packages) { ["sbl"] }
 
     context "on a boring local regular installation" do
       let(:vnc) { false }

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -376,21 +376,21 @@ describe Yast::Packages do
   end
 
   describe "#product_label" do
-    let(:product) { product(load_zypp("products_update.yml").first) }
+    let(:product_hash) { load_zypp("products_update.yml").first }
 
     it "returns display_name if available" do
-      expect(Yast::Packages.product_label(product)).to eq("SUSE Linux Enterprise Server 12")
+      expect(Yast::Packages.product_label(product(product_hash))).to eq("SUSE Linux Enterprise Server 12")
     end
 
     it "return short_name if display_name is not available" do
-      product["display_name"] = ""
-      expect(Yast::Packages.product_label(product)).to eq("SLES12")
+      product_hash["display_name"] = ""
+      expect(Yast::Packages.product_label(product(product_hash))).to eq("SLES12")
     end
 
     it "returns name when both display_name and short_name are not available" do
-      product["display_name"] = ""
-      product["short_name"] = ""
-      expect(Yast::Packages.product_label(product)).to eq("SLES")
+      product_hash["display_name"] = ""
+      product_hash["short_name"] = ""
+      expect(Yast::Packages.product_label(product(product_hash))).to eq("SLES")
     end
   end
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -607,8 +607,8 @@ describe Yast::Packages do
     context "when fips pattern is available" do
       before do
         allow_any_instance_of(Yast::ProductPatterns).to receive(:names).and_return([])
-        allow(Y2Packager::Resolvable).to receive(:find)
-          .with(name: "fips", kind: :pattern).and_return([pattern({ "name" => "fips" })])
+        allow(Y2Packager::Resolvable).to receive(:any?)
+          .with(name: "fips", kind: :pattern).and_return(true)
       end
 
       it "adds 'fips' pattern if the FIPS mode is active" do
@@ -632,8 +632,8 @@ describe Yast::Packages do
     context "when fips pattern is not available" do
       before do
         allow_any_instance_of(Yast::ProductPatterns).to receive(:names).and_return([])
-        allow(Y2Packager::Resolvable).to receive(:find)
-          .with(name: "fips", kind: :pattern).and_return([])
+        allow(Y2Packager::Resolvable).to receive(:any?)
+          .with(name: "fips", kind: :pattern).and_return(false)
         allow(Yast::Report).to receive(:Error)
       end
 

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1815,15 +1815,15 @@ describe Yast::Packages do
 
   describe "#proposal_changed?" do
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :patch)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :patch, :status=>:selected)
         .and_return([])
 
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, :status=>:selected)
         .and_return(
           [pattern("name" => "minimal_base", "status" => :selected),
            pattern("name" => "base", "status" => :selected)]
         )
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, :status=>:selected)
         .and_return([product("name" => "SLES", "status" => :selected)])
       allow(Yast::Pkg).to receive(:GetAdditionalLocales).and_return([])
       allow(Yast::Pkg).to receive(:GetPackageLocale).and_return("en_US")

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -376,7 +376,7 @@ describe Yast::Packages do
   end
 
   describe "#product_label" do
-    let(:product) { load_zypp("products_update.yml").first }
+    let(:product) { product(load_zypp("products_update.yml").first) }
 
     it "returns display_name if available" do
       expect(Yast::Packages.product_label(product)).to eq("SUSE Linux Enterprise Server 12")
@@ -395,9 +395,9 @@ describe Yast::Packages do
   end
 
   describe "#group_products_by_status" do
-    let(:products) { load_zypp("products_update.yml") }
-    let(:products2) { load_zypp("products_update2.yml") }
-    let(:smt_products) { load_zypp("products_update_smt.yml") }
+    let(:products) { load_zypp("products_update.yml").map { |p| product(p) } }
+    let(:products2) { load_zypp("products_update2.yml").map { |p| product(p) } }
+    let(:smt_products) { load_zypp("products_update_smt.yml").map { |p| product(p) } }
 
     it "returns groups of the products" do
       status = Yast::Packages.group_products_by_status(products)
@@ -405,7 +405,7 @@ describe Yast::Packages do
       expect(status[:new]).to eq([])
 
       # no update replacement for SDK, it will be removed
-      expect(status[:removed].first["display_name"]).to \
+      expect(status[:removed].first.display_name).to \
         eq("SUSE Linux Enterprise Software Development Kit 11 SP3")
 
       expect(status[:kept]).to eq([])
@@ -413,13 +413,13 @@ describe Yast::Packages do
       # update from SLES11-SP3 to SLES12
       expect(status[:updated].size).to eq(1)
       old_product, new_product = status[:updated].first
-      expect(old_product["display_name"]).to eq("SUSE Linux Enterprise Server 11 SP3")
-      expect(new_product["display_name"]).to eq("SUSE Linux Enterprise Server 12")
+      expect(old_product.display_name).to eq("SUSE Linux Enterprise Server 11 SP3")
+      expect(new_product.display_name).to eq("SUSE Linux Enterprise Server 12")
     end
 
     it "returns updated product which has been renamed" do
-      hae = { "name" => "sle-hae", "status" => :removed }
-      ha = { "name" => "sle-ha", "status" => :selected }
+      hae = product("name" => "sle-hae", "status" => :removed)
+      ha = product("name" => "sle-ha", "status" => :selected)
       products = [hae, ha]
 
       status = Yast::Packages.group_products_by_status(products)
@@ -432,9 +432,9 @@ describe Yast::Packages do
     end
 
     it "returns updated products which have been merged" do
-      hae = { "name" => "sle-hae", "status" => :removed }
-      haegeo = { "name" => "sle-haegeo", "status" => :removed }
-      ha = { "name" => "sle-ha", "status" => :selected }
+      hae = product( "name" => "sle-hae", "status" => :removed )
+      haegeo = product( "name" => "sle-haegeo", "status" => :removed )
+      ha = product( "name" => "sle-ha", "status" => :selected )
       products = [hae, haegeo, ha]
 
       status = Yast::Packages.group_products_by_status(products)

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -379,7 +379,8 @@ describe Yast::Packages do
     let(:product_hash) { load_zypp("products_update.yml").first }
 
     it "returns display_name if available" do
-      expect(Yast::Packages.product_label(product(product_hash))).to eq("SUSE Linux Enterprise Server 12")
+      expect(Yast::Packages.product_label(product(product_hash))).to
+      eq("SUSE Linux Enterprise Server 12")
     end
 
     it "return short_name if display_name is not available" do
@@ -432,9 +433,9 @@ describe Yast::Packages do
     end
 
     it "returns updated products which have been merged" do
-      hae = product( "name" => "sle-hae", "status" => :removed )
-      haegeo = product( "name" => "sle-haegeo", "status" => :removed )
-      ha = product( "name" => "sle-ha", "status" => :selected )
+      hae = product("name" => "sle-hae", "status" => :removed)
+      haegeo = product("name" => "sle-haegeo", "status" => :removed)
+      ha = product("name" => "sle-ha", "status" => :selected)
       products = [hae, haegeo, ha]
 
       status = Yast::Packages.group_products_by_status(products)

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -469,7 +469,7 @@ describe Yast::Packages do
   end
 
   describe "#product_update_summary" do
-    let(:products) { load_zypp("products_update.yml") }
+    let(:products) { load_zypp("products_update.yml").map { |p| product(p) } }
     let(:suma_products_map) { load_zypp("products_update_suma_branch_server.yml") }
     let(:suma_products) do
       suma_products_map.map do |p|
@@ -494,7 +494,7 @@ describe Yast::Packages do
     end
 
     it "handles multiple products updated to a single product" do
-      smt_update = load_zypp("products_update_smt.yml")
+      smt_update = load_zypp("products_update_smt.yml").map { |p| product(p) }
       summary_string = Yast::Packages.product_update_summary(smt_update).to_s
 
       expect(summary_string).to match(
@@ -523,7 +523,7 @@ describe Yast::Packages do
         .map { |p| Y2Packager::Product.from_h(p) }
       )
 
-      summary_string = Yast::Packages.product_update_summary(suma_products_map).to_s
+      summary_string = Yast::Packages.product_update_summary(suma_products).to_s
 
       # just to make the lines shorter
       rbs = "SUSE Manager Retail Branch Server"
@@ -545,7 +545,8 @@ describe Yast::Packages do
   end
 
   describe "#product_update_warning" do
-    let(:products) { load_zypp("products_update.yml") }
+    let(:products_map) { load_zypp("products_update.yml") }
+    let(:products) { products_map.map { |p| product(p) } }
 
     context "product will be removed due an obsolete" do
       before do
@@ -569,7 +570,10 @@ describe Yast::Packages do
       end
 
       it "returns empty hash when there is no automatically removed product" do
-        products.each { |product| product["transact_by"] = :user }
+        products = products_map.map do |p|
+          p["transact_by"] = :user
+          product(p)
+        end
         expect(Yast::Packages.product_update_warning(products)).to eq({})
       end
     end
@@ -596,7 +600,7 @@ describe Yast::Packages do
       # the SLES12-SP3 is replaced by the SUMA base product,
       # do not complain for the automatic SLES removal
       it "does not report any upgrade problem" do
-        expect(Yast::Packages.product_update_warning(suma_products_map)).to eq({})
+        expect(Yast::Packages.product_update_warning(suma_products)).to eq({})
       end
     end
   end

--- a/test/product_factory.rb
+++ b/test/product_factory.rb
@@ -84,13 +84,15 @@ class ProductFactory
     pattern_name = "#{product_name}_pattern"
     package_name = "#{product_name}-release"
     package = Y2Packager::Resolvable.new(
-      {"kind" => :package,
+      "kind" => :package,
        "name" => package_name, "status" => :selected,
        "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                  { "provides" => "defaultpattern(#{pattern_name})" }] })
+                  { "provides" => "defaultpattern(#{pattern_name})" }]
+    )
     product = Y2Packager::Resolvable.new(
       ProductFactory.create_product("status" => :selected,
-      "source" => src, "product_package" => package_name))
+      "source" => src, "product_package" => package_name)
+    )
 
     [pattern_name, package_name, package, product]
   end

--- a/test/product_factory.rb
+++ b/test/product_factory.rb
@@ -83,11 +83,14 @@ class ProductFactory
   def self.create_product_packages(product_name: "product", src: nil)
     pattern_name = "#{product_name}_pattern"
     package_name = "#{product_name}-release"
-    package = { "name" => package_name, "status" => :selected,
+    package = Y2Packager::Resolvable.new(
+      {"kind" => :package,
+       "name" => package_name, "status" => :selected,
        "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
-                  { "provides" => "defaultpattern(#{pattern_name})" }] }
-    product = ProductFactory.create_product("status" => :selected,
-      "source" => src, "product_package" => package_name)
+                  { "provides" => "defaultpattern(#{pattern_name})" }] })
+    product = Y2Packager::Resolvable.new(
+      ProductFactory.create_product("status" => :selected,
+      "source" => src, "product_package" => package_name))
 
     [pattern_name, package_name, package, product]
   end

--- a/test/product_factory.rb
+++ b/test/product_factory.rb
@@ -31,6 +31,7 @@ class ProductFactory
     # service pack level
     sp = rand(1..4)
 
+    product["kind"] = :product
     product["arch"] = attrs["arch"] || "x86_64"
     product["category"] = attrs["category"] || "addon"
     product["description"] = attrs["description"] || "SUSE Linux Enterprise #{product_name}."

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env rspec
 
 require_relative "./test_helper"
+require_relative "product_factory"
 
 Yast.import "ProductLicense"
 Yast.import "UI"
@@ -355,8 +356,9 @@ describe Yast::ProductLicense do
     before do
       allow(FileUtils).to receive(:mkdir_p)
       allow(Yast::Pkg).to receive(:SourceLoad)
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
-        .and_return([{ "name" => product, "source" => src }])
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+        .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product(
+          "name" => product, "source" => src))])
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(src)
         .and_return("product_dir" => "/test")
       allow(File).to receive(:write)
@@ -419,13 +421,11 @@ describe Yast::ProductLicense do
   end
 
   describe "#repository_product" do
-    let(:resolvable_properties) do
-      [{ "name" => "SLES-HA", "source" => 1 }, { "name" => "SLES-SDK", "source" => 2 }]
-    end
-
     before do
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
-        .and_return(resolvable_properties)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: 2)
+        .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product("name" => "SLES-SDK", "source" => 2 ))])
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: 3)
+        .and_return([])
     end
 
     context "when a product exists in the given repository" do

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -358,7 +358,8 @@ describe Yast::ProductLicense do
       allow(Yast::Pkg).to receive(:SourceLoad)
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product(
-          "name" => product, "source" => src))])
+                                                  "name" => product, "source" => src
+        ))])
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(src)
         .and_return("product_dir" => "/test")
       allow(File).to receive(:write)
@@ -423,7 +424,9 @@ describe Yast::ProductLicense do
   describe "#repository_product" do
     before do
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: 2)
-        .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product("name" => "SLES-SDK", "source" => 2 ))])
+        .and_return([Y2Packager::Resolvable.new(
+          ProductFactory.create_product("name" => "SLES-SDK", "source" => 2)
+        )])
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: 3)
         .and_return([])
     end

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -356,7 +356,8 @@ describe Yast::ProductLicense do
     before do
       allow(FileUtils).to receive(:mkdir_p)
       allow(Yast::Pkg).to receive(:SourceLoad)
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find)
+        .with(kind: :product, source: src)
         .and_return([Y2Packager::Resolvable.new(
           ProductFactory.create_product("name" => product, "source" => src)
         )])

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -357,9 +357,9 @@ describe Yast::ProductLicense do
       allow(FileUtils).to receive(:mkdir_p)
       allow(Yast::Pkg).to receive(:SourceLoad)
       allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
-        .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product(
-                                                  "name" => product, "source" => src
-        ))])
+        .and_return([Y2Packager::Resolvable.new(
+          ProductFactory.create_product("name" => product, "source" => src)
+        )])
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(src)
         .and_return("product_dir" => "/test")
       allow(File).to receive(:write)

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -26,7 +26,8 @@ describe Yast::ProductPatterns do
     it "returns empty list when the product release package is not found" do
       product = Y2Packager::Resolvable.new(
         ProductFactory.create_product("status"          => :selected,
-          "product_package" => nil))
+                                      "product_package" => nil)
+      )
 
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product])

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -10,26 +10,27 @@ Yast.import "Pkg"
 describe Yast::ProductPatterns do
   describe "#names" do
     it "returns empty list when there are no products" do
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([])
 
       expect(subject.names).to eq([])
     end
 
     it "returns empty list when there is no selected product" do
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
-        .and_return([ProductFactory.create_product])
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+        .and_return([Y2Packager::Resolvable.new(ProductFactory.create_product)])
 
       expect(subject.names).to eq([])
     end
 
     it "returns empty list when the product release package is not found" do
-      product = ProductFactory.create_product("status"          => :selected,
-                                              "product_package" => nil)
+      product = Y2Packager::Resolvable.new(
+        ProductFactory.create_product("status"          => :selected,
+          "product_package" => nil))
 
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(product["name"], :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product["name"], kind: :product)
         .and_return([product])
 
       expect(subject.names).to eq([])
@@ -39,11 +40,11 @@ describe Yast::ProductPatterns do
       pattern_name, package_name, package, product =
         ProductFactory.create_product_packages(product_name: "product1")
 
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(product["name"], :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product["name"], kind: :product)
         .and_return([product])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name, :package, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name, kind: :package)
         .and_return([package])
 
       expect(subject.names).to eq([pattern_name])
@@ -56,15 +57,15 @@ describe Yast::ProductPatterns do
       pattern_name_second, package_name_second, package_second, product_second =
         ProductFactory.create_product_packages(product_name: "product_second")
 
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product_first, product_second])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(product_first["name"], :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_first["name"], kind: :product)
         .and_return([product_first])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(product_second["name"], :product, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_second["name"], kind: :product)
         .and_return([product_second])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name_first, :package, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_first, kind: :package)
         .and_return([package_first])
-      expect(Yast::Pkg).to receive(:ResolvableDependencies).with(package_name_second, :package, "")
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_second, kind: :package)
         .and_return([package_second])
 
       expect(subject.names.sort).to eq([pattern_name_first, pattern_name_second].sort)
@@ -81,19 +82,19 @@ describe Yast::ProductPatterns do
         pattern_name_selected, package_name_selected, package_selected, product_selected =
           ProductFactory.create_product_packages(product_name: "product_selected", src: 2)
 
-        expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
           .and_return([product_other, product_selected])
-        expect(Yast::Pkg).to receive(:ResolvableProperties)
-          .with(product_other["name"], :product, "")
+        expect(Y2Packager::Resolvable).to receive(:find)
+          .with(name: product_other["name"], kind: :product)
           .and_return([product_other])
-        expect(Yast::Pkg).to receive(:ResolvableProperties)
-          .with(product_selected["name"], :product, "")
+        expect(Y2Packager::Resolvable).to receive(:find)
+          .with(name: product_selected["name"], kind: :product)
           .and_return([product_selected])
         # the product_other package should not be checked, it's in different repo
-        expect(Yast::Pkg).to_not receive(:ResolvableDependencies)
-          .with(package_name_other, :package, "")
-        expect(Yast::Pkg).to receive(:ResolvableDependencies)
-          .with(package_name_selected, :package, "")
+        expect(Y2Packager::Resolvable).to_not receive(:find)
+          .with(name: package_name_other, kind: :package)
+        expect(Y2Packager::Resolvable).to receive(:find)
+          .with(name: package_name_selected, kind: :package)
           .and_return([package_selected])
 
         expect(subject.names).to eq([pattern_name_selected])

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -60,13 +60,17 @@ describe Yast::ProductPatterns do
 
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product_first, product_second])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_first.name, kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_first.name,
+                                                            kind: :product)
         .and_return([product_first])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_second.name, kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_second.name,
+                                                            kind: :product)
         .and_return([product_second])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_first, kind: :package)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_first,
+                                                            kind: :package)
         .and_return([package_first])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_second, kind: :package)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_second,
+                                                            kind: :package)
         .and_return([package_second])
 
       expect(subject.names.sort).to eq([pattern_name_first, pattern_name_second].sort)

--- a/test/product_patterns_test.rb
+++ b/test/product_patterns_test.rb
@@ -30,7 +30,7 @@ describe Yast::ProductPatterns do
 
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product["name"], kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product.name, kind: :product)
         .and_return([product])
 
       expect(subject.names).to eq([])
@@ -42,7 +42,7 @@ describe Yast::ProductPatterns do
 
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product["name"], kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product.name, kind: :product)
         .and_return([product])
       expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name, kind: :package)
         .and_return([package])
@@ -59,9 +59,9 @@ describe Yast::ProductPatterns do
 
       expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return([product_first, product_second])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_first["name"], kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_first.name, kind: :product)
         .and_return([product_first])
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_second["name"], kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with(name: product_second.name, kind: :product)
         .and_return([product_second])
       expect(Y2Packager::Resolvable).to receive(:find).with(name: package_name_first, kind: :package)
         .and_return([package_first])
@@ -85,10 +85,10 @@ describe Yast::ProductPatterns do
         expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
           .and_return([product_other, product_selected])
         expect(Y2Packager::Resolvable).to receive(:find)
-          .with(name: product_other["name"], kind: :product)
+          .with(name: product_other.name, kind: :product)
           .and_return([product_other])
         expect(Y2Packager::Resolvable).to receive(:find)
-          .with(name: product_selected["name"], kind: :product)
+          .with(name: product_selected.name, kind: :product)
           .and_return([product_selected])
         # the product_other package should not be checked, it's in different repo
         expect(Y2Packager::Resolvable).to_not receive(:find)

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -214,9 +214,12 @@ describe Y2Packager::Repository do
   describe "#products" do
     let(:products_data) { [product] }
     let(:product) do
-      Y2Packager::Resolvable.new(ProductFactory.create_product(
-        "arch" => "x86_64", "name" => "openSUSE", "category" => "addon",
-        "status" => :available, "source" => repo_id, "vendor" => "openSUSE"))
+      Y2Packager::Resolvable.new(
+        ProductFactory.create_product(
+          "arch" => "x86_64", "name" => "openSUSE", "category" => "addon",
+          "status" => :available, "source" => repo_id, "vendor" => "openSUSE"
+        )
+      )
     end
 
     it "returns products available in the repository" do

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -223,7 +223,7 @@ describe Y2Packager::Repository do
     end
 
     it "returns products available in the repository" do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: repo_id)
         .and_return(products_data)
       product = repo.products.first
       expect(product.name).to eq("openSUSE")

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "test_helper"
 require "y2packager/repository"
+require_relative "product_factory"
 require "uri"
 
 describe Y2Packager::Repository do
@@ -213,12 +214,13 @@ describe Y2Packager::Repository do
   describe "#products" do
     let(:products_data) { [product] }
     let(:product) do
-      { "arch" => "x86_64", "name" => "openSUSE", "category" => "addon",
-        "status" => :available, "source" => repo_id, "vendor" => "openSUSE" }
+      Y2Packager::Resolvable.new(ProductFactory.create_product(
+        "arch" => "x86_64", "name" => "openSUSE", "category" => "addon",
+        "status" => :available, "source" => repo_id, "vendor" => "openSUSE"))
     end
 
     it "returns products available in the repository" do
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
         .and_return(products_data)
       product = repo.products.first
       expect(product.name).to eq("openSUSE")

--- a/test/self_update_addon_filter_test.rb
+++ b/test/self_update_addon_filter_test.rb
@@ -34,8 +34,9 @@ describe Y2Packager::SelfUpdateAddonFilter do
     end
 
     it "returns packages providing 'system-installation()' from the required repository" do
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(anything, :package, "")
-        .and_return(["source" => pkg_src]).exactly(4).times
+      expect(Y2Packager::Resolvable).to receive(:any?)
+        .with(kind: :package, name: //, source: pkg_src)
+        .and_return(true).exactly(4).times
 
       expect(Y2Packager::SelfUpdateAddonFilter.packages(pkg_src)).to contain_exactly(
         "skelcd-control-SLED", "skelcd-control-SLES", "SLES-release", "system-role-server-default"
@@ -43,8 +44,9 @@ describe Y2Packager::SelfUpdateAddonFilter do
     end
 
     it "returns an empty list if the packages are not from the required repository" do
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(anything, :package, "")
-        .and_return(["source" => 999]).exactly(4).times
+      expect(Y2Packager::Resolvable).to receive(:any?)
+        .with(kind: :package, name: //, source: pkg_src)
+        .and_return(false).exactly(4).times
 
       expect(Y2Packager::SelfUpdateAddonFilter.packages(pkg_src)).to eq([])
     end

--- a/test/system_packages_test.rb
+++ b/test/system_packages_test.rb
@@ -22,13 +22,12 @@ describe Y2Packager::SystemPackages do
       allow(Yast::Pkg).to receive(:GetSolverFlags)
       allow(Yast::Pkg).to receive(:PkgSolve)
       allow(Yast::Pkg).to receive(:SetSolverFlags)
-      allow(Yast::Pkg).to receive(:ResolvableProperties).and_return(
-        [
+      allow(Y2Packager::Resolvable).to receive(:find).and_return(
+        [Y2Packager::Resolvable.new(kind: :package,
           "name"        => system_package,
           "source"      => source_id,
           "status"      => :selected,
-          "transact_by" => :solver
-        ]
+          "transact_by" => :solver)]
       )
 
       expect(subject.packages).to eq(["system_package"])


### PR DESCRIPTION
Replacing old Pkg.ResolvableProperties()and Pkg.ResolvabeDependencies() calls by Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find in order to save memory.