### PR TITLE
Online Search: display the "Search Online" option in registrable systems

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  5 15:36:54 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Enable the "Search Online" menu entry for those systems that
+  are registered or that can be registered (jsc#SLE-9109).
+- 4.2.49
+
+-------------------------------------------------------------------
 Tue Feb  4 14:09:29 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Mark packager and repositories as WSL capable modules

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.48
+Version:        4.2.49
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -456,7 +456,7 @@ module Yast
         end
       end
       repo_management = Mode.normal if repo_management.nil?
-      online_search = Mode.normal && registered?
+      online_search = Mode.normal && online_search_available?
 
       ret = {
         "mode" => mode, "enable_repo_mgr" => repo_management,
@@ -804,14 +804,14 @@ module Yast
 
   private
 
-    # Determines whether the running system is registered or not
+    # Determines whether the online search can be used in the running system
     #
-    # @return [Booolean] true if the system is registered; false otherwise
-    def registered?
-      require "registration/registration"
-      ::Registration::Registration.is_registered?
-    rescue LoadError
-      false
+    # @note The online search feature is available in those systems that
+    #   can be installed. For the time being, we rely on the online_search
+    #   client being available (from `yast2-registration`).
+    # @return [Boolean]
+    def online_search_available?
+      Yast::WFM.ClientExists("online_search")
     end
   end
 end


### PR DESCRIPTION
Enable the `Search Online` feature when the client is available. The idea is to show the option only in those systems that can be registered. For the time being, `yast2-registration` is not available in such systems.