### PR TITLE
Move the libzypp cache (bsc#1182928)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Thu Mar 11 15:01:58 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Move the libzypp cache to the installed system to save some
+  memory and avoid crashing because out of memory (bsc#1182928)
+- Improved "memsample" script handling
+    - Do not start it again if it is already running
+      (might happen if YaST is started again after crash)
+    - Stop it when YaST finishes
+- 4.3.19
+
+-------------------------------------------------------------------
 Tue Mar  9 09:15:41 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added IBM tools product rename to the list (part of bsc#1182837)

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,10 +3,6 @@ Thu Mar 11 15:01:58 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Move the libzypp cache to the installed system to save some
   memory and avoid crashing because out of memory (bsc#1182928)
-- Improved "memsample" script handling
-    - Do not start it again if it is already running
-      (might happen if YaST is started again after crash)
-    - Stop it when YaST finishes
 - 4.3.19
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.18
+Version:        4.3.20
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.20
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -98,10 +98,6 @@ module Yast
       Pkg.SourceSaveAll
       Pkg.TargetFinish
 
-      # save repository metadata cache to the installed system
-      # (needs to be done _after_ saving repositories, see bnc#700881)
-      Pkg.SourceCacheCopyTo(Installation.destdir)
-
       # Patching /etc/zypp/zypp.conf in order not to install
       # recommended packages, doc-packages,...
       # (needed for products like CASP)

--- a/test/pkg_finish_test.rb
+++ b/test/pkg_finish_test.rb
@@ -68,7 +68,6 @@ describe Yast::PkgFinishClient do
       expect(Yast::Pkg).to receive(:SourceLoad)
       expect(Yast::Pkg).to receive(:SourceSaveAll)
       expect(Yast::Pkg).to receive(:TargetFinish)
-      expect(Yast::Pkg).to receive(:SourceCacheCopyTo).with(destdir)
       allow(Yast::WFM).to receive(:Execute)
       expect(client.run).to be_nil
     end


### PR DESCRIPTION
- Move the libzypp cache to the installed system to save some memory and avoid crashing because out of memory (bsc#1182928)
  - Create a symlink from the inst-sys to `/mnt` so the running libzypp can still find the files
- See related https://github.com/yast/yast-installation/pull/932
- 4.3.19

## Notes

For copying the cache we use the `Pkg.SourceCacheCopyTo()`, we already used it but at the very end of the installation. Just move it earlier.

This `Pkg` call also copies the zypp credentials so we can drop the old code.

## Testing

Tested manually in a Leap 15.3, SLE15-SP3 Full (DVD) and Online (SCC) installation.