### PR TITLE
[SLE-15-SP3] Fix patterns

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 19 13:47:23 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix crash when installation proposal require pattern and such
+  pattern is not available in any repository (found during testing
+  jsc#SLE-17427)
+- 4.3.14
+-------------------------------------------------------------------
 Mon Feb 15 20:07:15 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -811,7 +811,7 @@ module Yast
       @total_downloaded += @current_provide_size
 
       @total_count_downloaded += 1
-      log.info "Downloaded #{@total_downloaded}/#{@total_count_to_download} packages"
+      log.info "Downloaded #{@total_count_downloaded}/#{@total_count_to_download} packages"
 
       # move the progress also for downloaded files
       UpdateTotalProgressValue()

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -2540,7 +2540,7 @@ module Yast
 
           missing[type] = [] unless missing[type]
           # use quoted "summary" value for patterns as they usually contain spaces
-          name = (type == :pattern) ? statuses.first.summary.inspect : item
+          name = (type == :pattern && !statuses.empty?) ? statuses.first.summary.inspect : item
           missing[type] << name
         end
       end

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -1856,4 +1856,15 @@ describe Yast::Packages do
       end
     end
   end
+
+  describe "#check_missing_resolvables" do
+    it "does not crash for non available pattern" do
+      allow(Yast::PackagesProposal).to receive(:GetAllResolvablesForAllTypes)
+        .and_return(pattern: ["non-existing"])
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :pattern, name: "non-existing")
+        .and_return([])
+
+      expect(subject.send(:check_missing_resolvables)).to eq(pattern: ["non-existing"])
+    end
+  end
 end


### PR DESCRIPTION
Add in `master` branch the fix done at https://github.com/yast/yast-packager/pull/548, which 

>  Fix crash when installation proposal require pattern and such
>  pattern is not available in any repository.

---

Changes picked from SLE-15-SP2 branch following the [YaST Maintenance work flow](https://yastgithubio.readthedocs.io/en/latest/maintenance-branches/#maintenance-work-flow).
