### PR TITLE
Show Download Progress [master]

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr  7 11:28:48 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Show package downloads in the global progress bar during package
+  installation (bsc#1195608)
+  PR: https://github.com/yast/yast-packager/pull/612
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (#bsc1198109)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/package_slide_show_test.rb
+++ b/test/package_slide_show_test.rb
@@ -17,19 +17,19 @@ describe Yast::PackageSlideShow do
     end
   end
 
-  describe ".SlideDisplayDone" do
-    context "when deleting package" do
+  describe ".PkgInstallDone" do
+    context "when deleting a package" do
       it "increases removed counter in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, true) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
           change { package_slide_show.GetPackageSummary["removed"] }.from(0).to(1)
         )
       end
 
-      it "adds name to removed_list in summary in normal mode" do
+      it "adds the name to the removed_list in the summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, true) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, true) }.to(
           change { package_slide_show.GetPackageSummary["removed_list"] }
             .from([])
             .to(["test"])
@@ -37,21 +37,20 @@ describe Yast::PackageSlideShow do
       end
     end
 
-    context "when installing package" do
-      # TODO: lot of internal variables changes in size and time estimation that is hard to test
+    context "when installing a package" do
       # TODO: updating is also hard to test as it is set at start of package install
       # TODO: updating non trivial amount of table
       it "increases installed counter in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, false) }.to(
           change { package_slide_show.GetPackageSummary["installed"] }.from(0).to(1)
         )
       end
 
-      it "adds name to installed_list in summary in normal mode" do
+      it "adds the name to the installed_list in the summary in normal mode" do
         allow(Yast::Mode).to receive(:normal).and_return(true)
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 1, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 1, false) }.to(
           change { package_slide_show.GetPackageSummary["installed_list"] }
             .from([])
             .to(["test"])
@@ -60,7 +59,7 @@ describe Yast::PackageSlideShow do
 
       it "adds its size to installed_bytes in summary" do
         package_slide_show.main # to reset counter
-        expect { package_slide_show.SlideDisplayDone("test", 502, false) }.to(
+        expect { package_slide_show.PkgInstallDone("test", 502, false) }.to(
           change { package_slide_show.GetPackageSummary["installed_bytes"] }.from(0).to(502)
         )
       end
@@ -68,13 +67,13 @@ describe Yast::PackageSlideShow do
       it "sets global progress label in slide show" do
         expect(Yast::SlideShow).to receive(:SetGlobalProgressLabel)
 
-        package_slide_show.SlideDisplayDone("test", 502, false)
+        package_slide_show.PkgInstallDone("test", 502, false)
       end
 
       it "updates stage progress" do
         expect(Yast::SlideShow).to receive(:StageProgress)
 
-        package_slide_show.SlideDisplayDone("test", 502, false)
+        package_slide_show.PkgInstallDone("test", 502, false)
       end
     end
   end

--- a/test/slide_show_callbacks_test.rb
+++ b/test/slide_show_callbacks_test.rb
@@ -15,7 +15,7 @@ describe Yast::SlideShowCallbacksClass do
     let(:deleting) { false }
 
     before do
-      allow(Yast::PackageSlideShow).to receive(:SlideDisplayStart)
+      allow(Yast::PackageSlideShow).to receive(:PkgInstallStart)
       allow(subject).to receive(:HandleInput)
       allow(Yast::Installation).to receive(:destdir).and_return("/")
       allow(File).to receive(:exist?).and_return(true)


### PR DESCRIPTION
## Target Branch / Product

**_This is for master / Factory / Tumbleweed._**

This merges https://github.com/yast/yast-packager/pull/609 to master / Factory / Tumbleweed.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1195608


## Trello

https://trello.com/c/38oLzang/


## Problem

During package installation (only in the installed system, not during installation) there was no visual feedback while packages were being downloaded, only when all downloads were finished and it started actually installing the downloaded packages: The user saw only a progress bar stuck at 0% for minutes while the download was in progress.

During system installation, this was not a problem since download and installation is now (since SLE-15 SP4 / Leap 15.4) done in parallel.


## Cause

After the progress reporting was greatly simplified to enable parallel actions in libzypp, there was only one single progress bar, no lists of current actions (which had included downloads).


## Fix

Now displaying both the downloads _and_ the installed / upgraded / removed packages in that single progress bar.

- Total: Expected (unpacked) install sizes of all packages + expected (packed) download sizes

- Current: Finished install sizes + finished download sizes + partial download sizes

## Video

https://user-images.githubusercontent.com/11538225/161561914-ec78f295-236d-4bb3-9e57-2fe2f98974cd.mp4


## Rationale

Of course this is a little apples vs. oranges: Downloading 100 MB of RPMs rarely takes the same time as installing 100 MB of RPMs. But this makes the progress bar move during all waiting times, so the user can see that there is progress.

While doing similar operations on the command line, many seasoned users do

```
sudo zypper refresh
sudo zypper dup --download-only -y
```

And only when this is finished:

```
sudo zypper dup
```

This makes sure that this is a transaction, and it doesn't get stuck in the middle because of some packages that could not be downloaded. The current policy of the YaST software module in the installed system does very much the same: First, all required packages are downloaded, and when that is finished, the actual install / upgrade / remove operations are started.

Depending on the user's Internet connection, the download phase may take considerably longer than the installation phase, so the progress bar will very likely move quicker during the second phase. But it is very unlikely that any user will complain when it speeds up during the process; that will be very welcome by most users.


## Parallel Download and Installation

During system installation, we are now using a new libzypp mode that does downloading and installing packages in parallel, so the code needs to take that into account.

The first naive approach was to just check for `Mode.normal` (i.e. only in the installed system, not during system installation / system upgrade / AutoYaST installation). That works right now, but who knows when we will start using that new mode also in other scenarios.

So the code now keeps track in the callbacks (`DownloadStart()`, `DownloadProgress()`, `DownloadEnd()`, `PkgInstallStart()`, ...) if there is any indication that a package starts being installed while another one is downloaded, and changes to the _parallel_download_ mode, i.e. the progress bar only takes the package installation into account and not the downloads anymore; i.e. it auto-adapts.

The initial default is still based on `Mode.normal`, though.


## Other Changes

- Cleaned up that `PackageSlideShow` module:
  - Removed code duplication (initializing the member variables)
  - Removed redundant member variables: Some counter variables were really only the size of lists (packages installed, packages updated, ...). It never made any sense to duplicate that information. Now using `@xxx_list.size` instead wherever needed.
  - Clearly renamed the download callbacks to indicate what they do.
  - Factored out the very uncommon `DownloadError()` case into a separate method for clearer control flow; the uncommon case should not obscure the common one (download finished normally), much less with _always_ passing 2 (!) out of 3 method parameters for the uncommon error case.
  - Removed most YCP zombies (`Ops.Add()`, seriously?!)


## Related PR

- https://github.com/yast/yast-yast2/pull/1250