### PR TITLE
Bring `ProductUpgrade` from `yast2.rpm` package

### DIFF
--- a/src/lib/y2packager/product_upgrade.rb
+++ b/src/lib/y2packager/product_upgrade.rb
@@ -23,6 +23,7 @@ module Y2Packager
 
     # mapping with upgraded products to handle some corner cases,
     # maps installed products to a new available base product
+    # rubocop:disable Metrics/LineLength
     MAPPING = {
       # SLES12 + HPC module => SLESHPC15
       # (a bit tricky, the module became a new base product!)
@@ -59,6 +60,7 @@ module Y2Packager
       # and the SLES product to avoid automatic upgrade by the solver
       ["SLES", "SUSE-Manager-Proxy", "SUSE-Manager-Retail-Branch-Server"] => ["SLES", "SUSE-Manager-Proxy"]
     }.freeze
+    # rubocop:enable Metrics/LineLength
 
     class << self
       # Find a new available base product which upgrades the installed base product.

--- a/src/lib/y2packager/product_upgrade.rb
+++ b/src/lib/y2packager/product_upgrade.rb
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------------
 
 require "y2packager/product"
+require "y2packager/product_spec"
 
 module Y2Packager
   # Evaluate the installed and available products and find the new upgraded
@@ -89,7 +90,7 @@ module Y2Packager
       #
       # @return [Y2Packager::Product,nil] the new upgraded product
       def new_base_product
-        available = Y2Packager::Product.available_base_products
+        available = Y2Packager::ProductSpec.base_products
         return nil if available.empty?
 
         # just one product?

