### PR TITLE
handle variable expansion in repository name

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jul 14 10:41:22 CEST 2020 - aschnell@suse.com
+
+- Handle variable expansion in repository name (bsc#1172477)
+- 4.1.51
+
+-------------------------------------------------------------------
 Thu Dec  5 18:20:30 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Speed up product renames calculation (bsc#1157926).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.50
+Version:        4.1.51
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -47,8 +47,8 @@ BuildRequires:  augeas-lenses
 # Newly added RPM
 Requires:       yast2-country-data >= 2.16.3
 
-# Pkg::PrdLicenseLocales
-Requires:       yast2-pkg-bindings >= 4.0.8
+# raw_name
+Requires:       yast2-pkg-bindings >= 4.1.3
 
 # inst_rpmcopy.rb: SlideShow.RebuildDialog(true)
 Requires:       yast2 >= 4.1.71

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -366,7 +366,8 @@ module Yast
         "\">&nbsp;&nbsp;&nbsp;"
       )
 
-      # TRANSLATORS: the raw name is the original repository name with unexpanded variables like "$releasever"
+      # TRANSLATORS: the raw name is the original repository name with unexpanded variables
+      # like "$releasever"
       name_string = name != raw_name ? _("Raw name: %s") % raw_name + "<BR>" : ""
 
       url = _("Unknown") if url == ""

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -366,6 +366,7 @@ module Yast
         "\">&nbsp;&nbsp;&nbsp;"
       )
 
+      # TRANSLATORS: the raw name is the original repository name with unexpanded variables like "$releasever"
       name_string = name != raw_name ? _("Raw name: %s") % raw_name + "<BR>" : ""
 
       url = _("Unknown") if url == ""

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -297,6 +297,7 @@ module Yast
         "enabled"      => Ops.get_boolean(source, "enabled", true),
         "autorefresh"  => Ops.get_boolean(source, "autorefresh", true),
         "name"         => Ops.get_locale(source, "name", _("Unknown Name")),
+        "raw_name"     => source.fetch("raw_name", _("Unknown Name")),
         "url"          => Ops.get_string(generalData, "url", ""),
         "raw_url"      => Ops.get_string(generalData, "raw_url", ""),
         "type"         => Ops.get_string(generalData, "type", ""),
@@ -324,7 +325,7 @@ module Yast
 
       itemList = repo_mode ? deep_copy(@sourceStatesOut) : deep_copy(@serviceStatesOut)
 
-      # displaye only repositories from the selected service
+      # display only repositories from the selected service
       if repo_mode && service_name != ""
         itemList = ReposFromService(service_name, itemList)
       end
@@ -348,6 +349,9 @@ module Yast
     end
 
     def repoInfoRichText(name, category, info)
+      name = info["name"]
+      raw_name = info["raw_name"]
+
       url = info["url"]
       raw_url = info["raw_url"]
 
@@ -362,6 +366,8 @@ module Yast
         "\">&nbsp;&nbsp;&nbsp;"
       )
 
+      name_string = name != raw_name ? _("Raw name: %s") % raw_name + "<BR>" : ""
+
       url = _("Unknown") if url == ""
       raw_url = _("Unknown") if raw_url == ""
 
@@ -374,9 +380,10 @@ module Yast
       end
 
       Builtins.sformat(
-        "<P>%1<B><BIG>%2</BIG></B></P><P>%3<BR>%4</P>",
+        "<P>%1<B><BIG>%2</BIG></B></P><P>%3%4<BR>%5</P>",
         icon_tag,
         name,
+        name_string,
         url_string,
         category
       )
@@ -1797,7 +1804,8 @@ module Yast
       old_url = url2
       plaindir = Ops.get_string(generalData, "type", "YaST") == @plaindir_type
 
-      SourceDialogs.SetRepoName(Ops.get_string(sourceState, "name", ""))
+      SourceDialogs.SetRepoName(sourceState.fetch("raw_name", ""))
+
       begin
         url2 = SourceDialogs.EditPopupType(url2, plaindir)
 
@@ -1916,12 +1924,11 @@ module Yast
               # remove the duplicate at the end
               @sourceStatesOut = Builtins.remove(@sourceStatesOut, idx)
 
+              new_raw_name = addedSource.fetch("raw_name", "")
+              new_name = Yast::Pkg.ExpandedName(new_raw_name)
+
               # refresh only the name and URL in the table
-              UI.ChangeWidget(
-                Id(:table),
-                Cell(global_current, 3),
-                Ops.get_string(addedSource, "name", "")
-              )
+              UI.ChangeWidget(Id(:table), Cell(global_current, 3), new_name)
               UI.ChangeWidget(Id(:table), Cell(global_current, 5), url2)
 
               fillCurrentRepoInfo
@@ -1932,19 +1939,18 @@ module Yast
             "URL is the same, not recreating the source"
           )
 
