### PR TITLE
set zypp release version environment var at the correct place (bsc#1172870)

### DIFF
--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -104,6 +104,14 @@ module Yast
     def main
       textdomain "packager"
 
+      # Set release version environment variable for zypp.
+      #
+      # Otherwise zypp might use the old version (update) resp. fail to find
+      # a product version at all (new installation).
+      #
+      # cf. bsc#1172870
+      ENV[RELEASEVER_ENV] = Product.version
+
       if AddOnProduct.skip_add_ons
         log.info("Skipping module (as requested before)")
         return :auto
@@ -137,10 +145,6 @@ module Yast
         CommandLine.Run("id" => "inst_productsources")
         return :auto
       end
-
-      # Set the proper release version for newly added repositories
-      # we want to use new product and not old
-      ENV[RELEASEVER_ENV] = Product.version
 
       # (Applicable only in inst-sys)
       @preselect_recommended = true


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1172870
- https://trello.com/c/RjeB1CJP

`$releasever` expansion in repository URLs does not (always) happen.

## Solution

The variable is set in the [product sources client](https://github.com/yast/yast-packager/blob/master/src/lib/y2packager/clients/inst_productsources.rb).

Keep it in this client but move it to a place where it will always be set, not just when add-ons are used.

## Note

This does nothing about other zypp variables in URLs. They would have to be added at the same spot. But I'm not convinced about their usefulness. linuxrc handles only `$releasever`.

Instead of going all-in we can just document that for installation/update yast allows to use `$releasever` (and nothing else).