### PR TITLE
Enable RSpec verifying doubles

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 18 15:46:09 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Enabled RSpec verifying doubles (bsc#1194784)
+- 4.4.20
+
+-------------------------------------------------------------------
 Wed Jan 12 11:52:12 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Simplify slide show to support future parallel installations

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -40,6 +40,8 @@ BuildRequires:  yast2-storage-ng >= 4.0.141
 BuildRequires:  yast2 >= 4.4.25
 # raw_name
 BuildRequires:  yast2-pkg-bindings >= 4.2.8
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 # Augeas lenses
 BuildRequires:  augeas-lenses
 BuildRequires:  ruby-solv

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.19
+Version:        4.4.20
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -322,7 +322,6 @@ module Yast
     publish variable: :total_size_to_install, type: "integer" # Used in installation client
     publish function: :GetPackageSummary, type: "map <string, any> ()"
     publish function: :InitPkgData, type: "void (boolean)"
-    publish function: :SetCurrentCdNo, type: "void (integer, integer)"
     publish function: :UpdateCurrentPackageProgress, type: "void (integer)"
     publish function: :UpdateCurrentPackageRateProgress, type: "void (integer, integer, integer)"
     publish function: :DisplayGlobalProgress, type: "void ()"

--- a/test/addon_product_test.rb
+++ b/test/addon_product_test.rb
@@ -697,7 +697,6 @@ describe Yast::AddOnProduct do
 
     before do
       allow(subject).to receive(:GetCachedFileFromSource)
-      allow(subject).to receive(:IntegrateReleaseNotes)
       allow(Yast::WorkflowManager).to receive(:GetCachedWorkflowFilename)
       allow(Yast::WorkflowManager).to receive(:AddWorkflow)
     end

--- a/test/addon_selector_test.rb
+++ b/test/addon_selector_test.rb
@@ -63,7 +63,8 @@ describe Y2Packager::Dialogs::AddonSelector do
       end
 
       it "does not display any popup" do
-        expect(Yast::Popup).to_not receive(:anything)
+        # stub empty Yast::Popup so any method call would raise an exception
+        stub_const("Yast::Popup", double)
         subject.next_handler
       end
     end

--- a/test/package_installation_test.rb
+++ b/test/package_installation_test.rb
@@ -12,7 +12,6 @@ describe Yast::PackageInstallation do
     let(:result) { [1, [], [], [], []] }
 
     before do
-      allow(Yast::PackageSlideShow).to receive(:SetCurrentCdNo)
       allow(Yast::Pkg).to receive(:Commit).with(config)
         .and_return(result)
       allow(Yast::PackagesUI).to receive(:show_update_messages)

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -41,12 +41,7 @@ describe Yast::Packages do
   end
 
   describe "#kernelCmdLinePackages" do
-    before(:each) do
-      # default value
-      allow(Yast::Product).to receive(:Product).and_return nil
-    end
-
-    context "when biosdevname behavior explicitly defined on the Kenel command line" do
+    context "when biosdevname behavior explicitly defined on the Kernel command line" do
       context "when biosdevname=1" do
         around do |example|
           root = File.join(DATA_PATH, "cmdline-biosdevname_1")

--- a/test/product_license_test.rb
+++ b/test/product_license_test.rb
@@ -154,7 +154,7 @@ describe Yast::ProductLicense do
           expect(Yast::ProductLicense).to receive(:AllLicensesAccepted).and_return(false)
             .at_least(:once)
           # :halt case
-          allow(Yast::ProductLicense).to receive(:TimedOKCancel).and_return(true)
+          allow(Yast::Popup).to receive(:TimedOKCancel).and_return(true)
         end
 
         context "when cancel action is 'continue'" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,15 +73,8 @@ Yast::RSpec::Helpers.define_yast_module("Proxy")
 
 Yast::RSpec::Helpers.define_yast_module("InstFunctions", methods: [:second_stage_required?])
 
-Yast::RSpec::Helpers.define_yast_module("Language", methods: [:language]) do
-  # @param _lang [String]
-  # @return [Boolean]
-  def supported_language?(_lang); end
-
-  # @param _force [Boolean]
-  # @return [Hash<String,Array>]
-  def GetLanguagesMap(_force); end
-end
+Yast::RSpec::Helpers.define_yast_module("Language",
+  methods: [:language, :supported_language?, :GetLanguagesMap])
 
 # mock empty class to avoid build dependency on yast2-installation
 module Installation

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,36 +71,16 @@ Yast::RSpec::Helpers.define_yast_module("NtpClient")
 # define missing modules with an API, these are used in the tests and need to
 # implement the *same* API as the real modules
 
-Yast::RSpec::Helpers.define_yast_module("InstFunctions") do
-  # see modules/InstFunctions.rb in yast2-installation
-  module Yast
-    class InstFunctionsClass < Module
-      # @return [Boolean]
-      def second_stage_required?; end
-    end
+Yast::RSpec::Helpers.define_yast_module("InstFunctions", methods: [:second_stage_required?])
 
-    InstFunctions = InstFunctionsClass.new
-  end
-end
+Yast::RSpec::Helpers.define_yast_module("Language", methods: [:language]) do
+  # @param _lang [String]
+  # @return [Boolean]
+  def supported_language?(_lang); end
 
-Yast::RSpec::Helpers.define_yast_module("Language") do
-  # see modules/Language.rb in yast2-country
-  module Yast
-    class LanguageClass < Module
-      # @return [String]
-      def language; end
-
-      # @param _lang [String]
-      # @return [Boolean]
-      def supported_language?(_lang); end
-
-      # @param _force [Boolean]
-      # @return [Hash<String,Array>]
-      def GetLanguagesMap(_force); end
-    end
-
-    Language = LanguageClass.new
-  end
+  # @param _force [Boolean]
+  # @return [Hash<String,Array>]
+  def GetLanguagesMap(_force); end
 end
 
 # mock empty class to avoid build dependency on yast2-installation

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,10 +63,10 @@ end
 # stub missing YaST modules from different yast packages to avoid build dependencies
 
 # these are not used in the tests so we can just use an empty implementation
-Yast::RSpec::Helpers.define_yast_module("Proxy")
 Yast::RSpec::Helpers.define_yast_module("FTP")
 Yast::RSpec::Helpers.define_yast_module("HTTP")
 Yast::RSpec::Helpers.define_yast_module("NtpClient")
+Yast::RSpec::Helpers.define_yast_module("Proxy")
 
 # define missing modules with an API, these are used in the tests and need to
 # implement the *same* API as the real modules


### PR DESCRIPTION
- It found some problems in the tests which have been fixed
- Tested both locally (using the real YaST modules) and in `rake osc:build` using the new mocks
- All works fine