### PR TITLE
Adjusted memory check for RPi (bsc#1139325)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 12 13:28:52 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Adjusted memory check to display a low memory warning on RPi
+  (bsc#1139325)
+- 4.4.7
+
+-------------------------------------------------------------------
 Fri Jun 18 08:39:06 UTC 2021 - Stefan Schubert <schubi@schubi.de>
 
 - Adding NFS repository: Checking user input e.g. white spaces in

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1697,7 +1697,7 @@ module Yast
     def low_memory?
       # less than LOW_MEMORY_MIB RAM, the 64MiB buffer is for possible
       # rounding in hwinfo memory detection (bsc#1045915)
-      Yast2::HwDetection.memory < ((LOW_MEMORY_MIB - 64) << 20)
+      Yast2::HwDetection.memory <= ((LOW_MEMORY_MIB - 64) << 20)
     end
 
     # Ask the user if he wishes to activate online repos.


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1139325
- YaST displays a [warning on low memory systems](https://github.com/yast/yast-packager/blob/2c0c05736812df34f7bd4031e8dc0067d892881c/src/lib/y2packager/clients/inst_productsources.rb#L1684-L1690) to discourage using the online repositories (the repository metadata need quite a lot of RAM)
- But on Raspberry Pi the amount of memory exactly matches the limit so no warning is displayed (if it had *one byte less* memory the warning would be displayed)
- Update the check to display the warning in that case as well