### PR TITLE
Fix URI to work with Ruby 3.2

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 14 13:40:12 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Ruby 3.2: Change a test to treat dir:///foo equal to dir:/foo
+  (bsc#1207239)
+- 4.5.15
+
+-------------------------------------------------------------------
 Wed Feb  8 17:29:25 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent crash if nil dependencies instead of [] (bsc#1208068)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.14
+Version:        4.5.15
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/source_dialogs_test.rb
+++ b/test/source_dialogs_test.rb
@@ -116,17 +116,22 @@ describe Yast::SourceDialogs do
 
     it "uses dir url scheme parameter for local ISO files" do
       converted = "iso:///install/openSUSE-13.2-DVD-x86_64.iso"
-      url = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall"
+      url_old = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2Finstall"
+      url_new = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso&url=dir%3A%2F%2F%2Finstall"
 
-      expect(subject.PostprocessISOURL(converted)).to eq(url)
+      # Since Ruby 3.2, URI("dir:///foo").to_s no longer returns "dir:/foo"
+      # It's OK with Zypp, it understands both forms
+      expect([url_old, url_new]).to include(subject.PostprocessISOURL(converted))
     end
 
     it "prevents double escaping if get already escaped string" do
       converted = "iso:///install/Duomenys%20600%20GB/openSUSE-13.2-DVD-x86_64.iso"
-      url = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso" \
-            "&url=dir%3A%2Finstall%2FDuomenys%2520600%2520GB"
+      url_old = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso" \
+                "&url=dir%3A%2Finstall%2FDuomenys%2520600%2520GB"
+      url_new = "iso:///?iso=openSUSE-13.2-DVD-x86_64.iso" \
+                "&url=dir%3A%2F%2F%2Finstall%2FDuomenys%2520600%2520GB"
 
-      expect(subject.PostprocessISOURL(converted)).to eq(url)
+      expect([url_old, url_new]).to include(subject.PostprocessISOURL(converted))
     end
   end
 


### PR DESCRIPTION
## Problem

Context: Ruby 3.2 is coming to Tumbleweed but YaST fails to build. Staging:H.

This part of the failures is: `URI("dir:///foo").to_s` no longer returns `"dir:/foo"`

- https://bugzilla.suse.com/show_bug.cgi?id=1207239 
- https://trello.com/c/jRe5bWVE/3249-ostumbleweed-1206419-staging-ruby-keyword-parameters-yast-stack-fails-to-build-against-ruby-32


## Solution

- some of the failing tests are fixed in the `ZyppUrl` class in https://github.com/yast/yast-yast2/pull/1285
- the other half here: change the test expectation to allow for 3 slashes (here %-escaped) since zypp treats them the same anyway. And allow for 1 slash to continue building with older Rubies


## Testing

- it's all in existing unit tests


## Screenshots

N/A
