### PR TITLE
Improved medium type detection

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+  image: registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
 
 Rubocop_task:
   container:

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul 10 07:14:05 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improve medium type detection, do not report Online medium
+  when the /media.1/products file is missing in the repository,
+  SMT does not mirror this file (bsc#1173336)
+- 4.2.63
+
+-------------------------------------------------------------------
 Mon Apr 20 11:46:59 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - prevent race condition between log rotation and migration

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.62
+Version:        4.2.63
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/medium_type.rb
+++ b/src/lib/y2packager/medium_type.rb
@@ -105,13 +105,6 @@ module Y2Packager
         downloader = Y2Packager::RepomdDownloader.new(url)
         product_repos = downloader.product_repos
 
-        # the online medium should not contain any repository
-        # TODO: how to detect an invalid installation URL or a broken medium??
-        if product_repos.empty?
-          log.info("Detected medium type: online (no repository on the medium)")
-          return :online
-        end
-
         # the offline medium contains several modules and extensions
         if product_repos.size > 1
           log.info("Detected medium type: offline (found #{product_repos.size} product repos)")

--- a/src/lib/y2packager/product_location.rb
+++ b/src/lib/y2packager/product_location.rb
@@ -60,7 +60,7 @@ module Y2Packager
 
       pool = Y2Packager::SolvablePool.new
 
-      repomd_files = downloader.primary_xmls
+      repomd_files = downloader.primary_xmls(force_scan)
       return [] if repomd_files.empty?
 
       repomd_files.each do |repomd|

--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -61,12 +61,18 @@ module Y2Packager
     # @return [Array<String>] List of paths pointing to the downloaded primary.xml.gz files,
     #   returns an empty list if the URL or the repository is not valid.
     #
-    def primary_xmls
-      return [] if product_repos.empty?
+    def primary_xmls(force = false)
+      repos = product_repos
+
+      if repos.empty?
+        return [] unless force
+
+        repos = { "" => "/" }
+      end
 
       # add a temporary repository for downloading the files via libzypp
       src = Yast::Pkg.RepositoryAdd("base_urls" => [url])
-      product_repos.map do |(_name, dir)|
+      repos.map do |(_name, dir)|
         # download the repository index file (repomd.xml)
         repomd_file = Yast::Pkg.SourceProvideFile(src, 1, File.join(dir, "repodata/repomd.xml"))
 

--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -48,6 +48,9 @@ module Y2Packager
     #
     # Returns the downloaded primary.xml.gz file(s) from the repository.
     #
+    # @param force [Boolean] Force scanning the repositories even when
+    #   the /media.1/products file is missing, default `false`
+    #
     # @note For remote repositories (http://, ftp://, ...) the files are downloaded
     #  to a temporary directory (/var/tmp/...), but for the local repositories
     #  or mountable repositories (dir://, dvd://) it directly points to the original files!
@@ -62,11 +65,13 @@ module Y2Packager
     #   returns an empty list if the URL or the repository is not valid.
     #
     def primary_xmls(force = false)
+      # first check if there are any products defined in /media.1/products
       repos = product_repos
 
       if repos.empty?
         return [] unless force
 
+        # if `force` is true then scan the repository at the root anyway
         repos = { "" => "/" }
       end
 

--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -71,8 +71,9 @@ module Y2Packager
       if repos.empty?
         return [] unless force
 
-        # if `force` is true then scan the repository at the root anyway
-        repos = { "" => "/" }
+        # if `force` is true then scan the repository at the root anyway,
+        # the repository name is ignored later so it can be any string
+        repos = { "Root Repository" => "/" }
       end
 
       # add a temporary repository for downloading the files via libzypp

--- a/test/medium_type_test.rb
+++ b/test/medium_type_test.rb
@@ -24,13 +24,6 @@ describe Y2Packager::MediumType do
       expect { described_class.type }.to raise_exception(/The installation URL is not set/)
     end
 
-    it "returns :online if no repository is found on the medium" do
-      expect_any_instance_of(Y2Packager::RepomdDownloader)
-        .to receive(:product_repos).and_return([])
-
-      expect(described_class.type).to eq(:online)
-    end
-
     it "returns :offline if at least two repositories are found on the medium" do
       expect_any_instance_of(Y2Packager::RepomdDownloader)
         .to receive(:product_repos).and_return(
@@ -41,6 +34,18 @@ describe Y2Packager::MediumType do
         )
 
       expect(described_class.type).to eq(:offline)
+    end
+
+    context "missing media.1/products on the installation medium" do
+      before do
+        expect_any_instance_of(Y2Packager::RepomdDownloader)
+          .to receive(:product_repos).and_return([])
+      end
+
+      it "returns :online if the repository does not contain any base product" do
+        expect(Y2Packager::ProductLocation).to receive(:scan).and_return([])
+        expect(described_class.type).to eq(:online)
+      end
     end
 
     context "only one repository on the installation medium" do


### PR DESCRIPTION
## Introduction

Since SLE15-SP2 YaST needs to support Online, Full and standard (openSUSE Leap) installation media. See more details in the [media types documentation](https://github.com/yast/yast-installation/wiki/Installation-Media-Types).

The medium type is determined from the place where `install=` boot parameter points, it does not matter which medium was booted. You can boot the Online medium, but point `install=` to a repository containing the Full installation source.

## The Problem

See https://bugzilla.suse.com/show_bug.cgi?id=1173336

It turned out that a common use case is to mirror the repositories from SCC using SMT and then use a small installation medium for installation. You should not need to download that 10GB Full medium when you already mirrored all repositories from SCC, that makes sense.

So the use case is to mirror all repositories from SCC and point `install=` to the SMT repository with the SLES product.

Unfortunately it turned out that SMT does not mirror the `/media.1/products` file from SCC. This file is actually not needed for normal operations when accessing the repositories (installing packages). However, YaST uses that file for distinguishing between the Full and Online media.

It the file was missing YaST considered it as the Online installation medium. But the Online installation medium requires registration because it does not contain any packages to install. So the result was that YaST displayed an error popup that registration is mandatory although it was not true, the packages were available via the SMT repositories.

## The Fix

The fix is relatively simple, if YaST does not find any products (because the `/media.1/products` file is missing) it still tries to download the repository metadata and checks which products/packages are available there.

## TODO

- [ ] Report a bug for SMT, it should mirror this file as well...