### PR TITLE
Fixed missing license translations (bsc#1186747)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov  4 15:18:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed missing license translations after going back in the
+  installation workflow (bsc#1186747)
+- 4.4.12
+
+-------------------------------------------------------------------
 Thu Nov  4 08:34:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Adjusted low memory message (bsc#1139325)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1664,7 +1664,11 @@ module Yast
 
       while initial_repository.nil?
         initial_repository = Pkg.SourceCreateBase(base_url, product_dir)
-        next unless initial_repository == -1 || initial_repository.nil?
+        if initial_repository && initial_repository >= 0
+          # make the repository known to libzypp so it does not delete it's cache later
+          Pkg.SourceSaveAll
+          next
+        end
 
         Builtins.y2error("No repository in '%1'", log_url)
         base_url = UpdateSourceURL(base_url)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1186747
- Fixed missing license translations after going back in the installation workflow
- The initial repository was not saved to the inst-sys so libzypp later removed it's cache
- Without the cache the licenses were not available

#### Original Behavior
![licenses_broken](https://user-images.githubusercontent.com/907998/140351168-abb2b8e5-52f4-4c68-9220-f4c94edc8d25.gif)

#### Fixed Behavior
![licenses_fixed](https://user-images.githubusercontent.com/907998/140351376-4aa69d0d-1632-4b5e-96aa-0b41f04f94ca.gif)


### Testing

Tested manually using the `yupdate` script, see the screencast above.