-          new_name = SourceDialogs.GetRepoName
-          if new_name != Ops.get_string(sourceState, "name", "")
+          new_raw_name = SourceDialogs.GetRepoName
+          if new_raw_name != sourceState.fetch("raw_name", "")
             warn_service_repository(sourceState)
 
-            Ops.set(sourceState, "name", new_name)
-            Ops.set(@sourceStatesOut, global_current, sourceState)
+            new_name = Yast::Pkg.ExpandedName(new_raw_name)
+
+            sourceState["name"] = new_name
+            sourceState["raw_name"] = new_raw_name
+            @sourceStatesOut[global_current] = sourceState
 
             # update only the name cell in the table
-            UI.ChangeWidget(
-              Id(:table),
-              Cell(global_current, 3),
-              new_name
-            )
+            UI.ChangeWidget(Id(:table), Cell(global_current, 3), new_name)
 
             fillCurrentRepoInfo
           else

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -8,7 +8,7 @@ Yast.import "NetworkService"
 
 # Yast namespace
 module Yast
-  # Displays possibilities to install from NFS, CD or partion
+  # Displays possibilities to install from NFS, CD or partition
   class SourceDialogsClass < Module
     # to use N_ in the class constant
     extend Yast::I18n

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -47,7 +47,7 @@ describe "PackagerRepositoriesIncludeInclude" do
     let(:url) { "cd://" }
     let(:plaindir) { false }
     let(:download) { false }
-    let(:preffered_name) { "" }
+    let(:preferred_name) { "" }
     let(:repo_id) { 42 }
 
     before do
@@ -70,7 +70,7 @@ describe "PackagerRepositoriesIncludeInclude" do
     end
 
     it "returns :again symbol when URL is empty" do
-      ret = RepositoryIncludeTester.createSource("", plaindir, download, preffered_name)
+      ret = RepositoryIncludeTester.createSource("", plaindir, download, preferred_name)
       expect(ret).to eq(:again)
     end
 
@@ -81,20 +81,20 @@ describe "PackagerRepositoriesIncludeInclude" do
       end
 
       it "returns :again symbol" do
-        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
         expect(ret).to eq(:again)
       end
 
       it "displays an error popup" do
         expect(Yast::Report).to receive(:Error).with(/Invalid URL/)
-        RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
       end
     end
 
     it "creates the repository" do
       repo_props = { "enabled"     => true,
                      "autorefresh" => false,
-                     "name"        => "Repository",
+                     "raw_name"    => "Repository",
                      "prod_dir"    => "/",
                      "alias"       => "Repository",
                      "base_urls"   => ["cd://"],
@@ -103,11 +103,11 @@ describe "PackagerRepositoriesIncludeInclude" do
       expect(Yast::Pkg).to receive(:RepositoryAdd).with(repo_props).and_return(repo_id)
       expect(Yast::Pkg).to_not receive(:SourceDelete)
 
-      RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+      RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
     end
 
     it "returns :ok symbol on success" do
-      ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+      ret = RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
       expect(ret).to eq(:ok)
     end
 
@@ -116,7 +116,7 @@ describe "PackagerRepositoriesIncludeInclude" do
         .with(repo_id).and_return(false)
       expect(Yast::Pkg).to receive(:SourceDelete).with(repo_id)
 
-      RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+      RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
     end
 
     context "more products available on the medium" do
@@ -135,7 +135,7 @@ describe "PackagerRepositoriesIncludeInclude" do
 
       it "displays a dialog for selecting the products to use" do
         expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:run)
-        RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
       end
 
       it "adds only the repositories for the selected products" do
@@ -145,7 +145,7 @@ describe "PackagerRepositoriesIncludeInclude" do
           .and_return(selected_products)
         expect(Yast::Pkg).to receive(:RepositoryAdd)
           .with(hash_including("prod_dir" => product1[1]))
-        RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
       end
 
       it "returns :next if nothing is selected" do
@@ -153,14 +153,14 @@ describe "PackagerRepositoriesIncludeInclude" do
           .and_return([])
         expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:run)
           .and_return(:next)
-        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
         expect(ret).to eq(:next)
       end
 
       it "returns :abort if product selection is aborted" do
         expect_any_instance_of(Y2Packager::Dialogs::AddonSelector).to receive(:run)
           .and_return(:abort)
-        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preffered_name)
+        ret = RepositoryIncludeTester.createSource(url, plaindir, download, preferred_name)
         expect(ret).to eq(:abort)
       end
     end


### PR DESCRIPTION
For https://bugzilla.suse.com/show_bug.cgi?id=1172477 and https://trello.com/c/QAAv9cMG/1895-3-osdistribution-p2-1172477-yast-replaces-releasever-by-the-current-release-in-repository-names-in-etc-zypp-reposd-repo.

The repository name can also include variables like $releasever or $arch. Handle and display raw_name where needed.

The extended yast2-pkg-bindings is needed.
