### PR TITLE
Removed Unsupported Widget Option :immediate

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 11 09:13:21 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Removed widget option :immediate which is undefined for the
+  MultiSelectionBox widget (bsc#1170431)
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 09:38:10 UTC 2020 - Michal Filka <mchf@suse.cz>
 
 - bnc#1166661

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -129,7 +129,7 @@ module Y2Packager
           VWeight(60, MinHeight(8,
             MultiSelectionBox(
               Id(:addon_repos),
-              Opt(:notify, :immediate),
+              Opt(:notify),
               "",
               selection_content
             ))),


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1170431

## Problem

Our QA team now checks y2logs for errors, and they found one that must have been there for a very long time:

```
[libycp] modules/Wizard.rb:818 Unknown option `immediate in MultiSelectionBox widget
```

## Impact

Only an error message in the y2log, no bad effects for the user or the installation.

## Real Error Location

https://github.com/yast/yast-packager/blob/master/src/lib/y2packager/dialogs/addon_selector.rb#L132

## Fix

Removed the `:immediate` option. It does not do anything for this widget, just log an error.

## Background Information

Some of our selection widgets (but not all!) have an _immediate_ mode that gives quicker feedback to the Ruby application if the user changes the selected item:

- SelectionBox
- Table
- Tree

but not the MultiSelectionBox. This option is only used in the NCurses UI.

https://doc.opensuse.org/projects/YaST/openSUSE11.3/tdg/UI-Events.html#Event_Reference

See _1.2.3.2.4. SelectionChanged WidgetEvent_  there.