### PR TITLE
Fix random jumps when moving cursor in TUI repository table (bsc#1177145)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  8 17:00:20 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Fix random jumps when moving cursor in TUI repository table (bsc#1177145)
+- 4.2.66
+
+-------------------------------------------------------------------
 Wed Sep  2 14:49:09 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed name of the add-on repository (bsc#1175374, related

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.65
+Version:        4.2.66
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -1039,10 +1039,8 @@ module Yast
 
       exit = false
       begin
-        if !current.nil? && Ops.greater_or_equal(current, 0)
-          UI.ChangeWidget(Id(:table), :CurrentItem, current)
-          fillCurrentRepoInfo
-        end
+        current = -1 if current.nil?
+        fillCurrentRepoInfo if current >= 0
 
         current = -1
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1177145 (L3 SLE15-SP2)
- https://trello.com/c/zbs8G5s7

In ncurses, `ChangeWidget(:table, :CurrentItem, ...)` will be wrong for sorted  tables (which is the default now).
    It is related to the `ChangeWidget(:table, Cell(.., ..), ...)` bug, bsc#1165388 (see https://github.com/libyui/libyui-ncurses/pull/100)
    
This is a workaround: removing the unnecessary ChangeWidget.

I tested that it works in ncurses and qt. It has been validated by the reporter.
