### PR TITLE
Fix typo in the "Module and Extension Selection" screen

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 27 11:12:43 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix a typo in the "Extension and Module Selection" screen
+  (bsc#1157789).
+- 4.2.35
+
+-------------------------------------------------------------------
 Tue Nov 26 14:21:34 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Show beta warning only once (bsc#1156629).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.34
+Version:        4.2.35
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -213,7 +213,7 @@ module Y2Packager
       # @return [String] translated text
       def description
         # TRANSLATORS: inline help text displayed below the product selection widget
-        _("Select a product to see it's description here. The dependent products " \
+        _("Select a product to see its description here. The dependent products " \
           "are selected automatically.")
       end
 


### PR DESCRIPTION
Fixes a typo in the add ons selection screen. See [bsc#1157789](https://bugzilla.suse.com/show_bug.cgi?id=1157789).