### PR TITLE
Fixed adding an empty repository at upgrade (bsc#1204399)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov  2 12:35:52 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not add an empty repository to the system when upgrading
+  a registered system using the Full installation medium
+  (bsc#1204399)
+- 4.4.33
+
+-------------------------------------------------------------------
 Tue May 17 20:49:27 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix package counters in the installation slideshow 

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.4.32
+Version:        4.4.33
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/medium_type.rb
+++ b/src/lib/y2packager/medium_type.rb
@@ -28,9 +28,9 @@ module Y2Packager
       # URL is not set (nil) or is empty.
       #
       # @return [Symbol] Symbol describing the medium, one of `:offline`,
-      # `:online` or `:standard`
+      #   `:online` or `:standard`
       def type
-        @type ||= detect_medium_type
+        @type ||= detected_type
       end
 
       # Returns the cached medium type value. If the medium detection has not been
@@ -42,6 +42,17 @@ module Y2Packager
         @type
       end
 
+      # Similar to {.type} method, but returns the cached original value of the
+      # detected medium type. Useful after changing the type via `type=` method.
+      # Raises an exception if the installation URL is not set (`nil`) or is empty.
+      #
+      # @see .type
+      # @return [Symbol] Symbol describing the medium, one of `:offline`,
+      #   `:online` or `:standard`
+      def detected_type
+        @detected_type ||= detect_medium_type
+      end
+
       # Possible types for type value
       POSSIBLE_TYPES = [:online, :offline, :standard].freeze
 
@@ -49,7 +60,7 @@ module Y2Packager
       # registered system with Full medium should act like Online medium.
       # @param type [Symbol] possible values are `:online`, `:offline` and `:standard`
       def type=(type)
-        log.info "Overwritting medium to #{type}"
+        log.info "Overriding the medium type from #{@type.inspect} to #{type.inspect}"
 
         if !POSSIBLE_TYPES.include?(type)
           raise ArgumentError, "Not allowed MediumType #{type.inspect}"
@@ -106,7 +117,7 @@ module Y2Packager
       # Detect the medium type.
       #
       # @return [Symbol] Symbol describing the medium, one of `:offline`,
-      # `:online` or `:standard`
+      #   `:online` or `:standard`
       def detect_medium_type
         url = Yast::InstURL.installInf2Url("")
 

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -1663,7 +1663,7 @@ module Yast
         return
       # TODO: the offline medium contains an empty repository in the root,
       # that should be removed in the future, remove this workaround as well
-      elsif Y2Packager::MediumType.offline? && product_dir == "/"
+      elsif Y2Packager::MediumType.detected_type == :offline && product_dir == "/"
         log.info "Ignoring the root repository on the offline medium"
         return
       end

--- a/test/medium_type_test.rb
+++ b/test/medium_type_test.rb
@@ -11,6 +11,7 @@ describe Y2Packager::MediumType do
   after do
     # the computed value is cached, we need to reset it manually for the next test
     described_class.instance_variable_set(:@type, nil)
+    described_class.instance_variable_set(:@detected_type, nil)
   end
 
   describe "#type" do


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1204399
- After upgrading a registered SLE system a strange empty repository is present in the system (the name is like `cd-3494b1a8`, created as a random unique name)

## Details

- It turned out that it only happens when using the *Full* (offline) medium for upgrading a *registered* system
- The empty repository is actually the repository from the root of the Full medium (the real repositories are in subdirectoriees) 
- The code actually already contains a condition which should prevent from this problem ([this code](https://github.com/yast/yast-packager/blob/d1be27c5ea5bd061bc2a368c121127122231e383/src/modules/Packages.rb#L1666-L1669))
- But when the Full medium is used in a registered system it should behave like the Online medium. This is achieved by explicitly switching the detected medium type from Full to Online ([this code](https://github.com/yast/yast-registration/blob/431d937b78c209c0d35ce911a98f9f05978e77ca/src/lib/registration/ui/migration_repos_workflow.rb#L602-L605))

## Solution

- Remember the originally detected medium type so we can use it even when the type is changed later

## Testing

- Tested manually
- Without the patch a `cd-*` repository is added to the system
- With the patch no such repository is added, only the repositories from SCC are present



