### PR TITLE
Read the products from libzypp in installed system

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 17 08:01:35 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Read the products from libzypp in installed system, fixes crash
+  during online migration (related to jsc#SLE-17309)
+- 4.4.26
+
+-------------------------------------------------------------------
 Tue Mar 15 17:20:53 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
 
 - do not keep file handle to repo metadata open accidentally (bsc#1196061)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.25
+Version:        4.4.26
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_spec_reader.rb
+++ b/src/lib/y2packager/product_spec_reader.rb
@@ -26,12 +26,16 @@ module Y2Packager
   # Reads product specification from different sources
   class ProductSpecReader
     include Yast::Logger
+    Yast.import "Mode"
 
     # Returns the list of product specifications.
     #
     # @return [Y2Packager::ProductSpec] List of product specifications
     def products
       # products_from_control || products_from_offline || products_from_libzypp
+
+      # online migration (in installed system)
+      return products_from_libzypp if Yast::Mode.normal
 
       if InstallationMedium.contain_multi_repos?
         products_from_multi_repos

--- a/test/lib/product_spec_reader_test.rb
+++ b/test/lib/product_spec_reader_test.rb
@@ -46,6 +46,7 @@ describe Y2Packager::ProductSpecReader do
       allow(Y2Packager::ProductSpecReaders::Libzypp).to receive(:new).and_return(libzypp_reader)
       allow(Y2Packager::InstallationMedium).to receive(:contain_repo?).and_return(false)
       allow(Y2Packager::InstallationMedium).to receive(:contain_multi_repos?).and_return(false)
+      allow(Yast::Mode).to receive(:normal).and_return(false)
     end
 
     context "when medium does not contain any repository" do
@@ -68,6 +69,16 @@ describe Y2Packager::ProductSpecReader do
     context "when medium contain single repository" do
       before do
         allow(Y2Packager::InstallationMedium).to receive(:contain_repo?).and_return(true)
+      end
+
+      it "returns the libzypp products" do
+        expect(reader.products).to eq(libzypp_products)
+      end
+    end
+
+    context "in installed system" do
+      before do
+        allow(Yast::Mode).to receive(:normal).and_return(true)
       end
 
       it "returns the libzypp products" do


### PR DESCRIPTION
![product_error](https://user-images.githubusercontent.com/907998/158771812-c48496c4-cfe8-4943-a4e2-8b57e82646e7.png)

- Read the products from libzypp in installed system
- Fixes crash during online migration
- Related to [jsc#SLE-17309](https://jira.suse.com/browse/SLE-17309)
- Tested manually, updated unit tests
