### PR TITLE
Do not crash trying to read a not known file

### DIFF
--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -78,9 +78,11 @@ module Y2Packager
 
       # add a temporary repository for downloading the files via libzypp
       src = Yast::Pkg.RepositoryAdd("base_urls" => [url])
-      repos.map do |(_name, dir)|
+      xml_paths = repos.map do |(_name, dir)|
         # download the repository index file (repomd.xml)
         repomd_file = Yast::Pkg.SourceProvideFile(src, 1, File.join(dir, "repodata/repomd.xml"))
+
+        next unless repomd_file
 
         # parse the index file and get the full name of the primary.xml.gz file
         doc = REXML::Document.new(File.read(repomd_file))
@@ -90,6 +92,8 @@ module Y2Packager
         # download the primary.xml.gz file
         Yast::Pkg.SourceProvideFile(src, 1, File.join(dir, primary_path))
       end
+
+      xml_paths.compact
     ensure
       # remove the temporary repository
       Yast::Pkg.SourceDelete(src) if src

--- a/src/lib/y2packager/repomd_downloader.rb
+++ b/src/lib/y2packager/repomd_downloader.rb
@@ -82,7 +82,10 @@ module Y2Packager
         # download the repository index file (repomd.xml)
         repomd_file = Yast::Pkg.SourceProvideFile(src, 1, File.join(dir, "repodata/repomd.xml"))
 
-        next unless repomd_file
+        if !repomd_file
+          Yast::Report.Error(Yast::Pkg.LastError)
+          next
+        end
 
         # parse the index file and get the full name of the primary.xml.gz file
         doc = REXML::Document.new(File.read(repomd_file))


### PR DESCRIPTION
## Problem

When running the installation or upgrade reading repositories from disk partition via `install=` boot param, it could crash with a `TypeError` exception when the `device` parameter is not added to the "ZyppRepoURL". Thus, booting with `install=disk:/path/to/installation/media` instead of `install=disk:/path/to/installation/media?device=sdb1` will end up in a crashed installation because _libzypp does not know which partition on the disk should be used_

![Screenshot_openSUSE-Leap_2021-07-02_16:33:22](https://user-images.githubusercontent.com/1691872/124564354-e0717980-de38-11eb-99b8-ae14f0e40ab9.png)

* Trello (internal link): https://trello.com/c/SF91Redx
* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1186387

## Solution

Ideally, instead of crashing, it would be nice to display a user-friendly message telling what was wrong. However, the exception in the Ruby side is too generic to be aware that the `#<TypeError: no implicit conversion of nil into String>` crash happens exactly because a missing `device` param.

So, since `RepomdDownloader#primary_xmls` could return an empty list of path, the implemented solution is to ignore repos for which `Yast::Pkg.SourceProvideFile` returns nil. And, apparently, it works.

## Pending

- [ ] Unit tests (help needed)
- [ ] Bump version and changelog
- [ ] Once merged, apply same changes to SLE-15-SP3 and master branches

## Manual test

To check manually that this change works, below steps were given

* Install a SLE-15-SP2 in a virtual machine
* Add a new disk to the virtual machine
* Create two partitions in the new disk
* Create the _sp2_ and _sp3_ directories in the second partition, /dev/vdb2
* Extract an SLE-15-SP2 media in sp2
* Extract an online SLE-15-SP3 media in sp3
* Boot with the SLE-15-SP2 cd
* Select Upgrade with `install=disk:/sp3` boot option
* Run the migration.
* Migrate the system
* Check that system was migrated

## `disk:/` vs `hd:/`

During manual tests, I could check that the problem only appears when using _install=**disk**:/whatever_ but not with _install=**hd**:/whatever_. For the latter, "ZyppRepoURL" gets the `device=` parameter _automagically_, as well as it happens with "RepoURL". See below screenshot

<details>
<summary>Click to show/hide the screenshot</summary>

---

![Screenshot_openSUSE-Leap_2021-07-06_09:16:34](https://user-images.githubusercontent.com/1691872/124566370-e49e9680-de3a-11eb-94b7-2f9872484b45.png)


</details>

I have been digging in the Linuxrc code and maybe this difference could be _killed_ in [url_print_zypp](https://github.com/openSUSE/linuxrc/blob/9346016b26ba883931aa78ba857bb22bbab14894/url.c#L1006), checking [if url schema is `inst_hd` **or `inst_disk`**](https://github.com/openSUSE/linuxrc/blob/9346016b26ba883931aa78ba857bb22bbab14894/url.c#L1090-L1094)