### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 20:07:15 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.13
+
+-------------------------------------------------------------------
 Fri Jan 15 12:11:32 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Proposal: fixed the logic to detect whether the partitioning has

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.12
+Version:        4.3.13
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -302,6 +302,8 @@ describe Yast::AddOnProduct do
           expect(Yast::Package).to receive(:Install).with("yast2-registration").and_return(false)
           expect(Yast::WFM).to_not receive(:CallFunction)
             .with("inst_scc", ["register_media_addon", repo_id])
+          # also error is shown
+          expect(Yast::Report).to receive(:Error)
 
           Yast::AddOnProduct.RegisterAddOnProduct(repo_id)
         end
@@ -470,6 +472,7 @@ describe Yast::AddOnProduct do
         allow(subject).to receive(:Integrate)
         allow(subject).to receive(:AddRepo).with(repo["url"], repo["path"], repo["priority"])
           .and_return(repo_id)
+        allow(Yast::Report).to receive(:Error)
       end
 
       it "adds the repository" do
@@ -777,6 +780,7 @@ describe Yast::AddOnProduct do
         allow(Yast::FileUtils).to receive(:Exists).and_return(true)
 
         allow(Yast::XML).to receive(:XMLToYCPFile).and_raise(Yast::XMLDeserializationError)
+        allow(Yast::Report).to receive(:Error)
       end
 
       it "return empty array" do

--- a/test/lib/clients/inst_productsources_test.rb
+++ b/test/lib/clients/inst_productsources_test.rb
@@ -106,6 +106,8 @@ describe Yast::InstProductsourcesClient do
     before do
       allow(Yast::Pkg).to receive(:RepositoryProbe).and_return("RPM-MD")
       allow(Yast::Pkg).to receive(:RepositoryAdd).and_return(1)
+      allow(Yast::Pkg).to receive(:SourceRefreshNow).and_return(true)
+      allow(Yast::Pkg).to receive(:SourceSetEnabled).and_return(true)
     end
 
     it "probes repo" do

--- a/test/lib/widgets/product_license_confirmation_test.rb
+++ b/test/lib/widgets/product_license_confirmation_test.rb
@@ -125,7 +125,8 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       context "and license is still unconfirmed" do
         let(:license_confirmed?) { false }
 
-        it "returns false" do
+        it "returns false and Report it" do
+          expect(Yast::Report).to receive(:Message)
           expect(widget.validate).to eq(false)
         end
       end

--- a/test/lib/widgets/product_license_confirmation_test.rb
+++ b/test/lib/widgets/product_license_confirmation_test.rb
@@ -125,7 +125,7 @@ describe Y2Packager::Widgets::ProductLicenseConfirmation do
       context "and license is still unconfirmed" do
         let(:license_confirmed?) { false }
 
-        it "returns false and Report it" do
+        it "reports the error and returns false" do
           expect(Yast::Report).to receive(:Message)
           expect(widget.validate).to eq(false)
         end

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -22,6 +22,7 @@ describe Yast::ProductLicense do
     before do
       allow(Yast::Language).to receive(:GetLanguagesMap).and_return({})
       allow(Yast::Language).to receive(:supported_language?).and_return(true)
+      allow(Yast::Report).to receive(:Error) # partial test does not fully mock
     end
 
     it "works" do

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -78,6 +78,7 @@ describe "PackagerRepositoriesIncludeInclude" do
       before do
         # URL expansion returns nil (bsc#1059744)
         allow(Yast::Pkg).to receive(:ExpandedUrl).with(url).and_return(nil)
+        allow(Yast::Report).to receive(:Error)
       end
 
       it "returns :again symbol" do


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.