### PR TITLE
Do not call [Install done] on aborted packages

### DIFF
--- a/src/modules/SlideShowCallbacks.rb
+++ b/src/modules/SlideShowCallbacks.rb
@@ -31,7 +31,7 @@ module Yast
 
       # never show the disk space warning popup during autoinstallation
       @ask_again = !Mode.autoinst
-      # true == continue with the installtion
+      # true == continue with the installation
       @user_input = true
     end
 
@@ -451,7 +451,7 @@ module Yast
       end
 
       if Builtins.size(ret).zero? ||
-          Builtins.tolower(Builtins.substring(ret, 0, 1)) != "r"
+          Builtins.tolower(Builtins.substring(ret, 0, 1)) == "i"
         PackageSlideShow.PkgInstallDone(
           PackageCallbacks._package_name,
           PackageCallbacks._package_size,


### PR DESCRIPTION
Fix [Bug 1203302](https://bugzilla.opensuse.org/show_bug.cgi?id=1203302)


## Problem

The slide show used by the package downloader does not recognise the return code for aborted packages and treats them as installed.

## Solution

Instead of checking that the return code is not RETRY, require it to be explicitly INSTALL.


## Testing

Currently beyond my possibilities, unfortunately.

## Screenshots

![negative remaining](https://user-images.githubusercontent.com/1363094/190633816-ef50f362-c5aa-4949-9e26-f1dbe3c5b5c0.png)

