### PR TITLE
bsc#1193212: move #register_target to the base ProductSpec class

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,10 +1,17 @@
 -------------------------------------------------------------------
+Wed Dec  1 12:52:52 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the register_target property to ProductSpec so it is
+  available in all the derived classes (bsc#1193212).
+- 4.4.15
+
+-------------------------------------------------------------------
 Mon Nov 22 08:22:46 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Use consistent names for the Full medium repositories
   (bsc#1191652)
 - 4.4.14
-  
+
 -------------------------------------------------------------------
 Fri Nov 12 13:02:17 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -36,8 +36,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:nokogiri)
 BuildRequires:  yast2-storage-ng >= 4.0.141
 # break the yast2-packager -> yast2-storage-ng -> yast2-packager build cycle
 #!BuildIgnore: yast2-packager
-# ProductSpec API
-BuildRequires:  yast2 >= 4.4.21
+# Product#register_target
+BuildRequires:  yast2 >= 4.4.25
 # raw_name
 BuildRequires:  yast2-pkg-bindings >= 4.2.8
 # Augeas lenses
@@ -48,8 +48,8 @@ BuildRequires:  ruby-solv
 Requires:       yast2-country-data >= 2.16.3
 # raw_name
 Requires:       yast2-pkg-bindings >= 4.2.8
-# ProductSpec API
-Requires:       yast2 >= 4.4.21
+# Product#register_target
+Requires:       yast2 >= 4.4.25
 # unzipping license file
 Requires:       unzip
 # HTTP, FTP, HTTPS modules (inst_productsources.ycp)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.14
+Version:        4.4.15
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/control_product_spec.rb
+++ b/src/lib/y2packager/control_product_spec.rb
@@ -28,8 +28,6 @@ module Y2Packager
   class ControlProductSpec < ProductSpec
     # @return [String] License URL
     attr_reader :license_url
-    # @return [String] Registration target name used for registering the product
-    attr_reader :register_target
 
     # @param register_target [String] The registration target name used
     #   for registering the product, the $arch variable is replaced
@@ -37,10 +35,8 @@ module Y2Packager
     # @param license_url [String] License URL
     def initialize(name:, version:, arch:, display_name:, order:, license_url:, register_target:)
       super(name: name, version: version, display_name: display_name, arch: arch,
-            order: order, base: true)
+            order: order, base: true, register_target: register_target)
 
-      # expand the "$arch" placeholder
-      @register_target = register_target&.gsub("$arch", arch) || ""
       @license_url = license_url
     end
   end

--- a/src/lib/y2packager/product_spec.rb
+++ b/src/lib/y2packager/product_spec.rb
@@ -50,6 +50,9 @@ module Y2Packager
     # @return [Boolean] Determine whether it is a base product
     attr_reader :base
 
+    # @return [String] Registration target name used for registering the product
+    attr_reader :register_target
+
     class << self
       # Returns the specs for the base products
       #
@@ -106,7 +109,7 @@ module Y2Packager
     # @param version [String] version ("15.2")
     # @param arch [String] The architecture ("x86_64")
     # @param display_name [String] The user visible name ("SUSE Linux Enterprise Server 15 SP2")
-    def initialize(name:, version:, arch:, display_name:, order: 1, base: true)
+    def initialize(name:, version:, arch:, display_name:, order: 1, base: true, register_target: "")
       @name = name
       @version = version
       @arch = arch
@@ -114,6 +117,10 @@ module Y2Packager
       @order = order
       @base = base
       @selected = false
+
+      @register_target = register_target || ""
+      # expand the "$arch" placeholder
+      @register_target = @register_target.gsub("$arch", arch.to_s) if arch
     end
 
     def selected?

--- a/src/lib/y2packager/product_spec.rb
+++ b/src/lib/y2packager/product_spec.rb
@@ -118,7 +118,7 @@ module Y2Packager
       @base = base
       @selected = false
 
-      @register_target = register_target || ""
+      @register_target = register_target
       # expand the "$arch" placeholder
       @register_target = @register_target.gsub("$arch", arch.to_s) if arch
     end

--- a/test/lib/product_upgrade_test.rb
+++ b/test/lib/product_upgrade_test.rb
@@ -126,7 +126,7 @@ describe Y2Packager::ProductUpgrade do
 
   describe ".obsolete_upgrades" do
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return(suma_products)
     end
 


### PR DESCRIPTION
* Move the `register_target` to the base class `ProductSpec`.
* Reads the `register_target` for `RepoProductSpect` in addition to `ControlProductSpec`.

Related:

* https://github.com/yast/yast-update/pull/175
* https://github.com/yast/yast-yast2/pull/1207 (tests depend on this one)