--- a/src/lib/y2packager/product_upgrade.rb
+++ b/src/lib/y2packager/product_upgrade.rb
@@ -1,0 +1,218 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "y2packager/product"
+
+module Y2Packager
+  # Evaluate the installed and available products and find the new upgraded
+  # product tp install.
+  class ProductUpgrade
+    include Yast::Logger
+
+    Yast.import "Pkg"
+
+    # mapping with upgraded products to handle some corner cases,
+    # maps installed products to a new available base product
+    MAPPING = {
+      # SLES12 + HPC module => SLESHPC15
+      # (a bit tricky, the module became a new base product!)
+      ["SLES", "sle-module-hpc"]                                          => "SLE_HPC",
+      ["SLES", "SUSE-Manager-Proxy"]                                      => "SUSE-Manager-Proxy",
+      ["SLES", "SUSE-Manager-Server"]                                     => "SUSE-Manager-Server",
+      ["SLES", "SUSE-Manager-Proxy", "SUSE-Manager-Retail-Branch-Server"] => "SUSE-Manager-Retail-Branch-Server",
+      # this is an internal product so far...
+      ["SLE-HPC"]                                                         => "SLE_HPC",
+      # SLES11 => SLES15
+      ["SUSE_SLES"]                                                       => "SLES",
+      # SLED11 => SLED15
+      ["SUSE_SLED"]                                                       => "SLED",
+      # SLES4SAP11 => SLES4SAP15
+      ["SUSE_SLES_SAP"]                                                   => "SLES_SAP",
+      # (installed) openSUSE => (available) SLES,
+      # this one is used when openSUSE is not available, e.g. booting SLE medium
+      # (moreover the openSUSE medium should contain only one product so that
+      # product should be used unconditionally)
+      ["openSUSE"]                                                        => "SLES",
+      # (installed) openSUSE Leap => (available) SLES,
+      # same as above, in 15.3+ the product has been renamed from "openSUSE" to "Leap"
+      ["Leap"]                                                            => "SLES"
+    }.freeze
+
+    # This maps uses a list of installed products as the key and the removed products as a value.
+    # All products in key have to be installed.
+    # It is used in special cases when the removed product is still available on the medium
+    # and it is selected to upgrade automatically by the solver (not by YaST or the user).
+    # However, the required behavior is to *uninstall* the product.
+    UPGRADE_REMOVAL_MAPPING = {
+      # the SLES + SUMA Proxy + SUMA Branch Server is upgraded to SUMA Branch Server
+      # (see the definition above), but we need to explicitly remove the old SUMA Proxy
+      # and the SLES product to avoid automatic upgrade by the solver
+      ["SLES", "SUSE-Manager-Proxy", "SUSE-Manager-Retail-Branch-Server"] => ["SLES", "SUSE-Manager-Proxy"]
+    }.freeze
+
+    class << self
+      # Find a new available base product which upgrades the installed base product.
+      #
+      # The workflow to find the new base product is:
+      #
+      #  1) If there is only one available base product then just use it,
+      #     there are no other options than to upgrade to this product.
+      #
+      #  2) TODO: Somehow evaluate the available and installed products and
+      #     find the best upgrade candidate.
+      #
+      #     Note: We cannot use the solver here because it evaluates *all*
+      #     packages, not just the products. Moreover some products
+      #     (modules/extensions) might be added later which could change
+      #     the best upgrade candidate.
+      #
+      #  3) Use a harcoded mapping with the list of installed products
+      #     mapped to a new base product product. The static mapping is needed to
+      #     handle some corner cases properly. This includes product renames or
+      #     changing a module to a base product.
+      #
+      #  4) As the last attempt try to find the installed base product in the
+      #     available base products. It is very likely that SLES will be upgraded
+      #     to SLES, SLED to SLED and so on.
+      #
+      #  If no candidate product is found then it returns nil. That should happen
+      #  only when using completely incompatible products.
+      #
+      # @return [Y2Packager::Product,nil] the new upgraded product
+      def new_base_product
+        available = Y2Packager::Product.available_base_products
+        return nil if available.empty?
+
+        # just one product?
+        product = find_by_count(available)
+        return product if product
+
+        # found by hardcoded mapping?
+        product = find_by_mapping(available)
+        return product if product
+
+        # just 1:1 product upgrade?
+        find_by_name(available)
+      end
+
+      # Returns the product name which obsoletes the given product.
+      # @param old_product_name <String> Product name which will be obsoleted
+      # @return [<String>] Product names which obsoletes this product.
+      def will_be_obsoleted_by(old_product_name)
+        installed = Y2Packager::Product.installed_products.map(&:name)
+        selected_products = Y2Packager::Product.with_status(:selected).map(&:name)
+
+        # the "sort_by(&:size).reverse" part ensures we try first the longer
+        # mappings (more installed products) to find more specific matches
+        old_products = MAPPING.keys.sort_by(&:size).reverse.find do |products|
+          # the product is included in the mapping key and all product mapping key
+          # products are installed and the replacement products are selected
+          products.include?(old_product_name) && (products - installed).empty? &&
+            selected_products.include?(MAPPING[products])
+        end
+
+        return [] unless old_products
+
+        [MAPPING[old_products]]
+      end
+
+      # Returns the products which are upgraded by the solver but should be actually
+      # removed from the system during upgrade. It uses an internal hardcoded
+      # product mapping.
+      # @return [<String>] Product names which should be uninstalled from the system
+      def obsolete_upgrades
+        system_installed = Y2Packager::Product.installed_products.map(&:name)
+
+        UPGRADE_REMOVAL_MAPPING.each_with_object([]) do |(installed_products, obsolete_products), a|
+          # all products from the mapping are installed and the obsolete one
+          # is removed by the solver (i.e. not removed by YaST or user)
+          next unless (installed_products - system_installed).empty? &&
+            obsolete_products.all? { |p| removed_by_solver?(p) }
+
+          a.concat(obsolete_products)
+        end
+      end
+
+      # Removes (uninstalls) the obsolete products. It uses an internal hardcoded
+      # product mapping.
+      # @see .obsolete_upgrades
+      def remove_obsolete_upgrades
+        # deselect the upgraded obsolete products (bsc#1133215)
+        obsolete_products = Y2Packager::ProductUpgrade.obsolete_upgrades
+        log.info "Found obsolete products to uninstall: #{obsolete_products.inspect}"
+        obsolete_products.each { |p| Yast::Pkg.ResolvableRemove(p, :product) }
+      end
+
+    private
+
+      # check the count of the new base products
+      # @param available [Array<Y2Packager::Product>] the available base products
+      # @return [Y2Packager::Product,nil] the new upgraded product
+      def find_by_count(available)
+        return nil unless available.size == 1
+
+        # only one base product available, we can upgrade only to this product
+        log.info("Only one base product available: #{available.first}")
+        available.first
+      end
+
+      # find the upgrade product from the fallback mapping
+      # @param available [Array<Y2Packager::Product>] the available base products
+      # @return [Y2Packager::Product,nil] the new upgraded product
+      def find_by_mapping(available)
+        installed = Y2Packager::Product.installed_products
+
+        # sort the keys by length, try more products first
+        # to find the most specific upgrade, prefer the
+        # SLES + sle-module-hpc => SLE_HPC upgrade to plain SLES => SLES upgrade
+        # (if that would be in the list)
+        upgrade = MAPPING.keys.sort_by(&:size).reverse.find do |keys|
+          keys.all? { |name| installed.any? { |p| p.name == name } }
+        end
+
+        log.info("Fallback upgrade for products: #{upgrade.inspect}")
+        return nil unless upgrade
+
+        name = MAPPING[upgrade]
+        product = available.find { |p| p.name == name }
+        log.info("New product: #{product}")
+        product
+      end
+
+      # find the upgrade product with the same identifier as the installed product
+      # @param available [Array<Y2Packager::Product>] the available base products
+      # @return [Y2Packager::Product,nil] the new upgraded product
+      def find_by_name(available)
+        installed_base = Y2Packager::Product.installed_base_product
+        return nil unless installed_base
+
+        product = available.find { |a| a.name == installed_base.name }
+        log.info("New product: #{product}")
+        product
+      end
+
+      # just a helper for logging the details for easier debugging
+      def log_products
+        products = Y2Packager::Resolvable.find(kind: :product)
+        log.debug("All products: #{products.map(&:name)}")
+        names = products.select { |p| p.status == :selected }.map(&:name)
+        log.info("Selected products: #{names.inspect}")
+      end
+
+      def removed_by_solver?(product_name)
+        Y2Packager::Resolvable.any?(
+          name: product_name, kind: :product, status: :removed, transact_by: :solver
+        )
+      end
+    end
+  end
+end

