### PR TITLE
do not keep file handle to repo metadata open accidentally (bsc#1196061)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 15 12:50:30 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not keep file handle to repo metadata open accidentally (bsc#1196061)
+- 4.3.26
+
+-------------------------------------------------------------------
 Fri Nov 19 14:09:32 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Use consistent names for the Full medium repositories

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.25
+Version:        4.3.26
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/solvable_pool.rb
+++ b/src/lib/y2packager/solvable_pool.rb
@@ -34,6 +34,9 @@ module Y2Packager
       File.open(primary_xml) do |gz|
         fd = Solv.xfopen_fd(primary_xml, gz.fileno)
         repo.add_rpmmd(fd, nil, 0)
+        # Explicitly close the file, do not rely on garbage collection to do
+        # it in a timely manner (bsc#1196061).
+        fd.close
       end
       pool.createwhatprovides
     end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1196061

A file handle to repo meta data (`*-primary.xml.gz`) is accidentally kept open preventing the detaching of installation media.

## Solution

Close file explicitly when no longer needed.