### PR TITLE
Show Download Progress

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  6 14:00:54 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Show package downloads in the global progress bar during package
+  installation (bsc#1195608)
+- 4.4.28
+
+-------------------------------------------------------------------
 Thu Mar 31 15:52:11 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed regression in repository alias name for add-ons (bsc#1193214)

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -3,6 +3,7 @@ Wed Apr  6 14:00:54 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Show package downloads in the global progress bar during package
   installation (bsc#1195608)
+  PR: https://github.com/yast/yast-packager/pull/609
 - 4.4.28
 
 -------------------------------------------------------------------

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.27
+Version:        4.4.28
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -223,7 +223,7 @@ module Yast
     # @deprecated Misleading method name. For API backwards compatibility.
     #
     def DisplayGlobalProgress
-      log.warning "DEPRECATED. Use UpdateTotalProgressText() instead."
+      log.warn "DEPRECATED. Use UpdateTotalProgressText() instead."
       UpdateTotalProgressText()
     end
 

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -415,7 +415,7 @@ module Yast
     publish function: :DownloadProgress, type: "void (integer)"
     publish function: :DownloadEnd, type: "void (string)"
     publish function: :DownloadError, type: "void (integer, string, string)"
-    publish function: :PkgInstallStart, type: "void (string, integer, string, boolean)"
+    publish function: :PkgInstallStart, type: "void (string, string, string, integer, boolean)"
     publish function: :PkgInstallProgress, type: "void (integer)"
     publish function: :PkgInstallDone, type: "void (string, integer, boolean)"
     #

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -24,6 +24,7 @@ module Yast
     def init_member_vars
       @init_pkg_data_complete = false
 
+      @total_pkgs_to_install = 0
       @total_size_to_install = 0 # directly accessed in one click installer :-(
       @total_installed_size = 0
       @expected_total_download_size = 0

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -146,9 +146,9 @@ module Yast
     # Update the overall progress value of the progress bar.
     #
     # If libzypp is downloading and installing in parallel, keep this simple
-    # and only use the installed package size for both the total and the
-    # current progress, disregarding the download size since the downloads are
-    # not causing additional delays.
+    # and only use the installed package size for the total vs. the current
+    # progress, disregarding the download size since the downloads are not
+    # causing additional delays.
     #
     # Otherwise, take the download into account so the progress bar doesn't
     # appear to be stuck at zero while libzypp downloads a whole lot of
@@ -156,7 +156,7 @@ module Yast
     # them.
     #
     # In that case, use the download size plus the installed (unpacked) package
-    # size for both the total and the current progress.
+    # size for the total vs. the current progress.
     #
     # Caveat 1: Of course the time to download a package cannot really be
     # compared to the time it takes to install it after it is downloaded; it

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -241,7 +241,7 @@ module Yast
           # TRANSLATORS: This is about a remaining download size.
           # %1 is the remaining size with a unit (kiB, MiB, GiB etc.),
           # %2 the total download size, also with a unit.
-          _(" (Remaining: %1 of %2)" ),
+          _(" (Remaining: %1 of %2)"),
           String.FormatSize(@expected_total_download_size - CurrentDownloadSize()),
           String.FormatSize(@expected_total_download_size)
         )
@@ -394,7 +394,9 @@ module Yast
       nil
     end
 
-    publish variable: :total_size_to_install, type: "integer" # Deprecated; used in one click installer client
+    # rubocop:disable Layout/LineLength
+    #
+    publish variable: :total_size_to_install, type: "integer" # Deprecated; used in one click installer
     publish function: :TotalSizeToInstall, type: "integer ()" # Better substitute for the above
     publish function: :GetPackageSummary, type: "map <string, any> ()"
     publish function: :InitPkgData, type: "void (boolean)"
@@ -407,6 +409,8 @@ module Yast
     publish function: :PkgInstallStart, type: "void (string, integer, string, boolean)"
     publish function: :PkgInstallProgress, type: "void (integer)"
     publish function: :PkgInstallDone, type: "void (string, integer, boolean)"
+    #
+    # rubocop:enable Layout/LineLength
   end
 
   PackageSlideShow = PackageSlideShowClass.new

--- a/src/modules/PackageSlideShow.rb
+++ b/src/modules/PackageSlideShow.rb
@@ -24,25 +24,30 @@ module Yast
     def init_member_vars
       @init_pkg_data_complete = false
 
+      @total_size_to_install = 0 # directly accessed in one click installer :-(
       @total_installed_size = 0
-      @total_size_to_install = 0 # also used in one click installer
       @expected_total_download_size = 0
       @finished_total_download_size = 0
 
-      @active_downloads = 0
+      @active_downloads = 0 # Number of pkg downloads currently going on
       @detected_parallel_download = false
 
-      # Those @current_pkg_... variables keep track of the most recent current
-      # download. Avoid using them if parallel downloads are in effect.
+      # Those @current_download_pkg_... variables keep track of the most recent
+      # current download. Avoid using them if parallel downloads are in effect.
 
       @current_download_pkg_size = 0 # RPM size, not installed size
       @current_download_pkg_percent = 0
       @current_download_pkg_name = ""
 
+      # Lists of package names that were installed / updated / removed
+      # (after that operation is finished)
+
       @installed_pkg_list = []
       @updated_pkg_list = []
       @removed_pkg_list = []
 
+      # This is a kludge to pass information from one callback that gets the
+      # needed information (the pkg name) to another that doesn't.
       @updating = false
       nil
     end
@@ -165,12 +170,12 @@ module Yast
     #
     # Caveat 1: Of course the time to download a package cannot really be
     # compared to the time it takes to install it after it is downloaded; it
-    # depends on the network (Internet or LAN) speed. It may be faster, or it
-    # may be slower than installing the package.
+    # depends on the network (Internet or LAN) speed. It may be slower, or it
+    # may even be faster than installing the package.
     #
     # This progress reporting is not meant to be an accurate prediction of the
-    # remaining time; that would only be wild guessing whenever network
-    # operations are involved.
+    # remaining time; that would only be wild guessing anyway since network
+    # operations with wildly unpredictable time behavior are involved.
     #
     # Caveat 2: Only real downloads are considered, not getting packages that
     # are directly available from a local repo (installation media or local
@@ -214,7 +219,7 @@ module Yast
       UpdateTotalProgressValue()
     end
 
-    # For API backwards compatibility. DEPRECATED.
+    # @deprecated Misleading method name. For API backwards compatibility.
     #
     def DisplayGlobalProgress
       log.warning "DEPRECATED. Use UpdateTotalProgressText() instead."
@@ -361,8 +366,11 @@ module Yast
     # @param [Integer] _pkg_percent percent of progress of this package
     #
     def PkgInstallProgress(_pkg_percent)
-      # Not doing anything here since we only take the fully installed packages
-      # into account for progress reporting.
+      # For future use and to mirror the callbacks one call level above
+      # (SlideShowCallbacks).
+      #
+      # Right now, not doing anything here since we only take the fully
+      # installed packages into account for progress reporting.
       nil
     end
 

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -69,7 +69,12 @@ module Yast
       nil
     end
 
-    #  at start of file providal
+    # Start of file providal.
+    #
+    # This can be a download (if the package is provided by a remote
+    # repository) or simply accessing a local repo, e.g. on the currently
+    # mounted installation media.
+    #
     def StartProvide(name, archivesize, remote)
       @pkg_inprogress = name
       @remote_provide = remote
@@ -78,7 +83,10 @@ module Yast
       nil
     end
 
-    # during file providal
+    # Update progress during file providal.
+    #
+    # This is meant to update a progress bar for the download percent.
+    #
     def ProgressProvide(percent)
       PackageSlideShow.DownloadProgress(percent) if @remote_provide
       HandleInput()
@@ -86,12 +94,22 @@ module Yast
     end
 
     # Update during package download: Percent, average and current bytes per second.
+    #
+    # Notice that there is also ProgressProvide for only the percentage value;
+    # this callback is meant to update a display of the current data rate and
+    # possibly predictions about the remaining time based on the data rate.
+    #
     def ProgressDownload(_percent, _bps_avg, _bps_current)
       HandleInput()
       !SlideShow.GetUserAbort
     end
 
-    # during file providal
+    # End of file providal; used both for success (error == 0) and error (error
+    # != 0).
+    #
+    # If this was a download from a remote repo, this means that the download
+    # is now finished.
+    #
     def DoneProvide(error, reason, name)
       if @remote_provide
         if error.zero?
@@ -107,6 +125,8 @@ module Yast
       ""
     end
 
+    # A pre- or post-install/uninstall script is started.
+    #
     def ScriptStart(patch_name, patch_version, patch_arch, script_path)
       patch_full_name = PackageCallbacks.FormatPatchName(
         patch_name,
@@ -133,6 +153,12 @@ module Yast
       nil
     end
 
+    # Progress during a pre- or post-install/uninstall script.
+    #
+    # Since there is no way to find out how far the execution of this script
+    # has progressed, this is only a "ping" notification, not reporting
+    # percents.
+    #
     def ScriptProgress(ping, output)
       Builtins.y2milestone("ScriptProgress: ping:%1, output: %2", ping, output)
 
@@ -156,11 +182,15 @@ module Yast
       ![:abort, :close].include?(input)
     end
 
+    # Error reporting during execution of a pre- or post-install/uninstall script.
+    #
     def ScriptProblem(description)
       # display Abort/Retry/Ignore popup
       PackageCallbacks.ScriptProblem(description)
     end
 
+    # A pre- or post-install/uninstall script has finished.
+    #
     def ScriptFinish
       Builtins.y2milestone("ScriptFinish")
 

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -139,8 +139,11 @@ module Yast
         script_path
       )
 
+      # FIXME: maybe use a DelayedProgressPopup here?
+
       # reset the progressbar
       if UI.WidgetExists(:progressCurrentPackage)
+        # FIXME: This widget does not exist anymore.
         UI.ChangeWidget(:progressCurrentPackage, :Label, patch_full_name)
         UI.ChangeWidget(:progressCurrentPackage, :Value, 0)
       end
@@ -161,6 +164,7 @@ module Yast
     #
     def ScriptProgress(ping, output)
       Builtins.y2milestone("ScriptProgress: ping:%1, output: %2", ping, output)
+      # FIXME: maybe use a DelayedProgressPopup here?
 
       if !output.nil? && output != ""
         # remove the trailing new line character

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -503,7 +503,7 @@ module Yast
       PackageCallbacks.SourceChange(source, media) # inform PackageCallbacks about the change
 
       # display remaining packages
-      PackageSlideShow.DisplayGlobalProgress
+      PackageSlideShow.UpdateTotalProgressText
 
       nil
     end

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -86,7 +86,7 @@ module Yast
     end
 
     # Update during package download: Percent, average and current bytes per second.
-    def ProgressDownload(percent, _bps_avg, _bps_current)
+    def ProgressDownload(_percent, _bps_avg, _bps_current)
       HandleInput()
       !SlideShow.GetUserAbort
     end

--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -25,7 +25,7 @@ module Yast
       Yast.import "Directory"
       Yast.import "URL"
 
-      @_remote_provide = false
+      @remote_provide = false
 
       @pkg_inprogress = ""
 
@@ -72,37 +72,34 @@ module Yast
     #  at start of file providal
     def StartProvide(name, archivesize, remote)
       @pkg_inprogress = name
-      @_remote_provide = remote
+      @remote_provide = remote
 
-      PackageSlideShow.SlideProvideStart(name, archivesize, remote)
-
+      PackageSlideShow.DownloadStart(name, archivesize) if @remote_provide
       nil
     end
 
     # during file providal
     def ProgressProvide(percent)
-      PackageSlideShow.UpdateCurrentPackageProgress(percent) if @_remote_provide
+      PackageSlideShow.DownloadProgress(percent) if @remote_provide
       HandleInput()
       !SlideShow.GetUserAbort
     end
 
-    def ProgressDownload(percent, bps_avg, bps_current)
-      PackageSlideShow.UpdateCurrentPackageRateProgress(
-        percent,
-        bps_avg,
-        bps_current
-      )
-
+    # Update during package download: Percent, average and current bytes per second.
+    def ProgressDownload(percent, _bps_avg, _bps_current)
       HandleInput()
       !SlideShow.GetUserAbort
     end
 
     # during file providal
     def DoneProvide(error, reason, name)
-      if @_remote_provide
-        PackageSlideShow.UpdateCurrentPackageProgress(100)
-        PackageSlideShow.DoneProvide(error, reason, name)
-        @_remote_provide = false
+      if @remote_provide
+        if error.zero?
+          PackageSlideShow.DownloadEnd(name)
+        else
+          PackageSlideShow.DownloadError(error, reason, name)
+        end
+        @remote_provide = false
       end
       return "C" if SlideShow.GetUserAbort
       return PackageCallbacks.DoneProvide(error, reason, name) if error.nonzero?
@@ -260,7 +257,7 @@ module Yast
     # and pass the "deleting" flag as appropriate.
     #
     def DisplayStartInstall(pkg_name, pkg_location, pkg_description, pkg_size, deleting)
-      PackageSlideShow.SlideDisplayStart(
+      PackageSlideShow.PkgInstallStart(
         pkg_name,
         pkg_location,
         pkg_description,
@@ -383,7 +380,7 @@ module Yast
       nil
     end
 
-    #  at start of package install
+    # Notification that a package starts being installed, updated or removed.
     def StartPackage(name, location, summary, install_size, is_delete)
       PackageCallbacks._package_name = name
       PackageCallbacks._package_size = install_size
@@ -394,9 +391,9 @@ module Yast
       nil
     end
 
-    # ProgressPackage percent
-    #
+    # Progress while a package is being installed, updated or removed.
     def ProgressPackage(pkg_percent)
+      PackageSlideShow.PkgInstallProgress(pkg_percent)
       HandleInput()
 
       Builtins.y2milestone("Aborted at %1%%", pkg_percent) if SlideShow.GetUserAbort
@@ -404,7 +401,8 @@ module Yast
       !SlideShow.GetUserAbort
     end
 
-    # at end of install
+    # Notification that a package is finished being installed, updated or removed.
+    #
     # just to override the PackageCallbacks default (which does a 'CloseDialog' :-})
     def DonePackage(error, reason)
       return "I" if SlideShow.GetUserAbort
@@ -420,7 +418,7 @@ module Yast
 
       if Builtins.size(ret).zero? ||
           Builtins.tolower(Builtins.substring(ret, 0, 1)) != "r"
-        PackageSlideShow.SlideDisplayDone(
+        PackageSlideShow.PkgInstallDone(
           PackageCallbacks._package_name,
           PackageCallbacks._package_size,
           PackageCallbacks._deleting_package
@@ -430,21 +428,12 @@ module Yast
     end
 
     #  at start of file providal
-    def StartDeltaProvide(name, archivesize)
-      PackageSlideShow.SlideGenericProvideStart(
-        name, # remote
-        archivesize,
-        _("Downloading delta RPM %1 (download size %2)"),
-        true
-      )
-
+    def StartDeltaProvide(_name, _archivesize)
       nil
     end
 
     #  at start of file providal
-    def StartDeltaApply(name)
-      PackageSlideShow.SlideDeltaApplyStart(name)
-
+    def StartDeltaApply(_name)
       nil
     end
 

--- a/test/package_slide_show_test.rb
+++ b/test/package_slide_show_test.rb
@@ -17,11 +17,11 @@ describe Yast::PackageSlideShow do
     end
   end
 
-  describe ".SlideDisplayDone" do
+  describe ".PkgInstallDone" do
     context "when deleting package" do
       it "increases removed counter in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, true) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
           change { package_slide_show.GetPackageSummary["removed"] }.from(0).to(1)
         )
       end
@@ -29,7 +29,7 @@ describe Yast::PackageSlideShow do
       it "adds name to removed_list in summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, true) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
           change { package_slide_show.GetPackageSummary["removed_list"] }
             .from([])
             .to(["test"])
@@ -43,7 +43,7 @@ describe Yast::PackageSlideShow do
       # TODO: updating non trivial amount of table
       it "increases installed counter in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, false) }.to(
           change { package_slide_show.GetPackageSummary["installed"] }.from(0).to(1)
         )
       end
@@ -51,7 +51,7 @@ describe Yast::PackageSlideShow do
       it "adds name to installed_list in summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, false) }.to(
           change { package_slide_show.GetPackageSummary["installed_list"] }
             .from([])
             .to(["test"])
@@ -60,7 +60,7 @@ describe Yast::PackageSlideShow do
 
       it "adds its size to installed_bytes in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 502, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 502, false) }.to(
           change { package_slide_show.GetPackageSummary["installed_bytes"] }.from(0).to(502)
         )
       end
@@ -68,13 +68,13 @@ describe Yast::PackageSlideShow do
       it "sets global progress label in slide show" do
         expect(Yast::SlideShow).to receive(:SetGlobalProgressLabel)
 
-        package_slide_show.SlideDisplayDone("test", 502, false)
+        package_slide_show.PkgInstallDone("test", 502, false)
       end
 
       it "updates stage progress" do
         expect(Yast::SlideShow).to receive(:StageProgress)
 
-        package_slide_show.SlideDisplayDone("test", 502, false)
+        package_slide_show.PkgInstallDone("test", 502, false)
       end
     end
   end

--- a/test/package_slide_show_test.rb
+++ b/test/package_slide_show_test.rb
@@ -18,7 +18,7 @@ describe Yast::PackageSlideShow do
   end
 
   describe ".PkgInstallDone" do
-    context "when deleting package" do
+    context "when deleting a package" do
       it "increases removed counter in summary" do
         package_slide_show.main # to reset counter
         expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
@@ -26,7 +26,7 @@ describe Yast::PackageSlideShow do
         )
       end
 
-      it "adds name to removed_list in summary in normal mode" do
+      it "adds the name to the removed_list in the summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
         expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
@@ -37,8 +37,7 @@ describe Yast::PackageSlideShow do
       end
     end
 
-    context "when installing package" do
-      # TODO: lot of internal variables changes in size and time estimation that is hard to test
+    context "when installing a package" do
       # TODO: updating is also hard to test as it is set at start of package install
       # TODO: updating non trivial amount of table
       it "increases installed counter in summary" do
@@ -48,7 +47,7 @@ describe Yast::PackageSlideShow do
         )
       end
 
-      it "adds name to installed_list in summary in normal mode" do
+      it "adds the name to the installed_list in the summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
         expect { package_slide_show.PkgInstallDone("test", 1, false) }.to(

--- a/test/slide_show_callbacks_test.rb
+++ b/test/slide_show_callbacks_test.rb
@@ -15,7 +15,7 @@ describe Yast::SlideShowCallbacksClass do
     let(:deleting) { false }
 
     before do
-      allow(Yast::PackageSlideShow).to receive(:SlideDisplayStart)
+      allow(Yast::PackageSlideShow).to receive(:PkgInstallStart)
       allow(subject).to receive(:HandleInput)
       allow(Yast::Installation).to receive(:destdir).and_return("/")
       allow(File).to receive(:exist?).and_return(true)


### PR DESCRIPTION
## Target Branch / Product

**_This is for SLE-15-SP4._**

Version for master: _TBD_

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1195608


## Trello

https://trello.com/c/38oLzang/


## Problem

During package installation (only in the installed system, not during installation) there was no visual feedback while packages were being downloaded, only when all downloads were finished and it started actually installing the downloaded packages: The user saw only a progress bar stuck at 0% for minutes while the download was in progress.

During system installation, this was not a problem since download and installation is now (since SLE-15 SP4 / Leap 15.4) done in parallel.


## Cause

After the progress reporting was greatly simplified to enable parallel actions in libzypp, there was only one single progress bar, no lists of current actions (which had included downloads).


## Fix

Now displaying both the downloads _and_ the installed / upgraded / removed packages in that single progress bar.

- Total: Expected (unpacked) install sizes of all packages + expected (packed) download sizes

- Current: Finished install sizes + finished download sizes + partial download sizes

## Video

https://user-images.githubusercontent.com/11538225/161561914-ec78f295-236d-4bb3-9e57-2fe2f98974cd.mp4


## Rationale

Of course this is a little apples vs. oranges: Downloading 100 MB of RPMs rarely takes the same time as installing 100 MB of RPMs. But this makes the progress bar move during all waiting times, so the user can see that there is progress.

While doing similar operations on the command line, many seasoned users do

```
sudo zypper refresh
sudo zypper dup --download-only -y
```

And only when this is finished:

```
sudo zypper dup
```

This makes sure that this is a transaction, and it doesn't get stuck in the middle because of some packages that could not be downloaded. The current policy of the YaST software module in the installed system does very much the same: First, all required packages are downloaded, and when that is finished, the actual install / upgrade / remove operations are started.

Depending on the user's Internet connection, the download phase may take considerably longer than the installation phase, so the progress bar will very likely move quicker during the second phase. But it is very unlikely that any user will complain when it speeds up during the process; that will be very welcome by most users.


## Parallel Download and Installation

During system installation, we are now using a new libzypp mode that does downloading and installing packages in parallel, so the code needs to take that into account.

The first naive approach was to just check for `Mode.normal` (i.e. only in the installed system, not during system installation / system upgrade / AutoYaST installation). That works right now, but who knows when we will start using that new mode also in other scenarios.

So the code now keeps track in the callbacks (`DownloadStart()`, `DownloadProgress()`, `DownloadEnd()`, `PkgInstallStart()`, ...) if there is any indication that a package starts being installed while another one is downloaded, and changes to the _parallel_download_ mode, i.e. the progress bar only takes the package installation into account and not the downloads anymore; i.e. it auto-adapts.

The initial default is still based on `Mode.normal`, though.


## Other Changes

- Cleaned up that `PackageSlideShow` module:
  - Removed code duplication (initializing the member variables)
  - Removed redundant member variables: Some counter variables were really only the size of lists (packages installed, packages updated, ...). It never made any sense to duplicate that information. Now using `@xxx_list.size` instead wherever needed.
  - Clearly renamed the download callbacks to indicate what they do.
  - Factored out the very uncommon `DownloadError()` case into a separate method for clearer control flow; the uncommon case should not obscure the common one (download finished normally), much less with _always_ passing 2 (!) out of 3 method parameters for the uncommon error case.
  - Removed most YCP zombies (`Ops.Add()`, seriously?!)


## Installer Self-Update?

This affects only the installed system, not the system installation or upgrade, so an installer self-update is not needed.


## Related PR

- https://github.com/yast/yast-yast2/pull/1250