--- a/test/data/zypp/products_update_suma_proxy.yml
+++ b/test/data/zypp/products_update_suma_proxy.yml
@@ -1,0 +1,641 @@
+---
+# these are the dumped products from the SLES12-SP3 + SUMA-Proxy-3.2
+# upgrade to SLE15-SP1 (RC3)
+- arch: x86_64
+  category: addon
+  description: |-
+    <p>
+          The Development Tools Module helps you developing applications for
+          SUSE Linux Enterprise 15.
+      </p>
+      <p>
+          Access to the Development Tools Module is included in your SUSE Linux Enterprise
+          product subscription. The module has a different lifecycle than SUSE Linux
+          Enterprise itself.
+      </p>
+  display_name: Development Tools Module RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-development-tools
+  on_system_by_user: false
+  product_file: sle-module-development-tools.prod
+  product_line: ''
+  product_package: sle-module-development-tools-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: ''
+  short_name: Development-Tools-Module
+  source: 3
+  status: :selected
+  summary: Development Tools Module RC3
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tThe SUSE Linux Enterprise Desktop Applications Module delivers
+    a\n\tbasic set of Desktop functionality.\n\t</p>\n\t<p>\n\tAccess to the Desktop
+    Applications Module is included in your SUSE Linux\n\tEnterprise product subscription.\n\t</p>"
+  display_name: Desktop Applications Module
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-desktop-applications
+  on_system_by_user: false
+  product_file: sle-module-desktop-applications.prod
+  product_line: ''
+  product_package: sle-module-desktop-applications-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: ''
+  short_name: Desktop-Applications-Module
+  source: 2
+  status: :selected
+  summary: Desktop Applications Module
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\n\tThe SUSE Linux Enterprise  Web and Scripting Module should
+    contains\n\tadditional packages that are helpful when running a webserver.\n\t</p>\n\t<p>\n\tAccess
+    to the Web and Scripting Module is included in your SUSE Linux\n\tEnterprise Server
+    subscription. The module has a different lifecycle\n\tthan SUSE Linux Enterprise
+    Server itself: Package versions in this\n\tmodule are usually supported for at
+    most three years. We are planning\n\tto release more recent versions on a schedule
+    of approximately 18\n\tmonth; the exact dates may differ per package.\n\t</p>"
+  display_name: Web and Scripting Module
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-web-scripting
+  on_system_by_user: false
+  product_file: sle-module-web-scripting.prod
+  product_line: ''
+  product_package: sle-module-web-scripting-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: ''
+  short_name: Web-Scripting-Module
+  source: 6
+  status: :selected
+  summary: Web and Scripting Module
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tThe SUSE Linux Enterprise Server Applications Module delivers
+    a\n\tbasic set of Server functionality.\n\t</p>\n\t<p>\n\tAccess to the Server
+    Applications Module is included in your SUSE Linux\n\tEnterprise Server subscription.\n\t</p>"
+  display_name: Server Applications Module
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-server-applications
+  on_system_by_user: false
+  product_file: sle-module-server-applications.prod
+  product_line: ''
+  product_package: sle-module-server-applications-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: ''
+  short_name: Server-Applications-Module
+  source: 5
+  status: :selected
+  summary: Server Applications Module
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: |-
+    <p>
+      The SUSE Linux Enterprise Basesystem Module delivers the base system of
+      the product.
+      </p>
+  display_name: Basesystem Module RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-basesystem
+  on_system_by_user: false
+  product_file: sle-module-basesystem.prod
+  product_line: ''
+  product_package: sle-module-basesystem-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: ''
+  short_name: Basesystem-Module
+  source: 1
+  status: :selected
+  summary: Basesystem Module RC3
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: base
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 12 SP3
+  download_size: 0
+  eol: 1730332800
+  flags: []
+  flavor: DVD
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SLES
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/SLES.prod"
+  product_line: sles
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm
+  short_name: SLES12-SP3
+  source: -1
+  status: :removed
+  summary: SUSE Linux Enterprise Server 12 SP3
+  transact_by: :solver
+  type: base
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12.3-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12.3'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 15 SP1 RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SLES
+  on_system_by_user: false
+  product_file: SLES.prod
+  product_line: ''
+  product_package: sles-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP1/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP1/release-notes-sles.rpm
+  short_name: SLES15-SP1
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise Server 15 SP1 RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class. SUSE Linux
+            Enterprise provides more than a cute desktop
+            product or a basic server offering. It is the
+            only Linux platform for enterprise computing,
+            and it is now replacing UNIX* and Windows*
+            as well.
+  display_name: SUSE Linux Enterprise Desktop 15 SP1 RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SLED
+  on_system_by_user: false
+  product_file: SLED.prod
+  product_line: ''
+  product_package: sled-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLED/15-SP1/release-notes-sled.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLED/15-SP1/release-notes-sled.rpm
+  short_name: SLED15-SP1
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise Desktop 15 SP1 RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Manager lets you efficiently manage physical, virtual,
+    and cloud-based Linux systems. It provides automated and cost-effective
+    configuration and software management, asset management, and system
+    provisioning.
+  display_name: SUSE Manager Server 4.0
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SUSE-Manager-Server
+  on_system_by_user: false
+  product_file: SUSE-Manager-Server.prod
+  product_line: ''
+  product_package: SUSE-Manager-Server-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/4.0/release-notes-susemanager.rpm
+  relnotes_urls:
+  - http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/4.0/release-notes-susemanager.rpm
+  replaces: []
+  short_name: SUSE Manager Server 4.0
+  source: 0
+  status: :available
+  summary: SUSE Manager Server 4.0
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 4.0-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '4.0'
+- arch: x86_64
+  category: addon
+  description: |-
+    The SUSE Manager for Retail Branch Server supports large and/or
+    geographically dispersed SUSE Manager for Retail environments by reducing
+    the load on the SUSE Manager Server, lowering bandwidth needs,
+    and providing faster local updates.
+  display_name: SUSE Manager Retail Branch Server 4.0
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SUSE-Manager-Retail-Branch-Server
+  on_system_by_user: false
+  product_file: SUSE-Manager-Retail-Branch-Server.prod
+  product_line: ''
+  product_package: SUSE-Manager-Retail-Branch-Server-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER-PROXY/4.0/release-notes-susemanager-proxy.rpm
+  relnotes_urls:
+  - http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER-PROXY/4.0/release-notes-susemanager-proxy.rpm
+  replaces: []
+  short_name: SUSE Manager Retail Branch Server 4.0
+  source: 0
+  status: :available
+  summary: SUSE Manager Retail Branch Server 4.0
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 4.0-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '4.0'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Manager Proxies extend large and/or geographically
+    dispersed SUSE Manager environments to reduce load on the SUSE Manager
+    Server, lower bandwidth needs, and provide faster local
+    updates.
+  display_name: SUSE Manager Proxy 3.2
+  download_size: 0
+  eol: 1590883200
+  flags: []
+  flavor: DVD
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SUSE-Manager-Proxy
+  on_system_by_user: false
+  product_file: "/mnt/etc/products.d/SUSE-Manager-Proxy.prod"
+  product_line: manager-proxy
+  register_flavor: extension
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: http://www.novell.com/linux/releasenotes/x86_64/SUSE-MANAGER-PROXY/3.2/release-notes-susemanager-proxy.rpm
+  relnotes_urls:
+  - http://www.novell.com/linux/releasenotes/x86_64/SUSE-MANAGER-PROXY/3.2/release-notes-susemanager-proxy.rpm
+  short_name: SUSE Manager Proxy 3.2
+  source: -1
+  status: :removed
+  summary: SUSE Manager Proxy 3.2
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 3.2-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '3.2'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Manager Proxies extend large and/or geographically
+    dispersed SUSE Manager environments to reduce load on the SUSE Manager
+    Server, lower bandwidth needs, and provide faster local
+    updates.
+  display_name: SUSE Manager Proxy 4.0
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: true
+  locked: false
+  medium_nr: 0
+  name: SUSE-Manager-Proxy
+  on_system_by_user: false
+  product_file: SUSE-Manager-Proxy.prod
+  product_line: ''
+  product_package: SUSE-Manager-Proxy-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER-PROXY/4.0/release-notes-susemanager-proxy.rpm
+  relnotes_urls:
+  - http://www.suse.com/releasenotes/x86_64/SUSE-MANAGER-PROXY/4.0/release-notes-susemanager-proxy.rpm
+  replaces: []
+  short_name: SUSE Manager Proxy 4.0
+  source: 0
+  status: :selected
+  summary: SUSE Manager Proxy 4.0
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 4.0-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '4.0'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tThe SUSE Linux Enterprise Real Time aims to reduce\n        the
+    latency and increase the predictability and reliability\n        of time-sensitive
+    mission-critical applications.\n\t</p>"
+  display_name: SUSE Linux Enterprise Real Time 15 SP1 RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "\uFEFFSUSE® End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SLE_RT
+  on_system_by_user: false
+  product_file: SLE_RT.prod
+  product_line: ''
+  product_package: SLE_RT-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLE-RT/15-SP1/release-notes-sle_rt.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLE-RT/15-SP1/release-notes-sle_rt.rpm
+  replaces: []
+  short_name: SLE-15-SP1-RT
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise Real Time 15 SP1 RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tSUSE Linux Enterprise High Performance Computing\n\tis a highly
+    scalable, high performance open source\n\toperating system designed to utilize
+    the power of\n\tparallel computing for modeling, simulation and\n\tadvanced analytics
+    workloads.\n\t</p>"
+  display_name: SUSE Linux Enterprise High Performance Computing 15 SP1 RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SLE_HPC
+  on_system_by_user: false
+  product_file: SLE_HPC.prod
+  product_line: ''
+  product_package: SLE_HPC-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLE-HPC/15-SP1/release-notes-sle_hpc.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLE-HPC/15-SP1/release-notes-sle_hpc.rpm
+  replaces: []
+  short_name: SLE-15-SP1-HPC
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise High Performance Computing 15 SP1 RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server for SAP Applications 15 SP1 RC3
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  license: "SUSE(R) End User License Agreement ..."
+  license_confirmed: false
+  locked: false
+  medium_nr: 0
+  name: SLES_SAP
+  on_system_by_user: false
+  product_file: SLES_SAP.prod
+  product_line: ''
+  product_package: SLES_SAP-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLE-SAP/15-SP1/release-notes-sles-for-sap.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLE-SAP/15-SP1/release-notes-sles-for-sap.rpm
+  replaces: []
+  short_name: SLE-15-SP1-SAP
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise Server for SAP Applications 15 SP1 RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 15 SP1 Business Critical Linux RC3
+  download_size: 0
+  eol: 1782864000
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SLES_BCL
+  on_system_by_user: false
+  product_file: SLES_BCL.prod
+  product_line: ''
+  product_package: SLES_BCL-release
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLES/15-SP1/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLES/15-SP1/release-notes-sles.rpm
+  replaces: []
+  short_name: SLE-15-SP1-BCL
+  source: 0
+  status: :available
+  summary: SUSE Linux Enterprise Server 15 SP1 Business Critical Linux RC3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  vendor: SUSE LLC <https://www.suse.com/>
+  version: 15.1-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15.1'

