### PR TITLE
bsc#1157780: improve addon selector

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 28 17:11:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- In the addon selector, display by default the information of the
+  first available product (related to bsc#1157780).
+- 4.2.55
+
+-------------------------------------------------------------------
 Fri Feb 28 16:53:10 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when the list of preselected modules is not defined

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.54
+Version:        4.2.55
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -108,7 +108,7 @@ module Y2Packager
         res = super
         Yast::Wizard.EnableNextButton
         Yast::Wizard.EnableBackButton
-
+        Yast::UI.SetFocus(Id(:addon_repos))
         res
       end
 
@@ -206,16 +206,17 @@ module Y2Packager
       # description widget
       # @return [Yast::Term] the addon details widget
       def details_widget
-        VWeight(40, RichText(Id(:details), Opt(:disabled), "<small>" +
-        description + "</small>"))
+        VWeight(
+          40,
+          RichText(Id(:details), Opt(:disabled), initial_description)
+        )
       end
 
       # extra help text
-      # @return [String] translated text
-      def description
-        # TRANSLATORS: inline help text displayed below the product selection widget
-        _("Select a product to see its description here. The dependent products " \
-          "are selected automatically.")
+      # @return [String] first product description
+      def initial_description
+        return "" if products.empty?
+        product_description(products.first)
       end
 
       def product_description(product)

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -216,6 +216,7 @@ module Y2Packager
       # @return [String] first product description
       def initial_description
         return "" if products.empty?
+
         product_description(products.first)
       end
 

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -83,9 +83,7 @@ module Y2Packager
 
       # Handle changing the current item or changing the selection
       def addon_repos_handler
-        current_item = Yast::UI.QueryWidget(Id(:addon_repos), :CurrentItem)
-        current_product = products.find { |p| p.dir == current_item }
-
+        current_product = find_current_product
         return unless current_product
 
         refresh_details(current_product)
@@ -279,6 +277,14 @@ module Y2Packager
         products.select do |p|
           default_modules.include?(p.details&.product)
         end
+      end
+
+      # Returns the current product (the one which has the focus in the addons list)
+      #
+      # @param [Y2Packager::Product,nil]
+      def find_current_product
+        current_item = Yast::UI.QueryWidget(Id(:addon_repos), :CurrentItem)
+        products.find { |p| p.dir == current_item }
       end
     end
   end

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -281,7 +281,7 @@ module Y2Packager
 
       # Returns the current product (the one which has the focus in the addons list)
       #
-      # @param [Y2Packager::Product,nil]
+      # @return [Y2Packager::Product,nil]
       def find_current_product
         current_item = Yast::UI.QueryWidget(Id(:addon_repos), :CurrentItem)
         products.find { |p| p.dir == current_item }


### PR DESCRIPTION
As the discussion about https://github.com/yast/yast-registration/pull/483 is taking some time, we have decided to propose this alternative fix until the new widget is ready. Bear in mind that the new widget will bring other improvements, but this PR should at least fix the bug described in [bsc#1157780](https://bugzilla.suse.com/show_bug.cgi?id=1157780) (although it changes the behaviour). Let's consider this a *Plan B* :)

In a nutshell, the idea is to consider the first available product as the current one (although it is not selected) and display its information. See the screenshots below and read on to find further information.

<details>
<summary>Addon selection in Qt</summary>

![addon-selection-qt](https://user-images.githubusercontent.com/15836/75568693-ab3a6780-5a4b-11ea-8037-acd2258c7e45.png)
</details>

<details>
<summary>Addon selection in ncurses</summary>

![addon-selection-ncurses](https://user-images.githubusercontent.com/15836/75567813-0bc8a500-5a4a-11ea-8a07-cca315a7b4fb.png)
</details>

## The problem

The selector widget considers the first element as the current one. So if the user clicks in the first element to see the details, the widget will not propagate that event (in reality, the value has not changed).