### PR TITLE
Fixed a crash when selecting depending products (bsc#1208421)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 20 14:25:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed a crash when selecting depending products (bsc#1208421)
+- 4.5.16
+
+-------------------------------------------------------------------
 Tue Feb 14 13:40:12 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Ruby 3.2: Change a test to treat dir:///foo equal to dir:/foo

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.15
+Version:        4.5.16
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -155,7 +155,8 @@ module Y2Packager
           selected_items.concat(p&.depends_on)
         end
 
-        selected_items.uniq!.compact!
+        selected_items.uniq!
+        selected_items.compact!
 
         Yast::UI.ChangeWidget(:addon_repos, :SelectedItems, selected_items)
       end

--- a/test/addon_selector_test.rb
+++ b/test/addon_selector_test.rb
@@ -11,7 +11,9 @@ describe Y2Packager::Dialogs::AddonSelector do
       Y2Packager::RepoProductSpec.new(name: "sle-module-basesystem", dir: "/Basesystem",
         base: false, media_name: "SLE-15-Module-Basesystem 15.3-0"),
       Y2Packager::RepoProductSpec.new(name: "sle-module-legacy", dir: "/Legacy",
-        base: false, media_name: "SLE-15-Module-Legacy 15.3-0")
+        base: false, media_name: "SLE-15-Module-Legacy 15.3-0"),
+      Y2Packager::RepoProductSpec.new(name: "sle-module-ha", dir: "/HA",
+        base: false, media_name: "SLE-15-Module-HA 15.3-0", depends_on: ["/Basesystem"])
     ]
   end
 
@@ -124,6 +126,28 @@ describe Y2Packager::Dialogs::AddonSelector do
 
         subject.create_dialog
       end
+    end
+  end
+
+  describe "#addon_repos_handler" do
+    it "selects the dependant products" do
+      # the product which just has been selected
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:addon_repos), :CurrentItem)
+        .and_return("/HA")
+      # all currently selected products
+      allow(Yast::UI).to receive(:QueryWidget).with(Id(:addon_repos), :SelectedItems)
+        .and_return(["/HA"])
+      # refreshing the details
+      allow(Yast::UI).to receive(:ChangeWidget)
+
+      # the dependant products are selected
+      expect(Yast::UI).to receive(:ChangeWidget) do |id, what, list|
+        if id == :addon_repos && what == :SelectedItems
+          expect(list).to include("/HA", "/Basesystem")
+        end
+      end
+
+      subject.addon_repos_handler
     end
   end
 end


### PR DESCRIPTION
## Problem

- Fixes a crash when selecting the HA product
- https://bugzilla.suse.com/show_bug.cgi?id=1208421

## Solution

- The `uniq!` call returns `nil` if there is no duplicate in the Array
- The `compact!` call must not be chained, it needs to be called on the variable again

## Testing

- Added a new unit test