--- a/test/lib/product_upgrade_test.rb
+++ b/test/lib/product_upgrade_test.rb
@@ -7,9 +7,15 @@ require "y2packager/product_upgrade"
 require "y2packager/product"
 
 describe Y2Packager::ProductUpgrade do
-  let(:product1) { Y2Packager::Product.new(name: "testing_product1") }
-  let(:product2) { Y2Packager::Product.new(name: "testing_product2") }
-  let(:product3) { Y2Packager::Product.new(name: "testing_product3") }
+  let(:product1) do
+    instance_double(Y2Packager::Product, name: "testing_product1")
+  end
+  let(:product2) do
+    instance_double(Y2Packager::Product, name: "testing_product2")
+  end
+  let(:product3) do
+    instance_double(Y2Packager::Product, name: "testing_product3")
+  end
   let(:sles) { Y2Packager::Product.new(name: "SLES") }
   let(:sles_hpc) { Y2Packager::Product.new(name: "SLE_HPC") }
   let(:hpc_module) { Y2Packager::Product.new(name: "sle-module-hpc") }
@@ -20,7 +26,7 @@ describe Y2Packager::ProductUpgrade do
   describe ".new_base_product" do
     context "no base product is available" do
       before do
-        expect(Y2Packager::Product).to receive(:available_base_products).and_return([])
+        expect(Y2Packager::ProductSpec).to receive(:base_products).and_return([])
       end
 
       it "returns nil" do
