### PR TITLE
Fixed WFM.Args call (bsc#1176653)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 21 08:30:04 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed WFM.Args call to not produce an error message in the y2log
+  (bsc#1176653)
+- 4.3.8
+
+-------------------------------------------------------------------
 Wed Sep 16 12:17:07 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed name of the add-on repository (bsc#1175374, related

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/medium_type.rb
+++ b/src/lib/y2packager/medium_type.rb
@@ -80,6 +80,8 @@ module Y2Packager
       # @return [Boolean] True if the client should be skipped.
       #
       def skip_step?
+        return false if Yast::WFM.Args.empty?
+
         skip = Yast::WFM.Args(0) && Yast::WFM.Args(0)["skip"]
         return true if skip&.split(",")&.include?(type.to_s)
 

--- a/test/medium_type_test.rb
+++ b/test/medium_type_test.rb
@@ -92,6 +92,11 @@ describe Y2Packager::MediumType do
     end
   end
 
+  def mock_arguments(arg)
+    allow(Yast::WFM).to receive(:Args).and_return([arg])
+    allow(Yast::WFM).to receive(:Args).with(0).and_return(arg)
+  end
+
   describe "#skip_step?" do
     context "online installation medium" do
       before do
@@ -99,27 +104,31 @@ describe Y2Packager::MediumType do
       end
 
       it "returns true if the client args contain \"skip\" => \"online\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return("skip" => "online")
+        mock_arguments("skip" => "online")
         expect(Y2Packager::MediumType.skip_step?).to eq(true)
       end
       it "returns true if the client args contain \"skip\" => \"standard,online\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return("skip" => "standard,online")
+        mock_arguments("skip" => "standard,online")
         expect(Y2Packager::MediumType.skip_step?).to eq(true)
       end
       it "returns false if the client args do not contain \"skip\" => \"online\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return({})
+        mock_arguments({})
         expect(Y2Packager::MediumType.skip_step?).to eq(false)
       end
       it "returns false if the client args contain \"only\" => \"online\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return("only" => "online")
+        mock_arguments("only" => "online")
         expect(Y2Packager::MediumType.skip_step?).to eq(false)
       end
       it "returns false if the client args contain \"only\" => \"online,standard\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return("only" => "standard,online")
+        mock_arguments("only" => "standard,online")
         expect(Y2Packager::MediumType.skip_step?).to eq(false)
       end
       it "returns false if the client args do not contain \"only\" => \"online\"" do
-        allow(Yast::WFM).to receive(:Args).with(0).and_return({})
+        mock_arguments({})
+        expect(Y2Packager::MediumType.skip_step?).to eq(false)
+      end
+      it "returns false if the client args are empty" do
+        allow(Yast::WFM).to receive(:Args).and_return([])
         expect(Y2Packager::MediumType.skip_step?).to eq(false)
       end
     end


### PR DESCRIPTION
- ... to not produce an error message in the y2log
- The `WFM.Args(0)` logs and error when the the arg list is empty
- Added a guard condition to skip the whole method if the list is empty
- See https://bugzilla.suse.com/show_bug.cgi?id=1176653
- 4.3.8