### PR TITLE
bsc#1187270: fix control center tooltip (SLE-15-SP2)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the Comment entry in the desktop file so the tooltip
+  in the control center is properly translated (bsc#1187270).
+- 4.2.70
+
+-------------------------------------------------------------------
 Fri Feb 19 13:21:25 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Show correct number of downloaded packages in log (bsc#1180278)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.2.69
+Version:        4.2.70
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/desktop/org.opensuse.yast.SWSource.desktop
+++ b/src/desktop/org.opensuse.yast.SWSource.desktop
@@ -21,5 +21,5 @@ Exec=xdg-su -c "/sbin/yast2 repositories"
 
 Name=YaST Software Repositories
 GenericName=Software Repositories
-Comment=Choose the repositories for installation of software packages (CD, network, etc.), add the community repositories
+Comment="Choose the repositories for installation of software packages (CD, network, etc.), add the community repositories"
 StartupNotify=true


### PR DESCRIPTION
Related to [bsc#1187270](https://bugzilla.opensuse.org/show_bug.cgi?id=1187270).

See [the original issue](https://github.com/yast/yast-users/pull/303) in the yast2-users module.