@@ -30,7 +36,7 @@ describe Y2Packager::ProductUpgrade do
 
     context "only one base product is available" do
       before do
-        expect(Y2Packager::Product).to receive(:available_base_products).and_return([product1])
+        expect(Y2Packager::ProductSpec).to receive(:base_products).and_return([product1])
         allow(Y2Packager::Resolvable).to receive(:find).and_return([])
       end
 
@@ -41,7 +47,7 @@ describe Y2Packager::ProductUpgrade do
 
     context "several base products are available" do
       before do
-        expect(Y2Packager::Product).to receive(:available_base_products)
+        expect(Y2Packager::ProductSpec).to receive(:base_products)
           .and_return([product1, product2, sles, sles_hpc]).at_least(:once)
       end
 
@@ -79,7 +85,7 @@ describe Y2Packager::ProductUpgrade do
       it "returns more matching installed products" do
         expect(Y2Packager::Product).to receive(:installed_products)
           .and_return([sles, suma_proxy, suma_branch_server])
-        expect(Y2Packager::Product).to receive(:available_base_products)
+        expect(Y2Packager::ProductSpec).to receive(:base_products)
           .and_return([sles, sles_hpc, suma_proxy, suma_branch_server])
 
         expect(described_class.new_base_product).to be(suma_branch_server)

