### PR TITLE
Preselect the default modules (jsc#SLE-8040)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 25 09:00:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Preselect the default modules in the offline installation
+  (jsc#SLE-8040, jsc#SLE-11455)
+- 4.2.52
+
+-------------------------------------------------------------------
 Wed Feb 19 15:34:23 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Media checker does not complain because sha checksums

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -17,6 +17,7 @@ require "y2packager/resolvable"
 
 Yast.import "AddOnProduct"
 Yast.import "Mode"
+Yast.import "ProductFeatures"
 Yast.import "Report"
 Yast.import "Stage"
 Yast.import "UI"
@@ -234,16 +235,47 @@ module Y2Packager
         erb.result(binding)
       end
 
-      # return a list of the preselected products
-      # during upgrade we want to preselect the installed products
+      # return a list of the preselected products depending on the installation mode
       # @return [Array<Y2Packager::ProductLocation>] the products
       def preselected_products
-        return [] unless Yast::Mode.update
+        # at upgrade preselect the installed addons
+        return preselected_upgrade_products if Yast::Mode.update
+        # in installation preselect the defaults defined in the control.xml/installation.xml
+        return preselected_installation_products if Yast::Mode.installation
 
+        # in other modes (e.g. installed system) do not preselect anything
+        []
+      end
+
+      # return a list of the preselected products at upgrade,
+      # preselect the installed products
+      # @return [Array<Y2Packager::ProductLocation>] the products
+      def preselected_upgrade_products
         missing_products = Yast::AddOnProduct.missing_upgrades
         # installed but not selected yet products (to avoid duplicates)
         products.select do |p|
           missing_products.include?(p.details&.product)
+        end
+      end
+
+      # return a list of the preselected products at installation,
+      # preselect the default products specified in the control.xml/installation.xml,
+      # the already selected products are ignored
+      # @return [Array<Y2Packager::ProductLocation>] the products
+      def preselected_installation_products
+        default_modules = Yast::ProductFeatures.GetFeature("software", "default_modules")
+        return [] unless default_modules
+
+        log.info("Defined default modules: #{default_modules.inspect}")
+        # skip the already selected products (to avoid duplicates)
+        selected_products = Y2Packager::Resolvable.find(kind: :product, status: :selected)
+          .map(&:name)
+        default_modules -= selected_products
+        log.info("Using default modules: #{default_modules.inspect}")
+
+        # select the default products
+        products.select do |p|
+          default_modules.include?(p.details&.product)
         end
       end
     end


### PR DESCRIPTION
## The Problem

- We need to preselect the default modules also in the offline installation ([jsc#SLE-8040](https://jira.suse.com/browse/SLE-8040))
- In online installation it already works (we get the defaults from the SCC)
- Related to https://github.com/yast/skelcd-control-leanos/pull/52

## Solution

- Read the defaults from the `control.xml`/`installation.xml`
- Preselect the matching products, skip the products which are already selected to install to avoid duplicates

## Testing

- Added an unit test
- Also tested manually, with the updated control file (https://github.com/yast/skelcd-control-leanos/pull/52) the Basesystem module is automatically preselected:
![preselect_default_modules](https://user-images.githubusercontent.com/907998/75233433-23d5c580-57b9-11ea-8d95-1b2f56ebf2e1.png)
