### PR TITLE
Avoid crashing when changing the language and keyboard layout

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 18 15:47:45 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Avoid crashing when changing a language and keyboard layout
+  (bsc#1161842).
+- 4.2.50
+
+-------------------------------------------------------------------
 Wed Feb  5 15:36:54 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Enable the "Search Online" menu entry for those systems that

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.49
+Version:        4.2.50
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -417,6 +417,8 @@ module Yast
       while @next_src_no < @remaining_sizes_per_cd_per_src.size
         remaining_sizes = @remaining_sizes_per_cd_per_src[@next_src_no]
 
+        break if remaining_sizes.nil?
+
         while @next_cd_no < remaining_sizes.size
           return if remaining_sizes[@next_cd_no] > 0
 


### PR DESCRIPTION
## Problem

After code cleaning performed at https://github.com/yast/yast-packager/pull/499, `yast2 language` is crashing in `FindNextMedia` when changing the language and keyboard layout.

* https://bugzilla.suse.com/show_bug.cgi?id=1161842
* https://trello.com/c/4mvMZhMP/1607-ostumbleweed-p5-1161842-y2-packager-yast2-language-switch-get-error

## Solution

Do not try to find next media when there are no _remaining\_sizes\_per\_cd\_per\_src_

:warning: originally, the code [were falling back to default values](https://github.com/yast/yast-packager/blob/a14c1fcc11a0ce8547747daa8144a9bafbc81eef/src/modules/PackageSlideShow.rb#L409-L443), producing the same result than the `break` line introduced in this commit. :warning:

## Tests

- Only tested manually