--- a/test/lib/product_upgrade_test.rb
+++ b/test/lib/product_upgrade_test.rb
@@ -133,16 +133,20 @@ describe Y2Packager::ProductUpgrade do
     # upgrade from SLE12-SP3 + SUMA Proxy 3.2 + SUMA Branch Server 3.2
     # to SLE15-SP1 (actually to SUMA Branch Server 4.0)
     context "SUSE Manager Branch Retail Server 3.2 upgrade" do
-      let(:suma_hash) { YAML.load_file(File.join(__dir__, "../data/zypp/products_update_suma_branch_server.yml")) }
+      let(:suma_hash) do
+        YAML.load_file(File.join(__dir__, "../data/zypp/products_update_suma_branch_server.yml"))
+      end
 
       let(:suma_products) do
         suma_hash.map { |p| Y2Packager::Resolvable.new(p) }
       end
 
       before do
-        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SLES", kind: :product)
+        allow(Y2Packager::Resolvable).to receive(:find)
+          .with(name: "SLES", kind: :product)
           .and_return(suma_products.select { |p| p.name == "SLES" })
-        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SUSE-Manager-Proxy", kind: :product)
+        allow(Y2Packager::Resolvable).to receive(:find)
+          .with(name: "SUSE-Manager-Proxy", kind: :product)
           .and_return(suma_products.select { |p| p.name == "SUSE-Manager-Proxy" })
       end
 
@@ -167,14 +171,18 @@ describe Y2Packager::ProductUpgrade do
 
     context "SUSE Manager Proxy 3.2 upgrade" do
       let(:suma_products) do
-        suma_hash = YAML.load_file(File.join(__dir__, "../data/zypp/products_update_suma_proxy.yml"))
+        suma_hash = YAML.load_file(
+          File.join(__dir__, "../data/zypp/products_update_suma_proxy.yml")
+        )
         suma_hash.map { |p| Y2Packager::Resolvable.new(p) }
       end
 
       it "returns empty list" do
