### PR TITLE
Online repositories help

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  8 15:44:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- During installation, explain what "online repositories" are
+  (bsc#1180707).
+- 4.3.17
+
+-------------------------------------------------------------------
 Mon Mar  8 14:31:30 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Extend the special installer configuration dialog with

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.16
+Version:        4.3.17
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1725,11 +1725,9 @@ module Yast
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
       msg << _("Enabling the online repositories during installation\n" \
-               "gives you access to all openSUSE software that did not\n" \
-               "fit on the installation media anymore. At the same time,\n" \
-               "those repositories might contain updated software\n" \
-               "packages, so your new openSUSE system will be right\n" \
-               "at the most up-to-date stage.")
+               "gives you access to all software that does not fit on\n" \
+               "the installation media anymore. Additionally, those\n" \
+               "repositories might contain updated software packages.")
 
       if low_memory?
         msg << _("However, since the system has less than %d MiB memory,\n" \

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1724,15 +1724,19 @@ module Yast
       # Ask only once
       return @@ask_activate_online_repos_result unless @@ask_activate_online_repos_result.nil?
 
-      msg << _("The system has an active network connection.\n" \
-              "Additional software is available online.")
+      msg << _("Enabling the online repositories during installation\n" \
+               "gives you access to all openSUSE software that did not\n" \
+               "fit on the installation media anymore. At the same time,\n" \
+               "those repositories might contain updated software\n" \
+               "packages, so your new openSUSE system will be right\n" \
+               "at the most up-to-date stage.")
 
       if low_memory?
-        msg << _("Since the system has less than %d MiB memory,\n"         \
+        msg << _("However, since the system has less than %d MiB memory,\n" \
                  "there is a significant risk of running out of memory,\n" \
-                 "and the installer may crash or freeze.\n"                \
-                 "\n"                                                      \
-                 "Using the online repositories later in the installed\n"  \
+                 "and the installer may crash or freeze.\n" \
+                 "\n" \
+                 "Using the online repositories later in the installed\n" \
                  "system is recommended.") % LOW_MEMORY_MIB
         @@posted_low_memory_warning = true
       end
@@ -1740,7 +1744,7 @@ module Yast
       msg << _("Activate online repositories now?")
 
       @@ask_activate_online_repos_result = Popup.AnyQuestion(
-        Popup.NoHeadline,
+        _("Online Repositories"),
         msg.join("\n\n"),
         Label.YesButton,
         Label.NoButton,


### PR DESCRIPTION
This PR tries to make clear what online repositories are during installation, as suggested in [bsc#1180707](https://bugzilla.suse.com/show_bug.cgi?id=1180707).

<details>
<summary>Online Repositories Popup (GUI)</summary>

![online-repositories-gui](https://user-images.githubusercontent.com/15836/110359700-b39d8900-8035-11eb-979a-cc6e1e7a7318.png)
</details>

<details>
<summary>Online Repositories Popup (text mode)</summary>

![online-repositories-tui](https://user-images.githubusercontent.com/15836/110359733-be581e00-8035-11eb-98a3-6d91507af865.png)
</details>

<details>
<summary>Online Repositories + Low Memory Warning</summary>

![online-repositories-tui-low-memory](https://user-images.githubusercontent.com/15836/110359748-c31cd200-8035-11eb-9935-e007f17c47d7.png)
</details>


