### PR TITLE
Run in container

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 26 12:40:24 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support managing system in a chroot (bsc#1199840)
+- 4.5.5
+
+-------------------------------------------------------------------
 Tue May 17 20:49:27 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix package counters in the installation slideshow

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/clients/sw_single.rb
+++ b/src/clients/sw_single.rb
@@ -135,7 +135,7 @@ module Yast
 
     def CheckWhichPackages(arg_list)
       arg_list = deep_copy(arg_list)
-      if !Pkg.TargetInit("/", false)
+      if !Pkg.TargetInit(Installation.destdir, false)
         # error message
         Report.Error("Cannot read the list of installed packages.")
         return :failed

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -25,6 +25,7 @@ Yast.import "SourceManager"
 Yast.import "SourceDialogs"
 Yast.import "Wizard"
 
+Yast.import "Installation"
 Yast.import "Label"
 Yast.import "Popup"
 Yast.import "Sequencer"
@@ -1527,7 +1528,7 @@ module Yast
       if !@full_mode
         # dialog caption
         Wizard.SetContents(_("Initializing..."), Empty(), "", false, true)
-        Pkg.TargetInit("/", true)
+        Pkg.TargetInit(Installation.destdir, true)
       end
 
       Wizard.SetDesktopTitleAndIcon("org.opensuse.yast.SWSource")


### PR DESCRIPTION
## Problem

- Adapt the repository manager and the package manager to be able to run in a management container

## Solution

- Just use `Installation.destdir` when initializing libzypp
- In a management container it is set to `/mnt`
- In a normal running system is set to `/`

## Notes

- See related PR:
  - https://github.com/yast/yast-yast2/pull/1258
  - https://github.com/yast/yast-ruby-bindings/pull/284/

## Testing

- Tested manually
