### PR TITLE
Backport release ver

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec  1 15:03:41 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- set zypp release version environment var at the correct place
+  (bsc#1172870, bsc#1173712)
+- 4.2.67
+
+-------------------------------------------------------------------
 Thu Oct  8 17:00:20 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Fix random jumps when moving cursor in TUI repository table (bsc#1177145)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.66
+Version:        4.2.67
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -104,6 +104,14 @@ module Yast
     def main
       textdomain "packager"
 
+      # Set release version environment variable for zypp.
+      #
+      # Otherwise zypp might use the old version (update) resp. fail to find
+      # a product version at all (new installation).
+      #
+      # cf. bsc#1172870
+      ENV[RELEASEVER_ENV] = Product.version
+
       if AddOnProduct.skip_add_ons
         log.info("Skipping module (as requested before)")
         return :auto
@@ -137,10 +145,6 @@ module Yast
         CommandLine.Run("id" => "inst_productsources")
         return :auto
       end
-
-      # Set the proper release version for newly added repositories
-      # we want to use new product and not old
-      ENV[RELEASEVER_ENV] = Product.version
 
       # (Applicable only in inst-sys)
       @preselect_recommended = true


### PR DESCRIPTION
trello: https://trello.com/c/6Tc5Fuoc/1960-3-osdistribution-p5-1173712-releasever-in-addonrepositoriesxml-does-not-work
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1173712
original PR: https://github.com/yast/yast-packager/pull/525