### PR TITLE
Show beta warning only once

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 26 14:21:34 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Show beta warning only once (bsc#1156629).
+- 4.2.34
+
+-------------------------------------------------------------------
 Fri Nov  8 19:28:57 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.33
+Version:        4.2.34
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/info_file.rb
+++ b/src/lib/y2packager/info_file.rb
@@ -1,0 +1,58 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "digest"
+
+module Y2Packager
+  # Small class to hold info files related information
+  #
+  # It is responsible for reading and generating a unique ID.
+  class InfoFile
+    class << self
+      # Reads a file from the given path
+      #
+      # @return [InfoFile,nil] InfoFile if it was read or nil if it could not be read
+      def read(file_path)
+        content = Yast::SCR.Read(Yast::Path.new(".target.string"), file_path)
+        return nil unless content
+
+        new(content)
+      end
+    end
+
+    # @return [String] File content
+    attr_reader :content
+
+    # Constructor
+    #
+    # @param content [String] File content
+    def initialize(content)
+      @content = content
+    end
+
+    # File unique ID
+    #
+    # The file ID is based on the file content. The path is not taken into account.
+    #
+    # @return [String]
+    def id
+      @id ||= Digest::SHA2.hexdigest(content)
+    end
+  end
+end

--- a/src/lib/y2packager/info_file.rb
+++ b/src/lib/y2packager/info_file.rb
@@ -27,6 +27,7 @@ module Y2Packager
     class << self
       # Reads a file from the given path
       #
+      # @param file_path [String] File path to read
       # @return [InfoFile,nil] InfoFile if it was read or nil if it could not be read
       def read(file_path)
         content = Yast::SCR.Read(Yast::Path.new(".target.string"), file_path)

--- a/src/modules/InstShowInfo.rb
+++ b/src/modules/InstShowInfo.rb
@@ -22,7 +22,7 @@ module Yast
     def show_info_txt(file_path)
       info_file = Y2Packager::InfoFile.read(file_path)
       if info_file.nil?
-        Builtins.y2milestone("No %1", info_file)
+        Builtins.y2milestone("No %1", file_path)
         return
       end
 

--- a/src/modules/InstShowInfo.rb
+++ b/src/modules/InstShowInfo.rb
@@ -1,4 +1,5 @@
 require "yast"
+require "y2packager/info_file"
 
 # Yast namespace
 module Yast
@@ -13,10 +14,24 @@ module Yast
 
       Yast.import "Report"
       Yast.import "Label"
+
+      @shown_info_files = []
     end
 
-    # @param [String] info_file path to be shown
-    def show_info_txt(info_file)
+    # @param file_path [String] path to be shown
+    def show_info_txt(file_path)
+      info_file = Y2Packager::InfoFile.read(file_path)
+      if info_file.nil?
+        Builtins.y2milestone("No %1", info_file)
+        return
+      end
+
+      if already_shown?(info_file)
+        Builtins.y2milestone("Info file with id #{info_file.id} was already shown")
+        return
+      end
+      register_as_shown(info_file)
+
       display_info = UI.GetDisplayInfo
       size_x = Builtins.tointeger(Ops.get_integer(display_info, "Width", 800))
       size_y = Builtins.tointeger(Ops.get_integer(display_info, "Height", 600))
@@ -27,13 +42,6 @@ module Yast
         size_x = 54
         size_y = 15
       end
-
-      if Ops.less_or_equal(SCR.Read(path(".target.size"), info_file), 0)
-        Builtins.y2milestone("No %1", info_file)
-        return
-      end
-
-      info_text = Convert.to_string(SCR.Read(path(".target.string"), info_file))
 
       report_settings = Report.Export
       message_settings = Ops.get_map(report_settings, "messages", {})
@@ -56,7 +64,7 @@ module Yast
 
       UI.OpenDialog(
         VBox(
-          MinSize(size_x, size_y, RichText(Opt(:plainText), info_text)),
+          MinSize(size_x, size_y, RichText(Opt(:plainText), info_file.content)),
           if use_timeout
             Label(Id(:timeout), Builtins.sformat("   %1   ", timeout_seconds))
           else
@@ -94,6 +102,25 @@ module Yast
     end
 
     publish function: :show_info_txt, type: "void (string)"
+
+  private
+
+    # Determines whether an info file was already shown
+    #
+    # @param info_file [InfoFile] Info file to check
+    # @return [Boolean] true if it was already shown; false otherwise
+    def already_shown?(info_file)
+      @shown_info_files.include?(info_file.id)
+    end
+
+    # Registers an info file as already shown
+    #
+    # When an info file is registered, it will not be shown again when calling {#show_info_txt}.
+    #
+    # @param info_file [InfoFile] Info file to register
+    def register_as_shown(info_file)
+      @shown_info_files << info_file.id
+    end
   end
 
   InstShowInfo = InstShowInfoClass.new

--- a/test/data/README.BETA
+++ b/test/data/README.BETA
@@ -1,0 +1,17 @@
+
+   SLES15-SP2 Alpha4
+ 
+   Attention! You are accessing our Beta Distribution.  If you install
+   any package, note that we can NOT GIVE ANY SUPPORT for your system - 
+   no matter if you update from a previous system or do a complete 
+   new installation.
+
+   Use this BETA distribution at your own risk! We recommend it for
+   testing, porting and evaluation purposes but not for any critical
+   production systems.
+
+   Use this distribution at your own risk - and remember to have a
+   lot of fun! :)
+
+                Your SUSE Linux Enterprise Team
+

--- a/test/inst_show_info_test.rb
+++ b/test/inst_show_info_test.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "./test_helper"
+
+Yast.import "InstShowInfo"
+
+describe Yast::InstShowInfo do
+  before do
+    described_class.main
+  end
+
+  describe "#show_info_txt" do
+    let(:path) { File.join(DATA_PATH, "README.BETA") }
+
+    it "shows the file content" do
+      expect(Yast::UI).to receive(:OpenDialog)
+      subject.show_info_txt(path)
+    end
+
+    context "when a file with the same content was already shown" do
+      before do
+        subject.show_info_txt(path)
+      end
+
+      it "does not show the content" do
+        expect(Yast::UI).to_not receive(:OpenDialog)
+        subject.show_info_txt(path)
+      end
+    end
+  end
+end

--- a/test/lib/info_file_test.rb
+++ b/test/lib/info_file_test.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env rspec
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2packager/info_file"
+
+describe Y2Packager::InfoFile do
+  subject(:info_file) { described_class.read(readme_path) }
+  let(:readme_path) { File.join(DATA_PATH, "README.BETA") }
+
+  describe ".read" do
+    it "reads the file from the given path" do
+      file = described_class.read(readme_path)
+      expect(file.content).to include("Attention!")
+    end
+
+    context "when the file does not exists" do
+      it "returns nil" do
+        file = described_class.read("does-not-exist.txt")
+        expect(file).to be_nil
+      end
+    end
+  end
+
+  describe "#id" do
+    it "returns a digest based ID" do
+      expect(info_file.id).to start_with("999de")
+    end
+  end
+end


### PR DESCRIPTION
## The problem

According to [bsc#1156629](https://bugzilla.suse.com/show_bug.cgi?id=1156629), the installer shows a beta warning for each beta module. Ideally, it should display the (same) beta warning only once. Of course, if two beta warnings are different, then it should show both of them.

Trello: https://trello.com/c/d8jtS3dA/
## The solution

This PR extends the `InstShowInfo` module to keep track of which information has already been displayed based on the file content (nor on the path). It is something similar to what YaST [already does](https://github.com/yast/yast-yast2/blob/22d33428525ecffbcab4c1cc9a911dce43f07704/library/packages/src/lib/y2packager/license.rb#L124) with licenses.

## Where is InstShowInfo.show_info_txt used?

```txt
registration/src/lib/registration/ui/addon_eula_dialog.rb
144:        Yast::InstShowInfo.show_info_txt(info_file) if File.exist?(info_file)

packager/src/modules/ProductLicense.rb
241:      InstShowInfo.show_info_txt(@beta_file) if !@beta_file.nil?
370:        InstShowInfo.show_info_txt(@beta_file) if !@beta_file.nil?
807:        InstShowInfo.show_info_txt(@beta_file)

installation/src/lib/installation/clients/inst_complex_welcome.rb
67:        InstShowInfo.show_info_txt(BETA_FILE)
```