### PR TITLE
bsc#1195519: fix wrong reference to EnsureSourceInit

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  8 09:50:41 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix a wrong reference to PackageSystem#EnsureSourceInit
+  (bsc#1195519, related to bsc#1194886).
+- 4.4.22
+
+-------------------------------------------------------------------
 Tue Jan 25 13:48:20 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use Package module instead of PackageSystem (bsc#1194886).

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.21
+Version:        4.4.22
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -36,6 +36,7 @@ module Yast
       Yast.import "Popup"
       Yast.import "GetInstArgs"
       Yast.import "Package"
+      Yast.import "PackageSystem"
       Yast.import "Report"
       Yast.import "FileUtils"
       Yast.import "PackagesUI"
@@ -150,7 +151,7 @@ module Yast
       # If the first argument is a package ending with .rpm call Pkg::TargetInstall for
       # each arg.
       if Builtins.regexpmatch(first_arg, "\\.rpm$") # package name given
-        Package.EnsureSourceInit
+        PackageSystem.EnsureSourceInit
 
         # if sw_single is called with an absolute package-pathname, there is no need to
         # mount the source medium or check SuSE version or dependencies


### PR DESCRIPTION
Fix for [bsc#1195519](https://bugzilla.suse.com/show_bug.cgi?id=1195519). Wrongly replaced `PackageSystem.EnsureSourceInit` with `Package.EnsureSourceInit`. The `Ensure*` methods were not moved.