### PR TITLE
Fixed a test failure in RPM build

### DIFF
--- a/src/lib/installation/console/plugins/repositories_button.rb
+++ b/src/lib/installation/console/plugins/repositories_button.rb
@@ -14,7 +14,6 @@
 require "yast"
 
 require "cwm"
-require "installation/console/menu_plugin"
 
 module Installation
   module Console

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,3 +67,13 @@ if ENV["COVERAGE"]
     ]
   end
 end
+
+# mock empty class to avoid build dependency on yast2-installation
+module Installation
+  module Console
+    module Plugins
+      class MenuPlugin
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Mock the class to avoid build dependency on yast2-installation
- At runtime the `require` is called from the console anyway, it's not mandatory here