### PR TITLE
Fixed migration summary in Leap -> SLES migration (bsc#1198562)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 27 11:24:44 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed migration summary in Leap -> SLES migration (bsc#1198562)
+- 4.4.29
+
+-------------------------------------------------------------------
 Wed Apr  6 14:00:54 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Show package downloads in the global progress bar during package

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.28
+Version:        4.4.29
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -41,8 +41,14 @@ module Yast
       "sle-sdk"                           => ["sle-module-development-tools"],
       # openSUSE => SLES migration
       "openSUSE"                          => ["SLES"],
+      # openSUSE 15.3+ => SLES migration
+      "Leap"                              => ["SLES"],
       # the IBM tools have been renamed in SLE12->SLE15 upgrade
       "ibm-dlpar-utils"                   => ["ibm-power-tools"]
+
+      # NOTE: if you change anything here then check
+      # https://github.com/yast/yast-packager/blob/master/src/lib/y2packager/product_upgrade.rb#L27
+      # maybe it needs an update as well...
     }.freeze
 
     # @return [Hash] Product renames added externally through the #add_rename method


### PR DESCRIPTION
## Problem

- The Leap -> SLES migration summary contained a wrong status for the old Leap product.

## Solution

- It turned out that the hardcoded product data does not contain the new `Leap` product name (they changed the product name in Leap 15.3... :thinking: ).

## Testing

- Tested manually

## Screenshots

The original wrong summary:

![migration_summary_bug](https://user-images.githubusercontent.com/907998/165518709-4a10b902-e9dc-4bed-932d-825ae66c36d9.png)

With the fix:

![migration_summary_fixed](https://user-images.githubusercontent.com/907998/165518769-4758a0c3-5524-4a7b-a6b3-0981513d9ea9.png)
