### PR TITLE
Fixed regression in repository alias name for add-ons (jsc#1193214)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 31 15:52:11 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed regression in repository alias name for add-ons (jsc#1193214)
+- 4.4.27
+
+-------------------------------------------------------------------
 Thu Mar 17 08:01:35 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Read the products from libzypp in installed system, fixes crash

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.26
+Version:        4.4.27
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/packager/repositories_include.rb
+++ b/src/include/packager/repositories_include.rb
@@ -148,7 +148,7 @@ module Yast
 
         alias_name = if force_alias != ""
           force_alias
-        elsif product.media_name && !product.media_name.empty?
+        elsif product.media_name && !product.media_name.empty? && product.media_name != "/"
           propose_alias(product.media_name)
         elsif product.name && !product.name.empty?
           propose_alias(product.name)


### PR DESCRIPTION
## Problem

- The alias for the extra add-on repositories (not from the Full medium) was set to the fallback text "Repository"
- https://bugzilla.suse.com/show_bug.cgi?id=1193214#c20
- The result of installation with HA repository:
```
# zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                             | Name                           | Enabled | GPG Check | Refresh
--+-----------------------------------+--------------------------------+---------+-----------+--------
1 | Basesystem-Module_15.4-0          | sle-module-basesystem          | No      | ----      | ----
2 | Repository                        | sle-ha                         | Yes     | (r ) Yes  | Yes
3 | SLES15-SP4-15.4-0                 | SLES15-SP4-15.4-0              | No      | ----      | ----
4 | Server-Applications-Module_15.4-0 | sle-module-server-applications | No      | ----      | ----
```
That's a regression compared to SP3.

It turned out that YaST prefers the medium name from the `media.1/products`, but for single product medium it is just plain `/`. And that it later reduced to an empty string because `/` cannot be used in alias, it is used for the *.repo file name. And empty string is replaced by the fallback name `Repository` later.

## Solution

- Do not use the medium location if it is just `/`.

## Testing

- Tested manually with patched installer

```
# zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                                    | Name                           | Enabled | GPG Check | Refresh
--+------------------------------------------+--------------------------------+---------+-----------+--------
1 | Basesystem-Module_15.4-0                 | sle-module-basesystem          | No      | ----      | ----
2 | SLE-15-SP4-Product-HA-POOL-x86_64-Media1 | sle-ha                         | Yes     | (r ) Yes  | Yes
3 | SLES15-SP4-15.4-0                        | SLES15-SP4-15.4-0              | No      | ----      | ----
4 | Server-Applications-Module_15.4-0        | sle-module-server-applications | No      | ----      | ----
```
With the patch the name is `SLE-15-SP4-Product-HA-POOL-x86_64-Media1`, the same as in SP3.