### PR TITLE
bsc#1177485: do not install xorg-x11

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  8 21:18:15 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not try to install xorg-x11 when installation via VNC is
+  enabled (bsc#1177485).
+- 4.3.9
+
+-------------------------------------------------------------------
 Mon Sep 21 08:30:04 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed WFM.Args call to not produce an error message in the y2log

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -25,7 +25,7 @@ module Yast
     RESOLVABLE_TYPES = [:product, :patch, :package, :pattern, :language].freeze
 
     # Minimum set of packages tags required to enable VNC server
-    VNC_BASE_TAGS = ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"].freeze
+    VNC_BASE_TAGS = ["xorg-x11-Xvnc", "xorg-x11-fonts"].freeze
     # Additional packages tags needed to run second stage in graphical mode
     AUTOYAST_X11_TAGS = ["libyui-qt", "yast2-x11"].freeze
     # Default window manager for VNC if none is installed

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -686,7 +686,7 @@ describe Yast::Packages do
 
   describe "#vnc_packages" do
     let(:packages) { Yast::Packages.vnc_packages.sort.uniq }
-    let(:base_packages) { ["xorg-x11", "xorg-x11-Xvnc", "xorg-x11-fonts"] }
+    let(:base_packages) { ["xorg-x11-Xvnc", "xorg-x11-fonts"] }
     let(:base_packages_and_wm) { ["icewm"] + base_packages }
     let(:autoyast_x11_packages) { ["libyui-qt6", "yast2-x11"] }
 


### PR DESCRIPTION
Fix [bsc#1177485](https://bugzilla.suse.com/show_bug.cgi?id=1177485). Do not install xorg-x11 when installation over VNC is enabled as it is not needed anymore.