### PR TITLE
Unescape the product name read from package Provides (bsc#1207276)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 26 12:53:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Unescape the product name read from package Provides
+  (bsc#1207276)
+- 4.5.12
+
+-------------------------------------------------------------------
 Tue Jan 10 17:35:41 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Media check fixes in containerized environment

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.11
+Version:        4.5.12
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_finder.rb
+++ b/src/lib/y2packager/product_finder.rb
@@ -11,6 +11,7 @@
 # ------------------------------------------------------------------------------
 
 require "y2packager/repo_product_spec"
+require "uri"
 
 module Y2Packager
   # This class finds products in a Solv pool
@@ -131,6 +132,10 @@ module Y2Packager
         dir = product_solvable.repo.name
         media_name_pair = media_names.find { |r| r[1] == dir }
         media_name = media_name_pair ? media_name_pair.first : dir
+
+        # the product name can be a percent encoded string like
+        # "sle%2Dmodule%2Dweb%2Dscripting"
+        product_name = URI::Parser.new.unescape(product_name)
 
         ret << RepoProductSpec.new(
           name:         product_name,


### PR DESCRIPTION
## Problem

- The product names in Provides is now percent escaped (as some other Provides values already do)
- https://bugzilla.suse.com/show_bug.cgi?id=1207276

## Notes

This is backward compatible, if escaping is not used it is still safe:

```
irb(main):002:0> URI.unescape("sle%2Dmodule%2Dweb%2Dscripting")
=> "sle-module-web-scripting"
irb(main):003:0> URI.unescape("sle-module-web-scripting")
=> "sle-module-web-scripting"
```
