### PR TITLE
Backport: log rotation failure

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 20 12:56:44 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Backport of PR#521.
+- prevent race condition between log rotation and migration
+  log backup (bsc#1166174)
+- 4.1.52
+
+-------------------------------------------------------------------
 Tue Jul 14 10:41:22 CEST 2020 - aschnell@suse.com
 
 - Handle variable expansion in repository name (bsc#1172477)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.1.51
+Version:        4.1.52
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -167,7 +167,6 @@ module Yast
       # timestamp
       date = Builtins.timestring("%Y%m%d", ::Time.now.to_i, false)
 
-
       # do not backup logs on running system (bsc#1166174)
       if Installation.destdir != "/"
         Builtins.y2milestone("Creating backup of %1", Directory.logdir)


### PR DESCRIPTION
### Problem

There is an error when doing backup/remove of logs during the migration process:

1. backup/remove is done in instdir/var/log/YaST2
2. instdir is "/" in yast2 migration
3. so it is done in real logs and not in chroot logs as expected

This causes a race condition but it is difficult to reproduce without Y2DEBUG. But in openQA there is higher chance that logs are filled enough before running migration.

Affected code streams are SLE12 and SLE15. It was already fixed for SLE-15-SP2, see  https://github.com/yast/yast-packager/pull/521. But openQA is still facing issues when migrating from SLE-15-SP1.

* https://bugzilla.suse.com/show_bug.cgi?id=1176163


### Solution

Backport for https://github.com/yast/yast-packager/pull/521. As quick workaround, *Y2DEBUG=1* should not use for the failing tests.
