### PR TITLE
Run the solver after selecting system packages (bsc#1195828)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,7 +2,7 @@
 Tue May  3 06:50:36 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the package solver after selecting additional system
-  packages, fixes possible broken package dependecies after system
+  packages, fixes possible broken package dependencies after system
   upgrade (bsc#1195828)
 - 4.4.31
 

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue May  3 06:50:36 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Run the package solver after selecting additional system
+  packages, fixes possible broken package dependecies after system
+  upgrade (bsc#1195828)
+- 4.4.31
+
+-------------------------------------------------------------------
 Wed Apr 27 13:31:36 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't rely on install.inf availability #(bsc#1198560)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.30
+Version:        4.4.31
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1939,6 +1939,9 @@ module Yast
         end
       end
 
+      # update the dependendcies
+      Pkg.PkgSolve(false)
+
       nil
     end
 


### PR DESCRIPTION
## Problem

- Broken package dependencies after system upgrade
- https://bugzilla.suse.com/show_bug.cgi?id=1195828
- A solver run is missing after selecting some additional system packages


## Solution

- Just run the solver


## Testing

- [x] [Manual test](https://bugzilla.suse.com/show_bug.cgi?id=1195828#c60) (tested by Libor Pecháček)

