### PR TITLE
Unify the Yes/No popup button IDs (bsc#1193326)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  2 14:39:19 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unify the Yes/No popup button IDs (bsc#1193326)
+- 4.4.17
+
+-------------------------------------------------------------------
 Thu Dec  2 12:58:16 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly set the custom repository name (#1191491)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -194,7 +194,7 @@ module Yast
     def YesNoButtonBox
       yes_button = PushButton(Id(:yes), Opt(:key_F10), Label.YesButton)
       no_button = PushButton(
-        Id(:no_button),
+        Id(:no),
         Opt(:default, :key_F9),
         Label.NoButton
       )


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1193326
- Let's use the same button IDs in all Yes/No popups to make testing via libyui REST API easier