### PR TITLE
Do not refresh package installation overview if the medium has changed.

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan  9 17:03:31 CET 2020 - schubi@suse.de
+
+- Do not refresh package installation overview if the medium has
+  been changed and the user has switched to the release notes tab.
+  (bsc#1129426, bsc#1159367)
+- 4.2.43
+
+-------------------------------------------------------------------
 Thu Jan  2 16:29:45 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Improve warning when all repositories are disabled (bsc#1158512)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
 # SlideShow.Redraw
-BuildRequires:  yast2 >= 4.2.52
+BuildRequires:  yast2 >= 4.2.54
 # Pkg::Resolvables
 BuildRequires:  yast2-pkg-bindings >= 4.2.0
 # Augeas lenses
@@ -48,7 +48,7 @@ Requires:       yast2-country-data >= 2.16.3
 # Pkg::Resolvables
 Requires:       yast2-pkg-bindings >= 4.2.0
 # SlideShow.Redraw
-Requires:       yast2 >= 4.2.52
+Requires:       yast2 >= 4.2.54
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.42
+Version:        4.2.43
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -35,8 +35,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
-# Y2Packager::Resolvable moved to yast2 package
-BuildRequires:  yast2 >= 4.2.43
+# SlideShow.user_switched_to_release_notes
+BuildRequires:  yast2 >= 4.2.52
 # Pkg::Resolvables
 BuildRequires:  yast2-pkg-bindings >= 4.2.0
 # Augeas lenses
@@ -47,8 +47,8 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # Pkg::Resolvables
 Requires:       yast2-pkg-bindings >= 4.2.0
-# Y2Packager::Resolvable moved to yast2 package
-Requires:       yast2 >= 4.2.43
+# SlideShow.user_switched_to_release_notes
+Requires:       yast2 >= 4.2.52
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -35,7 +35,7 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
-# SlideShow.user_switched_to_release_notes
+# SlideShow.Redraw
 BuildRequires:  yast2 >= 4.2.52
 # Pkg::Resolvables
 BuildRequires:  yast2-pkg-bindings >= 4.2.0
@@ -47,7 +47,7 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # Pkg::Resolvables
 Requires:       yast2-pkg-bindings >= 4.2.0
-# SlideShow.user_switched_to_release_notes
+# SlideShow.Redraw
 Requires:       yast2 >= 4.2.52
 # unzipping license file
 Requires:       unzip

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -540,6 +540,9 @@ module Yast
       SlideShow.CheckForSlides
       FindNextMedia()
 
+      # do not rebuild if the user reads the release notes
+      return if SlideShow.user_switched_to_release_notes
+
       if Slides.HaveSlides && Slides.HaveSlideSupport
         if !SlideShow.HaveSlideWidget
           # (true) : Showing release tab if needed

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -529,36 +529,16 @@ module Yast
     #
     def SetCurrentCdNo(src_no, cd_no)
       if cd_no.zero?
-        Builtins.y2milestone("medium number 0, using medium number 1")
+        log.info("medium number 0, using medium number 1")
         cd_no = 1
       end
 
-      Builtins.y2milestone("SetCurrentCdNo() - src: %1 , CD: %2", src_no, cd_no)
-      @current_src_no = Ops.get(@srcid_to_current_src_no, src_no, -1)
+      log.info("SetCurrentCdNo() - src: #{src_no} , CD: #{cd_no}")
+      @current_src_no = @srcid_to_current_src_no[src_no] || -1
       @current_cd_no = cd_no
-
-      SlideShow.CheckForSlides
       FindNextMedia()
 
-      # do not rebuild if the user reads the release notes
-      return if SlideShow.user_switched_to_release_notes
-
-      if Slides.HaveSlides && Slides.HaveSlideSupport
-        if !SlideShow.HaveSlideWidget
-          # (true) : Showing release tab if needed
-          SlideShow.RebuildDialog(true)
-
-          SlideShow.SwitchToDetailsView if SlideShow.user_switched_to_details
-        end
-
-        # Don't override explicit user request!
-        SlideShow.SwitchToSlideView if !SlideShow.user_switched_to_details
-      elsif !SlideShow.ShowingDetails
-        # (true) : Showing release tab if needed
-        SlideShow.RebuildDialog(true)
-      end
-
-      nil
+      SlideShow.Redraw() # Redrawing the complete slide show if needed.
     end
 
     # Recalculate remaining times per CD based on package sizes remaining

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -40,7 +40,6 @@ module Yast
     # @return true if user wishes to abort
     #
     def HandleInput
-      # any button = SlideShow::debug ? UI::PollInput() : UI::TimeoutUserInput( 10 );
       button = UI.PollInput
 
       # in case of cancel ask user if he really wants to quit installation


### PR DESCRIPTION
**Problem**
Reading Release Notes during installation is impossible because the installation switch to the
"Details" tab when the medium has been changed.
**Solution**
Do not refresh package installation overview if the medium has been changed and the user has switched to the release notes tab.