### PR TITLE
Do not crash when the product licenses cannot be read (bsc#1155454)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  1 18:52:02 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not crash when the product licenses cannot be read
+  (bsc#1155454)
+- 4.2.31
+
+-------------------------------------------------------------------
 Tue Oct  1 17:13:42 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not add an empty repository from the offline medium root

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1711,6 +1711,7 @@ module Yast
       product_names.each do |product_name|
         locales = Pkg.PrdLicenseLocales(product_name)
         log.info("License locales for product #{product_name.inspect}: #{locales.inspect}")
+        next unless locales
 
         locales.each do |locale|
           license = Pkg.PrdGetLicenseToConfirm(product_name, locale)

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1709,9 +1709,10 @@ module Yast
       found_license = false
 
       product_names.each do |product_name|
-        locales = Pkg.PrdLicenseLocales(product_name)
+        # in some corner cases the repository might contain a broken product
+        # for which we get 'nil' locales (bsc#1155454)
+        locales = Pkg.PrdLicenseLocales(product_name) || []
         log.info("License locales for product #{product_name.inspect}: #{locales.inspect}")
-        next unless locales
 
         locales.each do |locale|
           license = Pkg.PrdGetLicenseToConfirm(product_name, locale)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1155454
- This is kind of unusual bug, the tester used the http://download.suse.de/full/full-sle15-sp2-x86_64/ repository which contains all packages including the SLE and openSUSE products. Some product is broken there as libzypp reports this error:  
```
2019-10-29 11:47:43 <2> install(3486) [zypp] Product.cc(referencePackage):112
    (785)product:--0.noarch(full-sle15-sp2-x86_64): no reference package found:
    product() == -0
```
- Tested manually, now with the fix it does not crash
- 4.2.31
