### PR TITLE
Adjusted low memory message (bsc#1139325)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov  4 08:34:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Adjusted low memory message (bsc#1139325)
+- 4.4.11
+
+-------------------------------------------------------------------
 Wed Sep 15 12:35:42 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Check if the "pkg" UI plug-in is available and if not, ask

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/clients/inst_productsources.rb
+++ b/src/lib/y2packager/clients/inst_productsources.rb
@@ -1726,7 +1726,8 @@ module Yast
                "repositories might contain updated software packages.")
 
       if low_memory?
-        msg << _("However, since the system has less than %d MiB memory,\n" \
+        # TRANSLATORS: the %d is replaced by minimal memory required
+        msg << _("However, since the system does not have more than %d MiB memory,\n" \
                  "there is a significant risk of running out of memory,\n" \
                  "and the installer may crash or freeze.\n" \
                  "\n" \


### PR DESCRIPTION
- In #576 the memory check was adjusted so that the computer memory must be greater than the limit set, in the past it was enough if the size was the same as the limit.
- Adjust the message so it needs more memory than the limit as well.
- 4.4.11