### PR TITLE
Fixed evaluating module dependencies on the SLE Full medium 

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Aug 17 15:18:07 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed evaluating module dependencies on the SLE Full medium
+  - Ignore soft dependencies (Recommends), use only hard
+    dependencies (Requires)
+  - Do not select "Python2" module for "Workstation Extensions"
+    (bsc#1188633)
+- 4.4.8
+
+-------------------------------------------------------------------
 Thu Aug 12 13:28:52 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Adjusted memory check to display a low memory warning on RPi

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_finder.rb
+++ b/src/lib/y2packager/product_finder.rb
@@ -184,6 +184,9 @@ module Y2Packager
       jobs = select_products(product_solvable, selected_base)
       solver = pool.Solver
 
+      # disable soft dependencies (Recommends), use only the hard dependencies (Requires)
+      solver.set_flag(Solv::Solver::SOLVER_FLAG_IGNORE_RECOMMENDED, 1)
+
       # run the solver to evaluate all dependencies
       problems = solver.solve(jobs)
 


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1188633
  - Esp. see comments [c#10](https://bugzilla.suse.com/show_bug.cgi?id=1188633#c10) and [c#14](https://bugzilla.suse.com/show_bug.cgi?id=1188633#c14)
- After selecting the "Workstation Extension" the "Python2" module was automatically selected
- It turned out that there is a soft dependency in the WE product:
  `Recommends:       product(sle-module-python2) >= 15.4`
  But that should not select the module automatically, it's not a hard requirement, just recommended. 
- The Online medium uses only the hard dependencies (from SCC), the Full medium should behave similarly

## The Fix

- Ignore soft dependencies (`Recommends`) in the solver, use only the hard dependencies (`Requires`)

## Screenshots

Original behavior, the "Python2" module was automatically selected for the "Workstation Extension":
![we_selection_orig](https://user-images.githubusercontent.com/907998/127155122-fa5af13a-4ff6-4ced-893b-f45796832176.png)

Fixed version, the "Python2" module is not autoselected anymore:
![we_selection_fixed](https://user-images.githubusercontent.com/907998/127155183-b8993b65-5cb3-4fdd-839d-b51482d5c985.png)

## Testing

Tested manually in the latest Full medium build, see the screenshots above.