### PR TITLE
Remove duplicate repositories (bsc#1194546)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 14 09:40:00 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Remove duplicate repositories created at the end of installation
+  (repositories which are stored in the *.repo_1 files, bsc#1194546)
+- 4.4.23
+
+-------------------------------------------------------------------
 Tue Feb  8 09:50:41 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix a wrong reference to PackageSystem#EnsureSourceInit

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.22
+Version:        4.4.23
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1194546
- The `openSUSE-release` package in Leap 15.4 contains some extra repositories, the same as defined in the `control.xml`.
- When YaST saves the extra repositories libzypp detects that the files already exist and creates `*.repo_1` files
- Unfortunately we cannot detect the duplicates *before* saving the repositories as they were added by RPM outside of YaST/libzypp. So first we need to save the repositories and then detect to which file they were saved to.

### Testing

- Tested manually
- Added unit test