### PR TITLE
Remove .coveralls.yml file

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci


### PR DESCRIPTION
It is not needed anymore, the code coverage is processed by the `coverallsapp/github-action` GitHub action. See the `.github/workflows/ci.yml` file.