### PR TITLE
Don't Rely on /etc/install.inf being Available [15-SP4]

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 27 13:31:36 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't rely on install.inf availability #(bsc#1198560)
+- 4.4.30
+
+-------------------------------------------------------------------
 Wed Apr 27 11:24:44 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed migration summary in Leap -> SLES migration (bsc#1198562)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.29
+Version:        4.4.30
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_spec_reader.rb
+++ b/src/lib/y2packager/product_spec_reader.rb
@@ -27,6 +27,7 @@ module Y2Packager
   class ProductSpecReader
     include Yast::Logger
     Yast.import "Mode"
+    Yast.import "Linuxrc"
 
     # Returns the list of product specifications.
     #
@@ -35,7 +36,7 @@ module Y2Packager
       # products_from_control || products_from_offline || products_from_libzypp
 
       # online migration (in installed system)
-      return products_from_libzypp if Yast::Mode.normal
+      return products_from_libzypp if Yast::Mode.normal || !install_inf?
 
       if InstallationMedium.contain_multi_repos?
         products_from_multi_repos
@@ -69,6 +70,13 @@ module Y2Packager
       libzypp_products = Y2Packager::ProductSpecReaders::Libzypp.new.products
       log.info "Products from libzypp: #{libzypp_products.map(&:name).join(", ")}"
       libzypp_products
+    end
+
+    # Is information from an install.inf file available?
+    #
+    # @return [Boolean]
+    def install_inf?
+      !Yast::Linuxrc.keys.empty?
     end
   end
 end

--- a/test/lib/product_spec_reader_test.rb
+++ b/test/lib/product_spec_reader_test.rb
@@ -38,6 +38,9 @@ describe Y2Packager::ProductSpecReader do
   let(:full_products) { [instance_double(Y2Packager::ProductSpec, name: "SLES")] }
   let(:control_products) { [instance_double(Y2Packager::ProductSpec, name: "SLED")] }
   let(:libzypp_products) { [instance_double(Y2Packager::ProductSpec, name: "SLE-HA")] }
+  let(:linuxrc_fake) { { foo: "bar" } }
+  let(:linuxrc_empty) { {} }
+  let(:linuxrc_keys) { linuxrc_fake }
 
   describe "#products" do
     before do
@@ -47,6 +50,7 @@ describe Y2Packager::ProductSpecReader do
       allow(Y2Packager::InstallationMedium).to receive(:contain_repo?).and_return(false)
       allow(Y2Packager::InstallationMedium).to receive(:contain_multi_repos?).and_return(false)
       allow(Yast::Mode).to receive(:normal).and_return(false)
+      allow(Yast::Linuxrc).to receive(:keys).and_return(linuxrc_keys)
     end
 
     context "when medium does not contain any repository" do
@@ -79,6 +83,17 @@ describe Y2Packager::ProductSpecReader do
     context "in installed system" do
       before do
         allow(Yast::Mode).to receive(:normal).and_return(true)
+      end
+
+      it "returns the libzypp products" do
+        expect(reader.products).to eq(libzypp_products)
+      end
+    end
+
+    context "without /etc/install.inf" do
+      let(:linuxrc_keys) { linuxrc_empty }
+      before do
+        allow(Yast::Mode).to receive(:normal).and_return(false)
       end
 
       it "returns the libzypp products" do


### PR DESCRIPTION
## Target Branch / Product

**This is for SLE-15-SP4.** A port to master will follow.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1198560


## Trello

https://trello.com/c/AXWDv2jh/


## Problem

When migrating from Leap 15.4 to SLE-15 SP4 on the installed system, YaST crashes with an exception _"The installation URL is not set"_ in https://github.com/yast/yast-packager/blob/master/src/lib/y2packager/installation_medium.rb#L48-L50 .

## Cause

It tried to read `/etc/install.inf` (the config file that _linuxrc_ writes for YaST to consume) to check if the installation media has several products or just one. But in this scenario, the migration started from the installed system, not from an inst-sys on installation media; so there was no `/etc/install.inf`.

## Fix

Check if there is an `install.inf`; more precisely, if any data from that could be read, i.e. if there was _any_ content at all from such a file.

If there is none, read the products from libzypp: In this scenario, the old repos from the system that we want to migrate away from were just removed, and the ones from the new one (that we want to migrate to) were added. Those repos are what we need here.

Notice that in this scenario it does _not_ make sense to read a repo URL from a `control.xml` file: While there is one in `/etc/YaST2/control.xml`, that is not the default path on installation media, so it won't be found; and, worse, that file contains the URL of the _old_ repo, the system that we are migrating away from.


## Related PR

PR for master: _TBD_
