### PR TITLE
Version and changelog

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,3 +1,10 @@
+-------------------------------------------------------------------
+Fri Mar  5 10:41:42 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Support for configuring minimalistic DNF (bsc#1182849)
+  contributed by Sasi Olin (hel@lcp.world).
+- 4.3.15
+
 Fri Feb 19 14:07:15 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 -------------------------------------------------------------------
 

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later


### PR DESCRIPTION
#553 did not include a version bump, which implies ci.opensuse.org did not automatically created a submit request for it. Thus, the bug is still not fixed in Tumbleweed.

This should fix that.