### PR TITLE
Properly set the repository alias for the Full medium add-ons (bsc#1193214)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  8 13:37:35 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly set the repository alias for the Full medium add-ons
+  (bsc#1193214)
+- 4.4.24
+
+-------------------------------------------------------------------
 Mon Feb 14 09:40:00 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Remove duplicate repositories created at the end of installation

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.23
+Version:        4.4.24
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -146,7 +146,15 @@ module Yast
           next
         end
 
-        alias_name = (force_alias == "") ? propose_alias(product.name) : force_alias
+        alias_name = if force_alias != ""
+          force_alias
+        elsif product.media_name && !product.media_name.empty?
+          propose_alias(product.media_name)
+        elsif product.name && !product.name.empty?
+          propose_alias(product.name)
+        end
+
+        alias_name = propose_alias(Packages.fallback_name) if alias_name.empty?
 
         # map with repository parameters: $[ "enabled" : boolean,
         # "autorefresh" : boolean, "raw_name" : string, "alias" : string,


### PR DESCRIPTION
- Properly set the repository alias for the Full medium add-ons 
- https://bugzilla.suse.com/show_bug.cgi?id=1193214
- The used alias was different than in the previous SLE releases, it should be the product name from the `media.1/products` file
- The previous correct behavior: https://openqa.suse.de/tests/7725696#step/validate_repos/3
- The bug: https://openqa.suse.de/tests/8124709#step/validate_repos/10

## Testing

- Tested manually
- The `y2log` without the fix:
  ```
  Source_Create.cc(RepositoryAdd):504 Adding repository:
  Source_Create.cc(RepositoryAdd):505 --------------------------------------
  Source_Create.cc(RepositoryAdd):505 - alias       : sle-module-basesystem
  Source_Create.cc(RepositoryAdd):505 - name        : sle-module-basesystem
  ```
- The `y2log` with the fix:
  ```
  Source_Create.cc(RepositoryAdd):504 Adding repository:
  Source_Create.cc(RepositoryAdd):505 --------------------------------------
  Source_Create.cc(RepositoryAdd):505 - alias       : Basesystem-Module_15.4-0
  Source_Create.cc(RepositoryAdd):505 - name        : sle-module-basesystem
  ```
- Also `zypper` reports the correct names in the installed system.
- Tested also adding repositories in an installed system