### PR TITLE
Allow SHA checksums

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 19 15:34:23 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Media checker does not complain because sha checksums
+  (bsc#1158432).
+- Media checker shows information about the signature.
+- 4.2.51
+
+-------------------------------------------------------------------
 Tue Feb 18 15:47:45 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Avoid crashing when changing a language and keyboard layout

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.50
+Version:        4.2.51
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

YaST has a module (*CheckMedia*) for checking a media integrity. This module is complaining when the iso does not contain a md5 checksum in its application data block, see https://github.com/openSUSE/checkmedia#checkmedia. But new images contains a sha256 checksum instead of md5.

* https://bugzilla.suse.com/show_bug.cgi?id=1158432
* https://trello.com/c/OpCDVEry/1649-sle15-sp2-p2-1158432-build-101-check-media-media-does-not-contain-an-md5-checksum

## Solution

When searching for a checksum in the iso application data block, sha checksums are also considered.

Bonus: Now the module also shows information about the signature (i.e., whether the medium is signed or not, and if so, whether the signature can be verified).
 
## Testing

*MediaCheck* module does not contain unit tests. I consider it does not worth adding unit test  here because this module is kind of deprecated (probably we will drop it out in the future). Of course, it was tested manually.

## Screenshots

<details>
<summary>Show/Hide</summary>

![Screenshot from 2020-02-19 14-19-41](https://user-images.githubusercontent.com/1112304/74849179-5488ab80-5330-11ea-9591-135f15801705.png)

</details>
