### PR TITLE
Add the self-update add-on on Full medium (bsc#1168702)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  8 14:44:49 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Allow updating the roles via self_update repository (bsc#1168702)
+- 4.2.61
+
+-------------------------------------------------------------------
 Thu Mar 26 12:25:20 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Reverts changes made in 4.2.59 to improve the addons selection,

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.60
+Version:        4.2.61
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_repositories_initialization.rb
+++ b/src/lib/y2packager/clients/inst_repositories_initialization.rb
@@ -46,6 +46,19 @@ module Y2Packager
           return :auto
         end
 
+        # for the Full medium we need to just add the self-update add-on
+        # repo to make the new roles work
+        if Y2Packager::MediumType.offline?
+          if Y2Packager::SelfUpdateAddonRepo.present?
+            log.info "Adding the self-update add-on repository..."
+            Y2Packager::SelfUpdateAddonRepo.create_repo
+          else
+            log.info "Self-update repository not found - finishing..."
+          end
+
+          return :auto
+        end
+
         if !init_installation_repositories
           Yast::Popup.Error(
             _("Failed to initialize the software repositories.\nAborting the installation.")


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1168702
- The self-update add-on repository was not added during installation so the new/updated roles were not displayed
- Depends on https://github.com/yast/skelcd-control-leanos/pull/54


### Testing

```shell
yupdate patch yast-packager self_update_repo
yupdate patch skelcd-control-leanos self_update_repo

# edit the "SelfUpdate" value, the yupdate script automatically disables the
# self-update, write the self-update repository URL there
vim /etc/install.inf
```

Use the testing skelcd package from the bugzilla bug

### Screenshots

The original roles displayed:
![suma_roles](https://user-images.githubusercontent.com/907998/78798066-d738f900-79b8-11ea-923e-eef7c99893d8.png)

The new updated roles displayed after patching the installer:
![suma_new_roles](https://user-images.githubusercontent.com/907998/78798042-d0aa8180-79b8-11ea-9f31-815d4c88327d.png)
