### PR TITLE
Fix packages count

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  4 11:34:30 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix showing count of packages to install in slide show
+  (bsc#1161412)
+- 4.2.56
+
+-------------------------------------------------------------------
 Fri Feb 28 17:11:05 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - In the addon selector, display by default the information of the

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.55
+Version:        4.2.56
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -706,32 +706,32 @@ module Yast
         next if ListSum(inst_src) < 1
 
         inst_src.each_with_index do |src_remaining, cd_no|
-          if src_remaining > 0 ||
-              (src_no + 1) == @current_src_no &&
-                  (cd_no + 1) == @current_cd_no # suppress current CD
-            caption = @inst_src_names[src_no] || _("Unknown Source")
-            # add "Medium 1" only if more cds available (bsc#1158498)
-            caption += @media_type + (cd_no + 1).to_s unless @last_cd
-            rem_size = FormatRemainingSize(src_remaining) # column #1
-            rem_count = FormatRemainingCount(
-              @remaining_pkg_count_per_cd_per_src.dig(src_no, cd_no) || 0
-            )
-            rem_time = HOURGLASS
+          next unless src_remaining > 0 ||
+            (src_no + 1) == @current_src_no &&
+              (cd_no + 1) == @current_cd_no # suppress current CD
 
-            if show_remaining_time? && @bytes_per_second > 0
-              src_remaining /= @bytes_per_second
-              rem_time = FormatTimeShowOverflow(src_remaining) # column #2
-            end
+          caption = @inst_src_names[src_no] || _("Unknown Source")
+          # add "Medium 1" only if more cds available (bsc#1158498)
+          caption += @media_type + (cd_no + 1).to_s unless @last_cd
+          rem_size = FormatRemainingSize(src_remaining) # column #1
+          rem_count = FormatRemainingCount(
+            @remaining_pkg_count_per_cd_per_src.dig(src_no, cd_no) || 0
+          )
+          rem_time = HOURGLASS
 
-            itemList <<
-              SlideShow.TableItem(
-                "cd(#{src_no},#{cd_no})", # ID
-                caption,
-                ITEM_PREFIX + rem_size,
-                ITEM_PREFIX + rem_count,
-                ITEM_PREFIX + rem_time
-              )
+          if show_remaining_time? && @bytes_per_second > 0
+            src_remaining /= @bytes_per_second
+            rem_time = FormatTimeShowOverflow(src_remaining) # column #2
           end
+
+          itemList <<
+            SlideShow.TableItem(
+              "cd(#{src_no},#{cd_no})", # ID
+              caption,
+              ITEM_PREFIX + rem_size,
+              ITEM_PREFIX + rem_count,
+              ITEM_PREFIX + rem_time
+            )
         end
       end
 

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -700,16 +700,12 @@ module Yast
       # Now go through all repositories
       #
 
-      src_no = 0
-
-      @remaining_sizes_per_cd_per_src.each do |inst_src|
+      @remaining_sizes_per_cd_per_src.each_with_index do |inst_src, src_no|
         log.info "src ##{src_no}: #{inst_src}"
         # Ignore repositories from where there is nothing is to install
         next if ListSum(inst_src) < 1
 
-        cd_no = 0
-
-        inst_src.each do |src_remaining|
+        inst_src.each_with_index do |src_remaining, cd_no|
           if src_remaining > 0 ||
               (src_no + 1) == @current_src_no &&
                   (cd_no + 1) == @current_cd_no # suppress current CD
@@ -736,9 +732,7 @@ module Yast
                 ITEM_PREFIX + rem_time
               )
           end
-          cd_no += 1
         end
-        src_no += 1
       end
 
       itemList


### PR DESCRIPTION
trello: https://trello.com/c/HYrsC1sL/1679-3-sles15-sp2-p5-1161412-build-1261-slideshowdetails-packages-to-install-are-presented-incorrectly
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1161412

tested manually
root of issue is the "next" call when repository does not contain anything to install. That break src_no counting and point wrongly to hash.