### PR TITLE
Speed up calculation of libzypp product renames

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  5 18:20:30 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Speed up product renames calculation (bsc#1157926).
+- 4.1.50
+
+-------------------------------------------------------------------
 Thu Aug 29 11:11:05 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Avoid error when generating some warnings (bsc#1148536).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.49
+Version:        4.1.50
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -58,12 +58,13 @@ module Y2Packager
     class << self
       # Return all registered repositories
       #
+      # @param enabled_only [Boolean] Returns only enabled repositories
       # @return [Array<Repository>] Array containing all repositories
       #
       # @see Yast::Pkg.SourceGetCurrent
       # @see Y2Packager::Repository.find
-      def all
-        Yast::Pkg.SourceGetCurrent(false).map do |repo_id|
+      def all(enabled_only: false)
+        Yast::Pkg.SourceGetCurrent(enabled_only).map do |repo_id|
           find(repo_id)
         end
       end

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -46,6 +46,8 @@ module Y2Packager
     attr_reader :name
     # @return [URI::Generic] Repository URL
     attr_reader :url
+    # @return [String] Product directory
+    attr_reader :product_dir
 
     attr_writer :enabled
     private :enabled=
@@ -91,7 +93,7 @@ module Y2Packager
         raise NotFound if repo_data.nil?
         new(repo_id: repo_id, enabled: repo_data["enabled"],
           name: repo_data["name"], autorefresh: repo_data["autorefresh"],
-          url: URI(repo_data["url"]))
+          url: URI(repo_data["url"]), product_dir: repo_data["product_dir"])
       end
 
       # Add a repository
@@ -101,12 +103,15 @@ module Y2Packager
       # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
       # @param url         [URI::Generic] Repository URL
       # @return [Y2Packager::Repository,nil] New repository or nil if creation failed
-      def create(name:, url:, enabled: true, autorefresh: true)
+      def create(name:, url:, product_dir: "", enabled: true, autorefresh: true)
         repo_id = Yast::Pkg.RepositoryAdd(
           "name" => name, "base_urls" => [url], "enabled" => enabled, "autorefresh" => autorefresh
         )
         return nil unless repo_id
-        new(repo_id: repo_id, name: name, url: URI(url), enabled: enabled, autorefresh: autorefresh)
+        new(
+          repo_id: repo_id, name: name, url: URI(url), enabled: enabled,
+          autorefresh: autorefresh, product_dir: product_dir
+        )
       end
     end
 
@@ -117,12 +122,14 @@ module Y2Packager
     # @param enabled     [Boolean]      Is the repository enabled?
     # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
     # @param url         [URI::Generic] Repository URL
-    def initialize(repo_id:, name:, enabled:, autorefresh:, url:)
+    # @param product_dir [String]       Product directory
+    def initialize(repo_id:, name:, enabled:, autorefresh:, url:, product_dir: "/")
       @repo_id = repo_id
       @name    = name
       @enabled = enabled
       @autorefresh = autorefresh
       @url = url
+      @product_dir = product_dir
     end
 
     # Return repository scheme

--- a/src/lib/y2packager/repository.rb
+++ b/src/lib/y2packager/repository.rb
@@ -124,7 +124,7 @@ module Y2Packager
     # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
     # @param url         [URI::Generic] Repository URL
     # @param product_dir [String]       Product directory
-    def initialize(repo_id:, name:, enabled:, autorefresh:, url:, product_dir: "/")
+    def initialize(repo_id:, name:, enabled:, autorefresh:, url:, product_dir: "")
       @repo_id = repo_id
       @name    = name
       @enabled = enabled

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2214,11 +2214,14 @@ module Yast
     # @return [Boolean]
     def libzypp_repos_changed?
       repos = Y2Packager::Repository.all(enabled_only: true).sort_by(&:repo_id).map do |repo|
-        [repo.repo_id, repo.url, repo.product_dir]
+        "#{repo.repo_id}-#{repo.url}-#{repo.product_dir}"
       end
-      return false if @old_repos == repos
-      @old_repos = repos
-      true
+      if @old_repos == repos
+        false
+      else
+        @old_repos = repos
+        true
+      end
     end
   end
 

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2214,7 +2214,7 @@ module Yast
     # @return [Boolean]
     def libzypp_repos_changed?
       repos = Y2Packager::Repository.all(enabled_only: true).sort_by(&:repo_id).map do |repo|
-        File.join(repo.url.to_s, repo.product_dir.to_s)
+        [repo.repo_id, repo.url, repo.product_dir]
       end
       return false if @old_repos == repos
       @old_repos = repos

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -2067,7 +2067,7 @@ module Yast
     # @see names_from_product_package
     # @see add_rename_to_hash
     def product_renames_from_libzypp
-      return @libzypp_product_renames if @libzypp_product_renames && !libzypp_repos_changed?
+      return @libzypp_product_renames if !libzypp_repos_changed? && @libzypp_product_renames
       @libzypp_product_renames = {}
       # Dependencies are not included in this call
       products = Pkg.ResolvableProperties("", :product, "")

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -4,6 +4,7 @@ require "yast"
 require "shellwords"
 
 require "packager/product_patterns"
+require "y2packager/repository"
 
 # Yast namespace
 module Yast
@@ -171,6 +172,10 @@ module Yast
       # E.g.: product:sle-module-basesystem-15-0.x86_64 has buddy
       # sle-module-basesystem-release-15-91.2.x86_64
       @selected_installation_products = [] # e.g.:  ["sle-module-basesystem"]
+
+      # Libzypp product renames cache. When loaded, it is supposed to be a Hash.
+      # @see #product_renames_from_libzypp
+      @libzypp_product_renames = nil
     end
 
     # Downloads a requested file, caches it and returns path to that cached file.
@@ -2062,16 +2067,18 @@ module Yast
     # @see names_from_product_package
     # @see add_rename_to_hash
     def product_renames_from_libzypp
-      renames = {}
+      return @libzypp_product_renames if @libzypp_product_renames && !libzypp_repos_changed?
+      @libzypp_product_renames = {}
       # Dependencies are not included in this call
       products = Pkg.ResolvableProperties("", :product, "")
       products.each do |product|
-        renames = names_from_product_packages(product["product_package"])
-                  .reduce(renames) do |hash, rename|
+        next unless product["product_package"]
+        @libzypp_product_renames = names_from_product_packages(product["product_package"])
+                                   .reduce(@libzypp_product_renames) do |hash, rename|
           add_rename_to_hash(hash, rename, product["name"])
         end
       end
-      renames
+      @libzypp_product_renames
     end
 
     # Regular expresion to extract the product name. It supports two different
@@ -2197,6 +2204,21 @@ module Yast
 
       log.info("Found y2update.tgz file from the installer extension package: #{y2update}")
       y2update
+    end
+
+    # Determines whether the repositories libzypp information might have change
+    #
+    # This method returns true when the list of enabled repositories has changed.
+    # Disabled repositories are not even considered.
+    #
+    # @return [Boolean]
+    def libzypp_repos_changed?
+      repos = Y2Packager::Repository.all(enabled_only: true).sort_by(&:repo_id).map do |repo|
+        File.join(repo.url.to_s, repo.product_dir.to_s)
+      end
+      return false if @old_repos == repos
+      @old_repos = repos
+      true
     end
   end
 

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -31,6 +31,16 @@ describe Yast::AddOnProduct do
     end
 
     context "when according to libzypp a product is renamed" do
+      before do
+        subject.main
+        allow(Y2Packager::Repository).to receive(:all).and_return([repo0])
+      end
+
+      let(:repo0) do
+        instance_double(
+          Y2Packager::Repository, repo_id: 0, url: URI("dvd:///sr0"), product_dir: "/p0"
+        )
+      end
       let(:deps) do
         [
           { "obsoletes" => "product:old_product1" },
@@ -62,6 +72,37 @@ describe Yast::AddOnProduct do
         expect(subject.renamed?("old_product1", new_product["name"])).to eq(true)
         expect(subject.renamed?("old_product2", new_product["name"])).to eq(true)
         expect(subject.renamed?("old_name", new_product["name"])).to eq(true)
+      end
+
+      context "when renames information has been already loaded" do
+        before do
+          subject.renamed?("old_name", new_product["name"])
+        end
+
+        it "does not ask libzypp again" do
+          expect(Yast::Pkg).to_not receive(:ResolvableDependencies)
+          subject.renamed?("old_name", new_product["name"])
+        end
+
+        context "but renames information is obsolete" do
+          let(:repo1) do
+            instance_double(
+              Y2Packager::Repository, repo_id: 1, url: URI("dvd:///sr0"), product_dir: "/p1"
+            )
+          end
+
+          before do
+            subject.renamed?("old_name", new_product["name"])
+            allow(Y2Packager::Repository).to receive(:all).and_return([repo0, repo1])
+          end
+
+          it "asks libzypp again" do
+            expect(Yast::Pkg).to receive(:ResolvableDependencies)
+              .with(new_product["product_package"], :package, "")
+              .and_return([installed_product_package, new_product_package])
+            subject.renamed?("old_name", new_product["name"])
+          end
+        end
       end
     end
   end

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "./test_helper"
 require_relative "product_factory"
+require "uri"
 
 Yast.import "AddOnProduct"
 
@@ -84,7 +85,7 @@ describe Yast::AddOnProduct do
           subject.renamed?("old_name", new_product["name"])
         end
 
-        context "but renames information is obsolete" do
+        context "but a new repo has been added" do
           let(:repo1) do
             instance_double(
               Y2Packager::Repository, repo_id: 1, url: URI("dvd:///sr0"), product_dir: "/p1"
@@ -92,14 +93,44 @@ describe Yast::AddOnProduct do
           end
 
           before do
-            subject.renamed?("old_name", new_product["name"])
             allow(Y2Packager::Repository).to receive(:all).and_return([repo0, repo1])
           end
 
           it "asks libzypp again" do
-            expect(Yast::Pkg).to receive(:ResolvableDependencies)
-              .with(new_product["product_package"], :package, "")
-              .and_return([installed_product_package, new_product_package])
+            expect(Yast::Pkg).to receive(:ResolvableDependencies).and_return([])
+            subject.renamed?("old_name", new_product["name"])
+          end
+        end
+
+        context "but the repo_id for a given repo has changed" do
+          before do
+            allow(repo0).to receive(:repo_id).and_return(1)
+          end
+
+          it "asks libzypp again" do
+            expect(Yast::Pkg).to receive(:ResolvableDependencies).and_return([])
+            subject.renamed?("old_name", new_product["name"])
+          end
+        end
+
+        context "but the url for a given repo has changed" do
+          before do
+            allow(repo0).to receive(:url).and_return(URI("dvd:///sr2"))
+          end
+
+          it "asks libzypp again" do
+            expect(Yast::Pkg).to receive(:ResolvableDependencies).and_return([])
+            subject.renamed?("old_name", new_product["name"])
+          end
+        end
+
+        context "but the product_dir for a given repo has changed" do
+          before do
+            allow(repo0).to receive(:product_dir).and_return("/another")
+          end
+
+          it "asks libzypp again" do
+            expect(Yast::Pkg).to receive(:ResolvableDependencies).and_return([])
             subject.renamed?("old_name", new_product["name"])
           end
         end

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -39,7 +39,8 @@ describe Yast::AddOnProduct do
 
       let(:repo0) do
         instance_double(
-          Y2Packager::Repository, repo_id: 0, url: URI("dvd:///sr0"), product_dir: "/p0"
+          Y2Packager::Repository, repo_id: 0, url: URI("dvd:///?devices=/dev/sr0"),
+          product_dir: "/p0"
         )
       end
       let(:deps) do
@@ -88,7 +89,8 @@ describe Yast::AddOnProduct do
         context "but a new repo has been added" do
           let(:repo1) do
             instance_double(
-              Y2Packager::Repository, repo_id: 1, url: URI("dvd:///sr0"), product_dir: "/p1"
+              Y2Packager::Repository, repo_id: 1, url: URI("dvd:///?devices=/dev/sr0"),
+              product_dir: "/p1"
             )
           end
 
@@ -115,7 +117,7 @@ describe Yast::AddOnProduct do
 
         context "but the url for a given repo has changed" do
           before do
-            allow(repo0).to receive(:url).and_return(URI("dvd:///sr2"))
+            allow(repo0).to receive(:url).and_return(URI("dvd:///?devices=/dev/sr2"))
           end
 
           it "asks libzypp again" do

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -74,7 +74,7 @@ describe Y2Packager::Repository do
     context "when a valid repo_id is given" do
       let(:repo_data) do
         { "enabled" => true, "autorefresh" => true, "url" => repo_url,
-          "name" => "Repo #1" }
+          "name" => "Repo #1", "product_dir" => "/product" }
       end
 
       it "returns a repository with the given repo_id" do
@@ -82,6 +82,7 @@ describe Y2Packager::Repository do
         expect(repo.repo_id).to eq(repo_id)
         expect(repo.enabled?).to eq(repo_data["enabled"])
         expect(repo.url).to eq(URI(repo_data["url"]))
+        expect(repo.product_dir).to eq("/product")
       end
     end
 

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -24,7 +24,7 @@ describe Y2Packager::Repository do
 
   describe ".all" do
     before do
-      expect(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return(repo_ids)
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return(repo_ids)
     end
 
     context "when no repository exist" do
@@ -42,6 +42,20 @@ describe Y2Packager::Repository do
       it "returns an array containing existing repositories" do
         expect(described_class).to receive(:find).with(repo_id).and_return(repo)
         expect(described_class.all).to eq([repo])
+      end
+    end
+
+    context "when asked only for enabled repositories" do
+      let(:repo_ids) { [repo_id] }
+      let(:repo) { double("repo") }
+
+      before do
+        allow(described_class).to receive(:find).with(repo_id).and_return(repo)
+      end
+
+      it "returns only enabled repositories" do
+        expect(Yast::Pkg).to receive(:SourceGetCurrent).with(true).and_return(repo_ids)
+        described_class.all(enabled_only: true)
       end
     end
   end


### PR DESCRIPTION
This PR solves [bsc#1157926](https://bugzilla.suse.com/show_bug.cgi?id=1157926). The real problem is that it takes too much time to calculate the product renames from `libzypp`. So this PRs adds some code to cache these renames.

On the other hand,  it avoids trying to find the product rename when the `product_package` property is missing, avoiding a lot of failing calls to `Pkg.ResolvableDependencies`.

In a test I did in a VM, the patch reduced the time to show the analysis result from 45 seconds to just 9 seconds. We can even improve this time by moving the logic to invalidate the cached data outside of the `AddOnProduct` module, avoiding asking libzypp for changes. However, that approach looks wrong to me.

Trello: https://trello.com/c/ZTskvrjr/

![analyzing-your-system](https://user-images.githubusercontent.com/15836/70262007-6c1db280-178b-11ea-9857-25dd5d949fa5.png)

## Speed comparison

<details>
<summary>Migration proposal (from 45s to 9s)</summary>

Old code: ~45 seconds
![load-migration-products](https://user-images.githubusercontent.com/15836/70532580-41e34080-1b4f-11ea-8b2a-c3e52081f6fe.gif)

New code: ~9 seconds
![faster-load-migration-products](https://user-images.githubusercontent.com/15836/70532597-4d366c00-1b4f-11ea-89af-d0f5c1d5b2b5.gif)
</details>

<details>
<summary>Migration target selection (from 12s to 4s)</summary>

Old code
![load-migration-products](https://user-images.githubusercontent.com/15836/70527673-5f5edd00-1b44-11ea-9e8a-bd14902cc12c.gif)

New code
![faster-load-migration-products](https://user-images.githubusercontent.com/15836/70527701-6e458f80-1b44-11ea-8da4-5ca9d7d7ecf1.gif)
</details>