### PR TITLE
Remove CONTRIBUTING.md from the spec file

### DIFF
--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -128,6 +128,5 @@ This package contains the libraries and modules for software management.
 %dir %{yast_docdir}
 %license COPYING
 %doc %{yast_docdir}/README.md
-%doc %{yast_docdir}/CONTRIBUTING.md
 
 %changelog


### PR DESCRIPTION
## Problem

The **CONTRIBUTING.md** file was removed (#518) from the repository but the file is still referenced in the spec file

## Solution

Remove the file from the spec file
