### PR TITLE
Use "armv7hl" packages on "armv7l" (bsc#1183795)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 27 07:43:27 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use the "armv7hl" packages on the "armv7l" architecture
+  (bsc#1183795)
+- 4.3.22
+
+-------------------------------------------------------------------
 Tue Apr  6 13:06:27 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Revert copying the libzypp cache to the target system and

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.21
+Version:        4.3.22
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/solvable_pool.rb
+++ b/src/lib/y2packager/solvable_pool.rb
@@ -10,14 +10,18 @@
 # FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 # ------------------------------------------------------------------------------
 
+require "etc"
 require "solv"
+require "yast"
 
 module Y2Packager
   # This is a wrapper for the Solv::Pool class
   class SolvablePool
+    include Yast::Logger
+
     def initialize
       @pool = Solv::Pool.new
-      @pool.setarch
+      @pool.setarch(arch)
     end
 
     #
@@ -35,5 +39,23 @@ module Y2Packager
     end
 
     attr_reader :pool
+
+  private
+
+    # detect the system architecture
+    # @return [String] the machine architecture, equivalent to "uname -m"
+    def arch
+      # get the machine architecture name ("uname -m")
+      arch = Etc.uname[:machine]
+      log.info "Detected system architecture: #{arch}"
+
+      # use "armv7hl" packages on "armv7l" (bsc#1183795)
+      if arch == "armv7l"
+        arch = "armv7hl"
+        log.info "Using #{arch} package architecture"
+      end
+
+      arch
+    end
   end
 end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1183795#c16
- We need to handle the `armv7l` architecture specifically
- A [similar workaround](https://github.com/openSUSE/libzypp/blob/7f345ea4892fd02345e8de47c2a08ab5b174650b/zypp/ZConfig.cc#L145-L146) is applied in libzypp