### PR TITLE
Fixed crash when selecting incompatible modules/extensions (bsc#1210668)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  5 08:34:49 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed crash when selecting incompatible modules/extensions from
+  the Full medium in SLED (bsc#1210668)
+- 4.5.17
+
+-------------------------------------------------------------------
 Mon Feb 20 14:25:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed a crash when selecting depending products (bsc#1208421)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.16
+Version:        4.5.17
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -152,7 +152,7 @@ module Y2Packager
         new_items.each do |p|
           # the dependencies contain also the transitive (indirect) dependencies,
           # we do not need to recursively evaluate the list
-          selected_items.concat(p&.depends_on)
+          selected_items.concat(p&.depends_on || [])
         end
 
         selected_items.uniq!


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1210668
- Selecting an incompatible module/extension from the Full medium without registration in SLED caused a crash

![SLED_crash](https://user-images.githubusercontent.com/907998/236415524-e4405653-5e7e-4d89-a5a1-e8c469b5b60c.png)

## Details

To get a module dependencies we load all modules/extensions on the medium to the pool, select a product from one module (subdirectory) and the base product and see which other products get selected by the solver. We save the dependent products and repeat this for all modules.

The problem is that e.g. the "sle-module-server-applications-release" has `Conflicts: product(SLED) >= 15.5`. This causes a solver error because the solver cannot select both (the module and the SLED base product). This results in `nil` to indicate a dependency issue.

## Solution

- Avoid using `nil` when evaluating the module dependencies

## Testing

- Tested manually, with the patch the module can be selected without crash

![SLED_crash_fixed](https://user-images.githubusercontent.com/907998/236416229-b61284fc-8d00-4380-82d3-6c977c255151.png)

## Notes

Selecting an incompatible module causes dependency issues later. Later I'd like to display a confirmation popup to ask the user to really use it. This is a minimal fix for SP5.
