### PR TITLE
Fix package counters during installation (boo#1199621)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 17 20:49:27 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix package counters in the installation slideshow 
+  (boo#1199621).
+- 4.4.32
+
+-------------------------------------------------------------------
 Tue May  3 06:50:36 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the package solver after selecting additional system

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.31
+Version:        4.4.32
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

The count of remaining packages to install is not updated.

- [bsc#1199621](https://bugzilla.opensuse.org/show_bug.cgi?id=1199621)

## Solution

Keep the installed/updated/removed packages counters in separate variables. Alternatively, we could just update always the lists, but I guess the original idea was to not keep long lists of packages that are not going to be used. Unlike during installation/upgrade, in `Mode.normal`, the list is displayed at the end of the process.

## Testing

- *Tested manually*

## Screencast

![installed-packages-counter](https://user-images.githubusercontent.com/15836/168909333-a1d1d504-70d7-4777-a479-8f993cf982b3.gif)