### PR TITLE
Hide the abort button when calling the network client

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  7 11:06:45 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Hide the abort button when the network client is called
+  (bsc#1183586).
+- 4.4.0
+
+-------------------------------------------------------------------
 Thu Mar 18 16:33:19 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not create zypp cache symlink when running in installed

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.20
+Version:        4.4.0
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -337,16 +337,12 @@ module Yast
         end
 
         Builtins.y2milestone("User wants to setup the network")
-        # Call InstLan client
-        netret = WFM.call(
-          "inst_lan",
-          [GetInstArgs.argmap.merge("skip_detection" => true)]
-        )
 
-        if netret == :abort
-          Builtins.y2milestone("Aborting the network setup")
-          break
-        end
+        # Call InstLan client
+        WFM.call(
+          "inst_lan",
+          [GetInstArgs.argmap.merge("skip_detection" => true, "hide_abort_button" => true)]
+        )
       end
 
       ret

--- a/src/modules/SourceDialogs.rb
+++ b/src/modules/SourceDialogs.rb
@@ -2217,7 +2217,10 @@ module Yast
         RefreshTypeWidgets()
         return nil
       when :network
-        Yast::WFM.CallFunction("inst_lan", [{ "skip_detection" => true }])
+        Yast::WFM.CallFunction(
+          "inst_lan",
+          [{ "skip_detection" => true, "hide_abort_button" => true }]
+        )
       end
 
       return nil if event["ID"] != :next && event["ID"] != :ok


### PR DESCRIPTION
### Problem

> When user presses Abort button on Network settings page, it works same way as "Back" button and returns to the previous dialog. — https://bugzilla.suse.com/show_bug.cgi?id=1183586

As stated in the [second comment](https://bugzilla.suse.com/show_bug.cgi?id=1183586#c2), this happens

>  because the network **subworkflow** should not use [Abort] (...) It should be possible to **abort only in the main workflow**.

### Solution

To use an installation argument (`hide_abort_button`) when calling the _inst\_lan_ client to force it hiding the abort button during the installation. **See https://github.com/yast/yast-network/pull/1195** for more details.