### PR TITLE
Fixed going back (bsc#1163023)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 27 13:44:18 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed going back (bsc#1163023)
+- 4.2.53
+
+-------------------------------------------------------------------
 Tue Feb 25 09:00:30 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Preselect the default modules in the offline installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.52
+Version:        4.2.53
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -16,6 +16,7 @@ require "y2packager/product"
 require "y2packager/self_update_addon_repo"
 require "y2packager/medium_type"
 
+Yast.import "GetInstArgs"
 Yast.import "Packages"
 Yast.import "PackageCallbacks"
 Yast.import "Popup"
@@ -36,6 +37,9 @@ module Y2Packager
       # Client main method
       def main
         textdomain "packager"
+
+        # no changes if going back
+        return :back if Yast::GetInstArgs.going_back
 
         if Y2Packager::MediumType.skip_step?
           log.info "Skipping the client on the #{Y2Packager::MediumType.type} medium"

--- a/test/lib/clients/inst_repositories_initialization_test.rb
+++ b/test/lib/clients/inst_repositories_initialization_test.rb
@@ -21,6 +21,7 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       allow(Y2Packager::SelfUpdateAddonRepo).to receive(:present?).and_return(false)
       allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
       allow(Y2Packager::MediumType).to receive(:offline?).and_return(false)
+      allow(Yast::GetInstArgs).to receive(:going_back).and_return(false)
     end
 
     it "initializes Packages subsystem" do
@@ -42,6 +43,21 @@ describe Y2Packager::Clients::InstRepositoriesInitialization do
       expect(Y2Packager::SelfUpdateAddonRepo).to receive(:present?).and_return(false)
       expect(Y2Packager::SelfUpdateAddonRepo).to_not receive(:create_repo)
       client.main
+    end
+
+    context "going back" do
+      before do
+        allow(Yast::GetInstArgs).to receive(:going_back).and_return(true)
+      end
+
+      it "does not initialize Packages subsystem" do
+        expect(Yast::Packages).to_not receive(:InitializeCatalogs)
+        client.main
+      end
+
+      it "returns :back" do
+        expect(client.main).to eq(:back)
+      end
     end
 
     context "when initialization fails" do


### PR DESCRIPTION
## Problem

- When going back the workflow is restarted at the system analyze step and goes forward again, you actually cannot go back at all.
- See https://bugzilla.suse.com/show_bug.cgi?id=1163023

## Fix

- Handle `GetInstArgs.going_back` in the `inst_repositories_initialization.rb` client

## Tests

- Added unit tests
- Tested manually, with the fix I could go back even to the initial product selection
  The base product cannot be changed (as it is already registered)
  ![going_back_already_registered](https://user-images.githubusercontent.com/907998/75452430-95a53f00-5972-11ea-97d5-7bd23bfa91b4.png)
  And the already registered addons are properly marked and disabled:  
![going_back_already_registered_addons](https://user-images.githubusercontent.com/907998/75452452-9dfd7a00-5972-11ea-8130-d4e05d00b618.png)
- So it seems to work as expected.


