### PR TITLE
Properly set the custom repository name (#1191491)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  2 12:58:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly set the custom repository name (#1191491)
+- 4.4.16
+
+-------------------------------------------------------------------
 Wed Dec  1 12:52:52 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add the register_target property to ProductSpec so it is

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.15
+Version:        4.4.16
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/repositories_include_test.rb
+++ b/test/repositories_include_test.rb
@@ -207,4 +207,54 @@ describe "PackagerRepositoriesIncludeInclude" do
       end
     end
   end
+
+  # the "propose_name" method is private so use send() in the tests
+  describe ".propose_name" do
+    context "user provided a repository name" do
+      it "returns the name provided by user" do
+        preferred_name = "my repository"
+        url = "http://example.com"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        expect(ret).to eq(preferred_name)
+      end
+    end
+
+    context "no user provided repository name" do
+      it "returns a name created from the last URL path element" do
+        preferred_name = ""
+        url = "http://example.com/Leap-15.3"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        expect(ret).to eq("Leap-15.3")
+      end
+
+      it "returns a name created from the last non-empty URL path element" do
+        preferred_name = ""
+        url = "http://example.com/Leap-15.3/"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        expect(ret).to eq("Leap-15.3")
+      end
+
+      it "returns an unescaped URL path" do
+        preferred_name = ""
+        url = "http://example.com/Leap%2015.3/"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        # %20 (0x20) => " "
+        expect(ret).to eq("Leap 15.3")
+      end
+
+      it "returns the fallback name if the path is root" do
+        preferred_name = ""
+        url = "http://example.com/"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        expect(ret).to eq(Yast::Packages.fallback_name)
+      end
+
+      it "returns the fallback name if the path is empty" do
+        preferred_name = ""
+        url = "http://example.com"
+        ret = RepositoryIncludeTester.send(:propose_name, preferred_name, url)
+        expect(ret).to eq(Yast::Packages.fallback_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1191491
- Use the user provided name for a new repository
- Just pass the `preferred_name` to the method which creates the product definition
- Simplified URL path parsing, unescape the path (e.g. convert `%20` to spaces)
- Added unit test