### PR TITLE
Delete zypp cache in the destination before overwriting it (boo#1183711)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 31 08:30:56 UTC 2021 - Fabian Vogt <fvogt@suse.com>
+
+- Delete zypp cache in the destination before overwriting it,
+  to avoid corrupting already open files (boo#1183711)
+- 4.3.21
+
+-------------------------------------------------------------------
 Thu Mar 18 16:33:19 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not create zypp cache symlink when running in installed

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/clients/inst_kickoff.rb
+++ b/src/clients/inst_kickoff.rb
@@ -136,13 +136,18 @@ module Yast
     def copy_zypp_cache
       return unless Stage.initial
 
+      cache_path = Pkg.ZConfig()["repo_cache_path"] || "/var/cache/zypp"
+      log.info("Zypp cache size: #{`du -h -s #{cache_path.shellescape}`}")
+
+      # Delete the destination cache for consistency and to avoid that the copy
+      # below modifies opened files in place, leading to corruption.
+      ::FileUtils.rm_rf(File.join(Installation.destdir, cache_path))
+
       # copy the credential files (libzypp loads them from target)
       # and the repository cache to the target system
       Pkg.SourceCacheCopyTo(Installation.destdir)
 
       # symlink the cache from inst-sys to save same space (RAM!)
-      cache_path = Pkg.ZConfig()["repo_cache_path"] || "/var/cache/zypp"
-      log.info("Zypp cache size: #{`du -h -s #{cache_path.shellescape}`}")
       ::FileUtils.rm_rf(cache_path)
       File.symlink(File.join(Installation.destdir, cache_path), cache_path)
     end


### PR DESCRIPTION
When the copy happens, libzypp already has the cache file in the destination
open, but the copy from the local cache overwrites the opened file. This leads
to data corruption and ultimately crashes.