### PR TITLE
[SP3] Display repository alias if the repository name is not defined (bsc#1184935)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun 17 15:47:33 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- When editing a repository display the repository alias as a
+  fallback if the repository name is not set, do not display
+  empty name (bsc#1184935)
+- 4.3.24
+
+-------------------------------------------------------------------
 Tue Jun 15 09:17:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the Comment entry in the desktop file so the tooltip

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.23
+Version:        4.3.24
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -1791,7 +1791,12 @@ module Yast
       old_url = url2
       plaindir = Ops.get_string(generalData, "type", "YaST") == @plaindir_type
 
-      SourceDialogs.SetRepoName(source_state.fetch("raw_name", ""))
+      repo_name = source_state.fetch("raw_name", "")
+      # if the repository does not define a name then "raw_name" is empty,
+      # display "name" which contains the repository alias in that case
+      repo_name = source_state.fetch("name", "") if repo_name.empty?
+
+      SourceDialogs.SetRepoName(repo_name)
 
       begin
         url2 = SourceDialogs.EditPopupType(url2, plaindir)


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184935
- When editing a repository in the YaST repository manager in some cases the repository name field is empty.

![edit_repo_broken](https://user-images.githubusercontent.com/907998/122431372-b0029200-cf94-11eb-8ad7-4070c509106a.png)


## Background

Libzypp (or the reused Yum file format) actually uses two names for repositories:

- **alias** - This is the mandatory repository identifier, it should be a short string identifying the repository. It must be unique and some characters are not allowed there (`/` is [automatically replaced](https://github.com/openSUSE/libzypp/blob/7f345ea4892fd02345e8de47c2a08ab5b174650b/zypp/repo/RepoInfoBase.cc#L59-L60) because the alias is also used as the `.repo` file name). YaST never displays the alias as this is kind of internal data.
- **name** - This is the user visible name, it is optional (might be missing) and it might not be unique (duplicates are allowed), it can contain any arbitrary text, no limit for allowed characters. This is what YaST displays.

The name can contain some variables like `$releasever` which is replaced by the installed product version. So the `openSUSE $releasever` name gets expanded to `openSUSE 15.3` in Leap 15.3. It is possible to get both values from libzypp, the expanded one (via the `name()` method) and the unexpanded original (using the `rawName()` method).

## Debugging

Originally I was able to reproduce the problem in some previous Tumbleweed release. It behaved strangely, for some repositories the name was displayed correctly, for some it was just empty.

Later I could not reproduce the problem it with the latest TW, but luckily the problem happens on my older Leap workstation.

## Details

I was able to reproduce the problem locally with some testing repository I used in the past. The `/etc/zypp/repos.d/test.repo` contained:

```
[test]
enabled=0
autorefresh=1
baseurl=dir:/local/work/test
type=yast2
keeppackages=0
```

*As you can see the `name` attribute is actually missing there!*

It turned out that the `name()` [method fallbacks to the repository alias](https://github.com/openSUSE/libzypp/blob/7f345ea4892fd02345e8de47c2a08ab5b174650b/zypp/repo/RepoInfoBase.cc#L119-L120) in libzypp if the name is not defined. But the `rawName()` method does not use any fallback, if the name is not defined it returns empty string.

And YaST (as an exception) displays the raw name in that dialog to allow editing the variables in the name... 


## The Fix

To fix the problem YaST should display the name if the raw name is empty, in that case the name contains the alias as a fallback. That's also what YaST and zypper show as the repository name in that case.

## Testing

Just tested manually with that repository mentioned above, the name (actually the alias fallback) is displayed correctly:

![edit_repo_fixed](https://user-images.githubusercontent.com/907998/122434407-5c457800-cf97-11eb-89ab-aeb537ff78ea.png)
