### PR TITLE
support 'repo' scheme for add-ons (jsc#SLE-22578, jsc#SLE-24584)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 25 10:20:48 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- support 'repo' scheme for add-ons (jsc#SLE-22578, jsc#SLE-24584)
+- 4.5.6
+
+-------------------------------------------------------------------
 Thu May 26 12:40:24 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Support managing system in a chroot (bsc#1199840)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Task

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

Support new `repo` URI scheme that works relative to the installation medium.

## See also

- https://github.com/yast/yast-add-on/pull/127