### PR TITLE
sw_single: Check for -pkg UI Plug-In and Prompt to Install it if Needed

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 15 12:35:42 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Check if the "pkg" UI plug-in is available and if not, ask
+  the user if it should be installed
+  (jsc#SLE-20346, jsc#SLE-20462)
+- 4.4.10
+
+-------------------------------------------------------------------
 Mon Aug 23 13:31:34 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Include some hints in the "Priority" label in the repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.9
+Version:        4.4.10
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -49,7 +49,7 @@ Requires:       yast2-country-data >= 2.16.3
 # raw_name
 Requires:       yast2-pkg-bindings >= 4.2.8
 # UIExtensionChecker
-Requires:       yast2 >= 4.4.18
+Requires:       yast2 >= 4.4.19
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -48,8 +48,8 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # raw_name
 Requires:       yast2-pkg-bindings >= 4.2.8
-# Installation::InstallationInfo
-Requires:       yast2 >= 4.4.4
+# UIExtensionChecker
+Requires:       yast2 >= 4.4.18
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -8,6 +8,7 @@ require "shellwords"
 require "y2packager/known_repositories"
 require "y2packager/system_packages"
 require "y2packager/resolvable"
+require "ui/ui_extension_checker"
 
 module Yast
   # Purpose:     contains dialog loop for workflows:
@@ -72,6 +73,9 @@ module Yast
 
         return CommandLine.Run(@cmdline_description)
       end
+
+      ui_extension_checker = UIExtensionChecker.new("pkg")
+      return unless ui_extension_checker.ok?
 
       StartSWSingle()
     end


### PR DESCRIPTION
## Trello

https://trello.com/c/gT8nMq7O/2635-3-featureshouldhave-handle-more-gracefully-when-libyui-libraries-are-missing


## Jira

- https://jira.suse.com/browse/SLE-20346
- https://jira.suse.com/browse/SLE-20462


## Related PRs

- Main PR: https://github.com/yast/yast-yast2/pull/1194
- https://github.com/yast/yast-online-update/pull/36
- https://github.com/yast/yast-add-on/pull/114


## Problem

When a user installed the system with "no recommends", i.e. recommended packages were not installed, the resulting system will also not have the Qt-Pkg (YQPackageSelector) plug-in because the _libyui-qt-pkg_ package is not required unconditionally.

So when the user starts the YaST control center in the graphical (Qt) version and wants to start the YaST package management module from there, this will fail with a very obscure error message telling the user that "UI plug-in qt-pkg could not be loaded".


## Desired Outcome

Give the user a much better message so there is a realistic chance to fix the problem.

Minimum: Give a hint that the package needed for that action was not installed, of course including _what_ package that was.

Better: Open a pop-up dialog explaining the situation and offering to try to install that package directly from there, and give a hint to the alternative: Start the package management module in the NCurses version.


##  Chosen Approach

This checks if the "pkg" UI extension (`libyui-qt-pkg42`, `libyui-ncurses-pkg42`) is installed, and if not, it asks the user if it should now be installed. If the user confirms that, the package is installed, and the module is run as usual. If the user does not wish to install that package, the module exits.


## Screenshots

![need-pkg-installed-qt](https://user-images.githubusercontent.com/11538225/133434569-45974db6-a6fa-4e03-bd29-f11097164730.png)

![need-pkg-installed-ncurses](https://user-images.githubusercontent.com/11538225/133434575-430ca38f-84e9-43c0-9e3d-426cda0bbf62.png)


## Test

Either manually uninstall package `libyui-qt-pkg15` or brute-force delete the binary plug-in:

```
sudo rm -f /usr/lib64/yui/libyui-ncurses-pkg.so.15.0.0
```

Then start the `sw_single` module. It should open one of the above pop-ups and reinstall the package and open the package selection immediately afterwards without the need for restarting the YaST module.