### PR TITLE
Media check fixes in containerized environment

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Jan 10 17:35:41 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Media check fixes in containerized environment
+  - Start browsing the ISO files from the /host directory
+    to show the host files (bsc#1206834)
+  - Fixed file readability check to correctly use the specified
+    ISO file
+- 4.5.11
+
+-------------------------------------------------------------------
 Tue Dec 20 09:30:54 UTC 2022 - Ladislav Slezák <lslezak@suse.com>
 
 - Do not fail when the installation URL contains a space

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.10
+Version:        4.5.11
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/include/checkmedia/ui.rb
+++ b/src/include/checkmedia/ui.rb
@@ -23,6 +23,8 @@ require "shellwords"
 module Yast
   # All user interface functions.
   module CheckmediaUiInclude
+    include Yast::Logger
+
     def initialize_checkmedia_ui(_include_target)
       Yast.import "Pkg"
       Yast.import "UI"
@@ -555,12 +557,11 @@ module Yast
     # try to read one byte from the medium to check whether it is readable
     # @param file [String] file path
     # @return [Boolean] returns `true` if the file is readable, `false` otherwise
-    def file_readable?(file)
-      File.open(file) do |f|
-        f.read(1)
-      end
+    def medium_readable?(file)
+      File.read(file, 1)
       true
-    rescue StandardError
+    rescue StandardError => e
+      log.info("Cannot read #{file}: #{e}")
       false
     end
 


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1206834
- Start browsing the ISO files from the `/host` directory  to show the host files, starting from the container root is confusing for users (see the bugreport)
- Fixed file readablity check to correctly use the specified ISO file (`.target_bash` runs in `/host` chroot, the file selected by UI file selector starts from `/`, moreover we can easily replace the external shell command by native Ruby code)