### PR TITLE
do not keep file handle to repo metadata open accidentally (bsc#1196061)

### DIFF
--- a/src/lib/y2packager/solvable_pool.rb
+++ b/src/lib/y2packager/solvable_pool.rb
@@ -34,6 +34,9 @@ module Y2Packager
       File.open(primary_xml) do |gz|
         fd = Solv.xfopen_fd(primary_xml, gz.fileno)
         repo.add_rpmmd(fd, nil, 0)
+        # Explicitly close the file, do not rely on garbage collection to do
+        # it in a timely manner (bsc#1196061).
+        fd.close
       end
       pool.createwhatprovides
     end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1196061

An open file handle to repo meta data (`*-primary.xml.gz`) is accidentally kept open preventing the detaching of installation media.

## Solution

Close file explicitly when no longer needed.