-        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SUSE-Manager-Proxy", kind: :product)
+        allow(Y2Packager::Resolvable).to receive(:find)
+          .with(name: "SUSE-Manager-Proxy", kind: :product)
           .and_return(suma_products.select { |p| p.name == "SUSE-Manager-Proxy" })
-        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SLES", kind: :product)
+        allow(Y2Packager::Resolvable).to receive(:find)
+          .with(name: "SLES", kind: :product)
           .and_return(suma_products.select { |p| p.name == "SLES" })
         expect(described_class.obsolete_upgrades).to eq([])
       end

--- a/test/lib/product_upgrade_test.rb
+++ b/test/lib/product_upgrade_test.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+
+require "yaml"
+require "y2packager/product_upgrade"
+require "y2packager/product"
+
+describe Y2Packager::ProductUpgrade do
+  let(:product1) { Y2Packager::Product.new(name: "testing_product1") }
+  let(:product2) { Y2Packager::Product.new(name: "testing_product2") }
+  let(:product3) { Y2Packager::Product.new(name: "testing_product3") }
+  let(:sles) { Y2Packager::Product.new(name: "SLES") }
+  let(:sles_hpc) { Y2Packager::Product.new(name: "SLE_HPC") }
+  let(:hpc_module) { Y2Packager::Product.new(name: "sle-module-hpc") }
+  let(:sles11) { Y2Packager::Product.new(name: "SUSE_SLES") }
+  let(:suma_proxy) { Y2Packager::Product.new(name: "SUSE-Manager-Proxy") }
+  let(:suma_branch_server) { Y2Packager::Product.new(name: "SUSE-Manager-Retail-Branch-Server") }
+
+  describe ".new_base_product" do
+    context "no base product is available" do
+      before do
+        expect(Y2Packager::Product).to receive(:available_base_products).and_return([])
+      end
+
+      it "returns nil" do
+        expect(described_class.new_base_product).to be_nil
+      end
+    end
+
+    context "only one base product is available" do
+      before do
+        expect(Y2Packager::Product).to receive(:available_base_products).and_return([product1])
+        allow(Y2Packager::Resolvable).to receive(:find).and_return([])
+      end
+
+      it "returns that product" do
+        expect(described_class.new_base_product).to be(product1)
+      end
+    end
+
+    context "several base products are available" do
+      before do
+        expect(Y2Packager::Product).to receive(:available_base_products)
+          .and_return([product1, product2, sles, sles_hpc]).at_least(:once)
+      end
+
+      context "the new base product is found in the fallback mapping" do
+        it "returns SLES for SLES11" do
+          expect(Y2Packager::Product).to receive(:installed_products).and_return([sles11])
+          expect(described_class.new_base_product).to be(sles)
+        end
+
+        it "returns SLE_HPC for SLES and HPC module installed" do
+          expect(Y2Packager::Product).to receive(:installed_products)
+            .and_return([sles, hpc_module])
+          expect(described_class.new_base_product).to be(sles_hpc)
+        end
+      end
+
+      context "the base product if found by name" do
+        it "returns SLES for installed SLES" do
+          expect(Y2Packager::Product).to receive(:installed_base_product)
+            .and_return(sles)
+          expect(described_class.new_base_product).to be(sles)
+        end
+      end
+
+      it "returns nil if no upgrade product is found" do
+        expect(Y2Packager::Product).to receive(:installed_base_product)
+          .and_return(product3)
+        expect(described_class.new_base_product).to be_nil
+      end
+    end
+
+    context "SUSE Manager Retail Branch Server upgrade" do
+      # there are "SLES + SUMA Proxy" and "SLES + SUMA Proxy + SUMA Branch Server"
+      # mappings, make sure the longer one is preferred
+      it "returns more matching installed products" do
+        expect(Y2Packager::Product).to receive(:installed_products)
+          .and_return([sles, suma_proxy, suma_branch_server])
+        expect(Y2Packager::Product).to receive(:available_base_products)
+          .and_return([sles, sles_hpc, suma_proxy, suma_branch_server])
+
+        expect(described_class.new_base_product).to be(suma_branch_server)
+      end
+    end
+  end
+
+  describe ".will_be_obsoleted_by" do
+    before do
+      expect(Y2Packager::Product).to receive(:with_status).with(:selected)
+        .and_return([Y2Packager::Product.new(name: "SLE_HPC")])
+    end
+
+    context "given product is not installed" do
+      it "returns an empty array" do
+        expect(Y2Packager::Product).to receive(:installed_products)
+          .and_return([sles, hpc_module])
+        expect(described_class.will_be_obsoleted_by("not_there")).to be_empty
+      end
+    end
+
+    context "given product is installed but not required module" do
+      it "returns an empty array" do
+        expect(Y2Packager::Product).to receive(:installed_products)
+          .and_return([sles, sles_hpc])
+        expect(described_class.will_be_obsoleted_by("SLES")).to be_empty
+      end
+    end
+
+    context "given product and the required module is installed" do
+      it "returns the product which obsoletes the old one" do
+        expect(Y2Packager::Product).to receive(:installed_products)
+          .and_return([sles, hpc_module])
+        expect(described_class.will_be_obsoleted_by("SLES")).to contain_exactly("SLE_HPC")
+      end
+    end
+  end
+
+  describe ".obsolete_upgrades" do
+    before do
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+        .and_return(suma_products)
+    end
+
+    # upgrade from SLE12-SP3 + SUMA Proxy 3.2 + SUMA Branch Server 3.2
+    # to SLE15-SP1 (actually to SUMA Branch Server 4.0)
+    context "SUSE Manager Branch Retail Server 3.2 upgrade" do
+      let(:suma_hash) { YAML.load_file(File.join(__dir__, "../data/zypp/products_update_suma_branch_server.yml")) }
+
+      let(:suma_products) do
+        suma_hash.map { |p| Y2Packager::Resolvable.new(p) }
+      end
+
+      before do
+        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SLES", kind: :product)
+          .and_return(suma_products.select { |p| p.name == "SLES" })
+        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SUSE-Manager-Proxy", kind: :product)
+          .and_return(suma_products.select { |p| p.name == "SUSE-Manager-Proxy" })
+      end
+
+      it "returns obsoleted SLES + SUMA Proxy product" do
+        allow(Y2Packager::Resolvable).to receive(:any?).with(name: "SUSE-Manager-Proxy",
+          kind: :product, status: :removed, transact_by: :solver).and_return(true)
+        allow(Y2Packager::Resolvable).to receive(:any?).with(name: "SLES",
+          kind: :product, status: :removed, transact_by: :solver).and_return(true)
+
+        expect(described_class.obsolete_upgrades).to contain_exactly("SLES", "SUSE-Manager-Proxy")
+      end
+
+      it "returns empty list if the old product is removed by user" do
+        allow(Y2Packager::Resolvable).to receive(:any?).with(name: "SUSE-Manager-Proxy",
+          kind: :product, status: :removed, transact_by: :solver).and_return(false)
+        allow(Y2Packager::Resolvable).to receive(:any?).with(name: "SLES",
+          kind: :product, status: :removed, transact_by: :solver).and_return(false)
+
+        expect(described_class.obsolete_upgrades).to eq([])
+      end
+    end
+
+    context "SUSE Manager Proxy 3.2 upgrade" do
+      let(:suma_products) do
+        suma_hash = YAML.load_file(File.join(__dir__, "../data/zypp/products_update_suma_proxy.yml"))
+        suma_hash.map { |p| Y2Packager::Resolvable.new(p) }
+      end
+
+      it "returns empty list" do
+        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SUSE-Manager-Proxy", kind: :product)
+          .and_return(suma_products.select { |p| p.name == "SUSE-Manager-Proxy" })
+        allow(Y2Packager::Resolvable).to receive(:find).with(name: "SLES", kind: :product)
+          .and_return(suma_products.select { |p| p.name == "SLES" })
+        expect(described_class.obsolete_upgrades).to eq([])
+      end
+    end
+  end
+
+  describe ".remove_obsolete_upgrades" do
+    it "marks the obsolete products for removal" do
+      obsolete = ["SLES", "SUSE-Manager-Proxy"]
+
+      expect(described_class).to receive(:obsolete_upgrades).and_return(obsolete)
+      obsolete.each { |o| expect(Yast::Pkg).to receive(:ResolvableRemove).with(o, :product) }
+
+      described_class.remove_obsolete_upgrades
+    end
+  end
+end


### PR DESCRIPTION
* Move `ProductUpgrade` class from `yast2.rpm` package.
* Use `ProductSpec` to find out the list of available base products.
* See https://github.com/yast/yast-yast2/pull/1200.