### PR TITLE
Escape spaces in the installation URL (bsc#1201816)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 15 17:50:12 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not fail when the installation URL contains a space
+  (bsc#1201816)
+- 3.3.5
+
+-------------------------------------------------------------------
 Wed Oct 30 18:45:05 UTC 2019 - Christopher Hofmann <cwh@suse.com>
 
 - Aligned the language of the license text shown with the selected

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        3.3.4
+Version:        3.3.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/InstURL.rb
+++ b/src/modules/InstURL.rb
@@ -157,6 +157,9 @@ module Yast
       @installInf2Url = add_extra_dir_to_url(@installInf2Url, extra_dir) unless extra_dir.empty?
       @installInf2Url = add_ssl_verify_no_to_url(@installInf2Url) unless SSLVerificationEnabled()
 
+      # escape spaces otherwise it would be invalid and rejected by libzypp
+      @installInf2Url.gsub!(" ", "%20")
+
       log.info "Using install URL: #{URL.HidePassword(@installInf2Url)}"
       @installInf2Url
     end


### PR DESCRIPTION
## Problem

- The URL from `install.inf` might contain unescaped spaces. Spaces are not allowed in URL and should be escaped.
- See https://bugzilla.suse.com/show_bug.cgi?id=1201816#c10, https://bugzilla.suse.com/show_bug.cgi?id=1201816#c26


## Solution

- As a quick and simple fix just replace all spaces with the percent encoded values
- This does not need any change in `linuxrc` and can be deployed as a self-update

## Testing

- Tested manually
