### PR TITLE
Config crash

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 20 10:51:24 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- do not crash when invalid URL is used in config mode
+  (bsc#1073208)
+- 4.2.40
+
+-------------------------------------------------------------------
 Wed Dec 11 17:11:04 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Speed up product renames calculation (bsc#1157926).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.39
+Version:        4.2.40
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/SourceManager.rb
+++ b/src/modules/SourceManager.rb
@@ -272,7 +272,9 @@ module Yast
 
       UI.CloseDialog if !Mode.commandline
 
-      if @newSources.nil? || @newSources == -1 || @newSources.size.zero?
+      # Pkg.SourceScan can return Array with repos or -1 if failed. So be more
+      # paranoid here and accept only non empty list as success result.
+      if !@newSources.is_a?(::Array) || @newSources.empty?
         message1 = Builtins.sformat(
           _("Unable to create repository\nfrom URL '%1'."),
           URL.HidePassword(url)

--- a/src/modules/SourceManager.rb
+++ b/src/modules/SourceManager.rb
@@ -272,7 +272,7 @@ module Yast
 
       UI.CloseDialog if !Mode.commandline
 
-      if Builtins.size(@newSources).zero?
+      if @newSources.nil? || @newSources == -1 || @newSources.size.zero?
         message1 = Builtins.sformat(
           _("Unable to create repository\nfrom URL '%1'."),
           URL.HidePassword(url)


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1073208

crash is caused by returning -1 on which Builtins.size raises exception.