### PR TITLE
Bring back commit 3344dfcd281e963b37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     # just for easier debugging...
     - name: Inspect Installed Packages
@@ -38,7 +38,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -50,7 +50,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Package Build
       run: yast-ci-ruby -o package
@@ -62,7 +62,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: rake check:doc
@@ -76,7 +76,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 15 12:11:32 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Proposal: fixed the logic to detect whether the partitioning has
+  changed since the previous execution (found by bsc#1180537).
+- 4.3.12
+
+-------------------------------------------------------------------
 Thu Nov 26 22:29:43 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - correct add-on spelling (jsc#SLE-14772)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/software_proposal.rb
+++ b/src/lib/packager/clients/software_proposal.rb
@@ -18,6 +18,7 @@
 # ------------------------------------------------------------------------------
 
 require "installation/proposal_client"
+require "y2packager/storage_manager_proxy"
 
 module Yast
   # Software installation proposal
@@ -146,20 +147,25 @@ module Yast
         # save information about target change time in module Packages
         Packages.timestamp = Installation.dirinstall_target_time
       else
-        storage_timestamp = Convert.to_integer(
-          WFM.call("wrapper_storage", ["GetTargetChangeTime"])
-        )
-
         # check the partitioning in installation
-        if Packages.timestamp != storage_timestamp
+        if Packages.timestamp != staging_revision
           # don't set changed if it's the first "change"
           changed = true if Packages.timestamp.nonzero?
         end
-        # save information about target change time in module Packages
-        Packages.timestamp = storage_timestamp
+        # save information about devicegraph revision in module Packages
+        Packages.timestamp = staging_revision
       end
 
+      log.info "partitioning_changed? - #{changed}"
       changed
+    end
+
+    # Current revision of the staging storage devicegraph
+    #
+    # @return [Integer]
+    def staging_revision
+      @storage_manager ||= Y2Packager::StorageManagerProxy.new
+      @storage_manager.staging_revision
     end
 
     # Adjust package locales


### PR DESCRIPTION
## Problem

Commit 3344dfcd281e963b37 contained some code adjustments in the file `clients/software_proposal.rb` related to the introduction of storage-ng.

In parallel, commit 6a6b1764feabec3c10 moved that original file to a new location `lib/packager/clients/software_proposal.rb`.

As a consequence, when both branches were merged the changes of the former commit got lost and the file still contained the old code without the storage-ng adjustments.

## Solution

1) Checked why the problem has not been detected before.

The code was failing silently because `WMF.call` does not raise any error if the client doesn't exists. As a result, the method `#partitioning_changed?` was ALWAYS returning false.

2) Ensured `#partitioning_changed?` is the only affected code.

Done, that was the only modified file that has been moved afterwards, so everything else should be fine. Checked commit by commit in the original storage-ng branch.

3) Brought back the changes contained on that original commit.

Done, check next section for details.

## Testing

Manually tested. Verified that:

  - The first call to `#partitioning_changed?` always returns false. That's by design.
  - Subsequent calls return the expected result, i.e. true if the staging devicegraph has changed after the previous call to `#partitioning_changed?` and false otherwise.