### PR TITLE
Crash on empty status file

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  7 09:38:10 UTC 2020 - Michal Filka <mchf@suse.cz>
+
+- bnc#1166661
+  - do not crash on empty system_packages_repos.yaml
+- 4.3.0 
+
+-------------------------------------------------------------------
 Mon Apr 20 11:46:59 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - prevent race condition between log rotation and migration

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.62
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/known_repositories.rb
+++ b/src/lib/y2packager/known_repositories.rb
@@ -71,6 +71,12 @@ module Y2Packager
       end
 
       status = YAML.load_file(status_file)
+
+      if !status
+        log.info("Status file #{status_file} is empty or corrupted")
+        return []
+      end
+
       # unify the file in case it was manually modified
       status.uniq!
       status.sort!

--- a/src/lib/y2packager/known_repositories.rb
+++ b/src/lib/y2packager/known_repositories.rb
@@ -70,10 +70,15 @@ module Y2Packager
         return []
       end
 
-      status = YAML.load_file(status_file)
+      begin
+        status = YAML.load_file(status_file)
+      rescue Psych::SyntaxError => e
+        log.error("Status file #{status_file} is corrupted: #{e.message}")
+        return []
+      end
 
       if !status
-        log.info("Status file #{status_file} is empty or corrupted")
+        log.info("Status file #{status_file} is empty or its content is invalid")
         return []
       end
 


### PR DESCRIPTION
Bnc1166661

## Problem

when the file system_packages_repos.yaml was empty or somehow malformed (contained e.g. only '---') on first line yast-packager crashed with internal error as described in the bug (or a similar one).

## Solution

check what returns yaml parser

manually tested