### PR TITLE
Do not fail because %F "argument"

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 27 11:13:55 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not fail when Packager.desktop file is invoked without a list
+  of files (bsc#1159419).
+- 4.2.41
+
+-------------------------------------------------------------------
 Fri Dec 20 10:51:24 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - do not crash when invalid URL is used in config mode

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.40
+Version:        4.2.41
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/bin/sw_single_wrapper
+++ b/src/bin/sw_single_wrapper
@@ -8,8 +8,11 @@
 ARGS=""
 for ARG in "$@"
 do
-    QUOTED_ARG=$(printf %q "$ARG")
-    ARGS="$ARGS $QUOTED_ARG"
+    if [ "$ARG" != "%F" ]
+    then
+        QUOTED_ARG=$(printf %q "$ARG")
+        ARGS="$ARGS $QUOTED_ARG"
+    fi
 done
 
 xdg-su -c "/sbin/yast2 sw_single $ARGS"


### PR DESCRIPTION
## Problem

When the [Packager.desktop](https://github.com/yast/yast-packager/blob/master/desktop/org.opensuse.yast.Packager.desktop) file is _invoked_ without a list of files, YaST Software Manager fails with _"The following packages has not been found in the medium: %F"_ message.

* https://bugzilla.suse.com/show_bug.cgi?id=1159419

## Solution

Avoid to include the `%F` argument since it means that none file was given. Otherwise, it will be replaced by the list of files (see https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html for more information).

## Tests

Tested manually:

* To run the YaST Software Manager directly form the XFCE Settings Manager.
* To run the YaST Software Manger via right click -> "Open with YaST Software" in an _rpm_ file.

## Screenshots

<details>
<summary>Click to show/hide</summary>

---

<p align="center"><em>Before changes</em></p>

![YaST Software Manager BEFORE changes](https://user-images.githubusercontent.com/1691872/71515358-c0074d00-289a-11ea-95b8-dce832b62e76.png)

---

<p align="center"><em>After changes</em></p>


![YaST Software Manager BEFORE changes](https://user-images.githubusercontent.com/1691872/71515613-03ae8680-289c-11ea-8139-e0794857fc91.png)


</details>
