### PR TITLE
[master] Revert copying the libzypp cache to the target system (bsc#1183711)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr 22 07:51:02 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Revert copying the libzypp cache to the target system and
+  replacing it by a symlink, it is not safe and it can
+  cause crash (segfault) in some cases (bsc#1183711)
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr  7 11:06:45 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Hide the abort button when the network client is called

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -98,6 +98,10 @@ module Yast
       Pkg.SourceSaveAll
       Pkg.TargetFinish
 
+      # save repository metadata cache to the installed system
+      # (needs to be done _after_ saving repositories, see bnc#700881)
+      Pkg.SourceCacheCopyTo(Installation.destdir)
+
       # Patching /etc/zypp/zypp.conf in order not to install
       # recommended packages, doc-packages,...
       # (needed for products like CASP)

--- a/test/pkg_finish_test.rb
+++ b/test/pkg_finish_test.rb
@@ -68,6 +68,7 @@ describe Yast::PkgFinishClient do
       expect(Yast::Pkg).to receive(:SourceLoad)
       expect(Yast::Pkg).to receive(:SourceSaveAll)
       expect(Yast::Pkg).to receive(:TargetFinish)
+      expect(Yast::Pkg).to receive(:SourceCacheCopyTo).with(destdir)
       allow(Yast::WFM).to receive(:Execute)
       expect(client.run).to be_nil
     end


### PR DESCRIPTION
- Just merging #562 to `master`
- https://bugzilla.suse.com/show_bug.cgi?id=1183711