### PR TITLE
[master] Escape spaces in the installation URL (bsc#1201816)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 20 09:30:54 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not fail when the installation URL contains a space
+  (bsc#1201816)
+- 4.5.10
+
+-------------------------------------------------------------------
 Wed Dec 14 10:25:42 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Merged PR https://github.com/yast/yast-packager/pull/623

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/InstURL.rb
+++ b/src/modules/InstURL.rb
@@ -149,6 +149,9 @@ module Yast
         @installInf2Url = add_ssl_verify_no_to_url(@installInf2Url) unless SSLVerificationEnabled()
       end
 
+      # escape spaces otherwise it would be invalid and rejected by libzypp
+      @installInf2Url.gsub!(" ", "%20")
+
       log.info "Using install URL: #{URL.HidePassword(@installInf2Url)}"
       @installInf2Url
     end


### PR DESCRIPTION
Finally porting https://github.com/yast/yast-packager/pull/625 to `master`.