### PR TITLE
Repository names

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 19 14:09:32 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use consistent names for the Full medium repositories
+  (bsc#1191652)
+- 4.3.25
+
+-------------------------------------------------------------------
 Thu Jun 17 15:47:33 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - When editing a repository display the repository alias as a

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.24
+Version:        4.3.25
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -26,6 +26,7 @@ module Yast
       Yast.import "SourceDialogs"
       Yast.import "Report"
       Yast.import "Progress"
+      Yast.import "Packages"
 
       textdomain "packager"
 
@@ -364,7 +365,7 @@ module Yast
         url_path = URL.Parse(original_url)["path"]
         p_elems = url_path.split("/")
 
-        fallback = _("Repository")
+        fallback = Packages.fallback_name
 
         if p_elems.size > 1
           url_path = Ops.get(


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1191652
- The repositories added from the Full medium during installation have different names than the same repositories added in installed system.

![repo_names_broken_sp3](https://user-images.githubusercontent.com/907998/142636810-0eafb9ca-53e1-402b-ad10-8465b7ac0041.png)

```
# zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                             | Name                           | Enabled | GPG Check | Refresh
--+-----------------------------------+--------------------------------+---------+-----------+--------
1 | Basesystem-Module_15.3-0          | sle-module-basesystem          | No      | ----      | ----
2 | SLES15-SP3-15.3-0                 | SLES15-SP3-15.3-0              | No      | ----      | ----
3 | Server-Applications-Module_15.3-0 | sle-module-server-applications | No      | ----      | ----
```

As you can see, the internal alias is a better name than the name itself.

## Fix

- During installation the names are changed to the product name in the repository
- The reason is that normal repositories are added with name "Repository" and then after refreshing the repository the name is changed. However with Full medium the repositories already have a good name from the beginning, it is read from the `/media.1/products` index file.
- So the repository rename should be skipped if it is not the default name

![repo_names_fixed_sp3](https://user-images.githubusercontent.com/907998/142636856-a2b31a4b-477f-483a-a491-977d8e37dae5.png)

```
# zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                             | Name                              | Enabled | GPG Check | Refresh
--+-----------------------------------+-----------------------------------+---------+-----------+--------
1 | Basesystem-Module_15.3-0          | Basesystem-Module 15.3-0          | No      | ----      | ----
2 | SLES15-SP3-15.3-0                 | SLES15-SP3-15.3-0                 | No      | ----      | ----
3 | Server-Applications-Module_15.3-0 | Server-Applications-Module 15.3-0 | No      | ----      | ----
```
With the fix the repository names look much better.

## Tests

- Tested manually during installation
- Tested also in an installed system
- Added unit test