### PR TITLE
Don't Overwrite English License of Add-on Modules with Translated License

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 29 15:35:20 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't overwrite the default English license for add-on modules
+  with the translated license of the current installation language
+  (bsc#1160806)
+- 4.2.47
+
+-------------------------------------------------------------------
 Mon Jan 27 13:57:31 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Move y2packager/repository.rb to the yast2.rpm

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.46
+Version:        4.2.47
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1515,7 +1515,7 @@ module Yast
       # 'LANG=foo_BAR yast repositories'
       language = EnvLangToLangCode(Builtins.getenv("LANG"))
 
-      # Preferencies how the client selects from available languages
+      # Preferences how the client selects from available languages
       langs = [
         language,
         Builtins.substring(language, 0, 2), # "it_IT" -> "it"
@@ -1539,7 +1539,7 @@ module Yast
         end
       end
 
-      Builtins.y2milestone("Preffered lang: %1", language)
+      Builtins.y2milestone("Preferred lang: %1", language)
       return :auto if Builtins.size(available_langs.value).zero? # no license available
 
       @lic_lang = Builtins.find(langs) { |l| Builtins.haskey(licenses.value, l) }

--- a/src/modules/ProductLicense.rb
+++ b/src/modules/ProductLicense.rb
@@ -1716,7 +1716,11 @@ module Yast
         log.info("License locales for product #{product_name.inspect}: #{locales.inspect}")
 
         locales.each do |locale|
-          license = Pkg.PrdGetLicenseToConfirm(product_name, locale)
+          # Pkg.PrdGetLicenseToConfirm returns the license in the installation
+          # language, not the default English license if the requested locale
+          # is an empty string (bsc#1160806)
+          license_locale = locale.empty? ? "en" : locale
+          license = Pkg.PrdGetLicenseToConfirm(product_name, license_locale)
           next if license.nil? || license.empty?
 
           found_license = true


### PR DESCRIPTION
## Trello

https://trello.com/c/bsdGtjCH/1600-3-sle-15-sp2-p1-extension-module-ha-license-always-uses-current-language-when-english-is-selected

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1160806

## Problem

When installing in French, the license for an add-on module that has a license (like SLE-HA) is not available in English; the license that should be displayed when English is selected in the combo box above that module license is always in French.

This is the same for all other languages where a translated license is available (German, Italian, Russian, Chinese, ...).


## Cause

That code path does weird things: It unpacks the license tarball manually file by file (or, rather, language by language) even though it is already available unpacked in the file system. While unpacking, it overwrites the file that should contain the default English license, `license.txt`, with the translated license (the content of `license_fr.txt` in this case).

It uses  `Pkg.PrdGetLicenseToConfirm(product_name, locale)` which already handles the "empty string" case: If the requested locale is an empty string, it returns the "best" translation available, i.e. the license translation for the current installation license (French).


## Fix

Explicitly request English ("en") if the locale is empty while iterating over the languages.


## Screenshot

![add-on-03-modules-en-fixed](https://user-images.githubusercontent.com/11538225/73372096-f891b080-42b6-11ea-8252-84e0a1f756cd.png)


## Test

I had to add a line with `***` to the license text (for debugging only, of course) to make that workflow step visible: Since the license text for that add-on module is verbatim the same as the license for the base product (SLES), it would otherwise skip that step because the user already accepted that exact same language.

_@snwint is my witness._ :smiley: 