### PR TITLE
Added wicked needed NBFT packages if UseNBFT is set (bsc#1207573)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 26 13:52:26 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Added wicked-nbft package when Linuxrc sets UseNBFT
+  (jsc#PED-3138, bsc#1207573)
+- 4.5.13
+
+-------------------------------------------------------------------
 Thu Jan 26 12:53:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Unescape the product name read from package Provides

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.12
+Version:        4.5.13
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/Packages.rb
+++ b/src/modules/Packages.rb
@@ -34,6 +34,8 @@ module Yast
     REMOTE_X11_BASE_TAGS = ["xorg-x11-server", "xorg-x11-fonts", "icewm"].freeze
     # Graphical packages for VNC installation
     GRAPHIC_PACKAGES = ["xorg-x11-server", "xorg-x11-server-glx", "libusb", "yast2-x11"].freeze
+    # Package needed by NBFT installation (jsc#PED-967)
+    NBFT_PACKAGES = ["wicked-nbft"].freeze
 
     BASE_PRODUCT_FILE = "/etc/products.d/baseproduct".freeze
 
@@ -1118,6 +1120,7 @@ module Yast
       end
 
       install_list.concat(kernelCmdLinePackages)
+      install_list.concat(NBFT_PACKAGES) if Linuxrc.InstallInf("UseNBFT") == "1"
 
       install_list.concat(boardPackages)
 


### PR DESCRIPTION
## Problem

As described in the bug, wicked nbft has been implemented (https://jira.suse.com/browse/PED-3132).

It's provided in a `wicked-nbft` package and available in the installation system (see https://github.com/openSUSE/installation-images/pull/621/files), but the `wicked-nbft` package needs to be also selected for installation or the installed system will not work properly.

- https://bugzilla.suse.com/show_bug.cgi?id=1207573

## Solution

This option could be problematic in case that **NetworkManager** is selected at the end of the installation and therefore maybe the logic should be moved elsewhere.


