### PR TITLE
Fixed name of the add-on repository (bsc#1175374)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep  2 14:49:09 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed name of the add-on repository (bsc#1175374, related
+  to bsc#1172477)
+- 4.2.65
+
+-------------------------------------------------------------------
 Tue Jul 14 10:41:22 CEST 2020 - aschnell@suse.com
 
 - Handle variable expansion in repository name (bsc#1172477)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.64
+Version:        4.2.65
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1550,7 +1550,7 @@ module Yast
         sources_set = []
         Builtins.foreach(sources_got) do |one_source|
           if Ops.get_integer(one_source, "SrcId", -1) == src_id
-            Ops.set(one_source, "name", new_name)
+            Ops.set(one_source, "raw_name", new_name)
           end
           sources_set = Builtins.add(sources_set, one_source)
         end


### PR DESCRIPTION
## Summary

- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1175374 - the add-on repository have different Product names when the YaST self-update is enabled.
    - Expected: "SUSE Linux Enterprise High Availability Extension 15 SP2"
    - Actual: "SLE-15-SP2-Product-HA-POOL-x86_64-Build99.9-Media1/"
- This was actually caused by this change https://github.com/yast/yast-pkg-bindings/pull/133


### Details

This is the problematic code snippet:

```ruby
sources = Yast::Pkg.SourceEditGet
sources.first["name"] = "new_name"
# does not change anything actually :-(
Yast::Pkg.SourceEditSet(sources)
```

The problem is that `Pkg.SourceEditGet` now returns two keys, `name` and `raw_name` and `Pkg.SourceEditSet` prefers the `raw_name` if it is present (see https://github.com/yast/yast-pkg-bindings/pull/133). So in this case the name is not changed because the original `raw_name` is preferred.

The fix is to set the preferred `raw_name` instead of `name`:
```ruby
sources.first["raw_name"] = "new_name"
```

Then it works as expected.

## Testing

Tested manually in three scenarios:

#### GA installer (self-update) disabled

This is the original behavior:

![sle-15-sp2-addon-without_self_update](https://user-images.githubusercontent.com/907998/92004162-2d308380-ed42-11ea-8ce7-af75d34efcfd.png)


#### The Default Installation with Self-update

When running an SLE15-SP2 installation with enabled self-update you will see these repository names:

![sle-15-sp2-addon-with_self_update](https://user-images.githubusercontent.com/907998/92004260-4b967f00-ed42-11ea-8a9c-dd48db6eabaa.png)

That's a regression from the GA behavior.


#### With the Fix

With this fix applied the previous names (as in GM) are displayed even with self-update enabled:

![sle-15-sp2-addon-with_self_update_with_fix](https://user-images.githubusercontent.com/907998/92004403-78e32d00-ed42-11ea-9ad4-5645820c12d2.png)

