### PR TITLE
Avoid unselecting the base product (bsc#1165501)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar  6 09:11:15 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Avoid unselecting the base product (related to bsc#1165501)
+- 4.2.58
+
+-------------------------------------------------------------------
 Thu Mar  5 16:21:35 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Avoid to abort the installer when the user decides to not fix a

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.57
+Version:        4.2.58
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -126,7 +126,7 @@ module Y2Packager
         elsif products.size == 1
           products.first.select
         else
-          products.each(&:restore)
+          products.each(&:restore) unless Y2Packager::MediumType.online?
         end
       end
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1165501 
- During debugging it turned out that the base product (like SLES) was deselected at this point. Because it is later again selected by solver by other modules dependencies it did not make any problems. But lets fix it to be on the safe side.
- In an Offline installation this is called at a different place and does not make troubles so handle only the Online case.
- 4.2.58

### Tests
- [x] Tested manually in Online installation
- [x] Tested manually in Offline installation
