### PR TITLE
Prevent Crash if nil Product Dependencies instead of Empty List

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb  8 17:29:25 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent crash if nil dependencies instead of [] (bsc#1208068)
+- 4.5.14
+
+-------------------------------------------------------------------
 Thu Jan 26 13:52:26 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Added wicked-nbft package when Linuxrc sets UseNBFT

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.13
+Version:        4.5.14
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -152,10 +152,10 @@ module Y2Packager
         new_items.each do |p|
           # the dependencies contain also the transitive (indirect) dependencies,
           # we do not need to recursively evaluate the list
-          selected_items.concat(p.depends_on)
+          selected_items.concat(p&.depends_on)
         end
 
-        selected_items.uniq!
+        selected_items.uniq!.compact!
 
         Yast::UI.ChangeWidget(:addon_repos, :SelectedItems, selected_items)
       end


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1208068


## Trello

https://trello.com/c/HVBMy1Qf/


## Problem

"Internal error" crash when the SUSE Manager add-on product was selected.


## Cause

The dependencies of that add-on product were most likely specified wrong on the SCC or on the repo side: `nil` instead of an empty list `[ ]`.


## Fix

Made the code more robust against this sort of problem: It will most likely happen again in the future. Added the Ruby `&.` selector which survives a `nil`, unlike the normal `.`. Of course then the resulting list also needs to be filtered for `nil` with `compact()` or `compact!()`.


## Related Problem

That add-on product should actually have dependencies, at least the SLE-15 base product.