### PR TITLE
Empty preselected modules

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 28 16:53:10 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when the list of preselected modules is not defined
+  (related to jsc#SLE-8040, jsc#SLE-11455).
+- 4.2.54
+
+-------------------------------------------------------------------
 Thu Feb 27 13:44:18 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed going back (bsc#1163023)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.53
+Version:        4.2.54
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -264,7 +264,7 @@ module Y2Packager
       # @return [Array<Y2Packager::ProductLocation>] the products
       def preselected_installation_products
         default_modules = Yast::ProductFeatures.GetFeature("software", "default_modules")
-        return [] unless default_modules
+        return [] if default_modules == ""
 
         log.info("Defined default modules: #{default_modules.inspect}")
         # skip the already selected products (to avoid duplicates)

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -264,7 +264,7 @@ module Y2Packager
       # @return [Array<Y2Packager::ProductLocation>] the products
       def preselected_installation_products
         default_modules = Yast::ProductFeatures.GetFeature("software", "default_modules")
-        return [] if default_modules == ""
+        return [] unless default_modules.is_a?(Array)
 
         log.info("Defined default modules: #{default_modules.inspect}")
         # skip the already selected products (to avoid duplicates)


### PR DESCRIPTION
Do not crash when the list of preselected modules is empty (the default for `GetFeature` is an empty string).