### PR TITLE
Preselect the installed add-ons (jsc#SLE-7101)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  8 18:58:23 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Preselect the installed add-ons when upgrading from the Full
+  installation medium (related to jsc#SLE-7101)
+- 4.2.32
+
+-------------------------------------------------------------------
 Fri Nov  1 18:52:02 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not crash when the product licenses cannot be read

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.31
+Version:        4.2.32
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -240,29 +240,10 @@ module Y2Packager
       def preselected_products
         return [] unless Yast::Mode.update
 
-        installed_addons = Y2Packager::Resolvable.find(
-          kind: :product, status: :installed, type: "add-on"
-        ).map(&:name) + Y2Packager::Resolvable.find(
-          kind: :product, status: :removed, type: "add-on"
-        ).map(&:name)
-
-        selected_addons = Y2Packager::Resolvable.find(
-          kind: :product, status: :selected, type: "add-on"
-        ).map(&:name)
-
-        # handle the product renames, if a renamed product was installed
-        # replace it with the new product so the new product is preselected
-        Yast::AddOnProductClass::DEFAULT_PRODUCT_RENAMES.each do |k, v|
-          next unless installed_addons.include?(k)
-
-          installed_addons.delete(k)
-          installed_addons.concat(v)
-        end
-
+        missing_products = Yast::AddOnProduct.missing_upgrades
         # installed but not selected yet products (to avoid duplicates)
         products.select do |p|
-          installed_addons.include?(p.details&.product) &&
-            !selected_addons.include?(p.details&.product)
+          missing_products.include?(p.details&.product)
         end
       end
     end

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -1967,6 +1967,38 @@ module Yast
         old_name, new_name)
     end
 
+    # Return a list of the product add-ons which are installed but are not selected for upgrade.
+    # These add-ons should be additionally selected to install.
+    # It handles also the product renames, the returned list might contain different
+    # (new) names than the currently installed products.
+    # @return [Array<String>] the product names
+    def missing_upgrades
+      installed_addons = Y2Packager::Resolvable.find(
+        kind: :product, status: :installed, type: "addon"
+      ).map(&:name) + Y2Packager::Resolvable.find(
+        kind: :product, status: :removed, type: "addon"
+      ).map(&:name)
+
+      selected_addons = Y2Packager::Resolvable.find(
+        kind: :product, status: :selected, type: "addon"
+      ).map(&:name)
+
+      # handle the product renames, if a renamed product was installed
+      # replace it with the new product so the new product is preselected
+      DEFAULT_PRODUCT_RENAMES.each do |k, v|
+        next unless installed_addons.include?(k)
+
+        installed_addons.delete(k)
+        installed_addons.concat(v)
+      end
+
+      # installed but not selected
+      ret = installed_addons - selected_addons
+
+      log.info "Found missing product upgrades: #{ret}"
+      ret
+    end
+
     publish variable: :add_on_products, type: "list <map <string, any>>"
     publish variable: :src_id, type: "integer"
     publish variable: :last_ret, type: "symbol"


### PR DESCRIPTION
- ...when upgrading from the Full installation medium
- Related to https://jira.suse.com/browse/SLE-7101
- Handles also the product renames
- Tested manually
- 4.2.32

## Screenshot

When upgrading from the SP1 the already installed modules are automatically preselected:

![preselected_addons](https://user-images.githubusercontent.com/907998/68503344-e0376a00-0262-11ea-87cc-44fe20d76c2a.png)
