### PR TITLE
Avoid installation abort

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  5 16:21:35 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid to abort the installer when the user decides to not fix a
+  repository url (bsc#1163015).
+- 4.2.57
+
+-------------------------------------------------------------------
 Wed Mar  4 11:34:30 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - fix showing count of packages to install in slide show

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.56
+Version:        4.2.57
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -53,10 +53,12 @@ module Yast
     #   with this alias already exists then it is overwritten, use empty string ""
     #   to generate an unique alias
     # @return [Symbol] the result
-    #   :ok => successfully added
-    #   :again => failed, but user wants to edit the URL and try again
+    #   :ok     => successfully added
+    #   :again  => failed, but user wants to edit the URL and try again
+    #   :next   => continue in the workflow
     #   :cancel => failed, don't retry
-    #   :abort => repository added successfully, but user rejected the license
+    #   :abort  => repository added successfully, but user rejected the license
+    #
     #   TODO: abort is problematic as abort is used to abort installation, for license
     #         should be own symbol. Now abort in addon view in upgrade proposal ask for abort
     #         properly, but then just go back to proposal instead of full abort.
@@ -185,7 +187,7 @@ module Yast
 
       if newSources.empty?
         log.error("Cannot add the repository")
-        try_again(url, scheme) ? :again : :cancel
+        try_again(url, scheme) ? :again : :next
       else
         Progress.NextStage
         Builtins.foreach(newSources) do |id|

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -91,6 +91,36 @@ describe "PackagerRepositoriesIncludeInclude" do
       end
     end
 
+    context "when the repository cannot be created" do
+      before do
+        allow(Yast::Pkg).to receive(:RepositoryProbe).and_return(nil)
+      end
+
+      context "and the user accepts to edit the URL" do
+        before do
+          allow(Yast::Popup).to receive(:YesNo).and_return(true)
+        end
+
+        it "returns :again symbol" do
+          result = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+
+          expect(result).to eq(:again)
+        end
+      end
+
+      context "and the user does not accept to edit the URL" do
+        before do
+          allow(Yast::Popup).to receive(:YesNo).and_return(false)
+        end
+
+        it "returns :next symbol" do
+          result = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+
+          expect(result).to eq(:next)
+        end
+      end
+    end
+
     it "creates the repository" do
       repo_props = { "enabled"     => true,
                      "autorefresh" => false,


### PR DESCRIPTION
## Problem

When the user is adding an add-on and the repository cannot be created, a popup dialog gives to the user a new opportunity for changing the URL. If the user rejects such popup, the installation aborts instead of continue without adding the repository.

![VirtualBox_SLE-15-SP2_05_03_2020_13_26_24](https://user-images.githubusercontent.com/1112304/76002382-6ce6f180-5efe-11ea-8d5a-4e0ee10437a5.png)

## Solution

Fix return symbol when the user rejects.

## Testing

* Added unit test.
* Tested manually.
