### PR TITLE
Move loading the Pkg module (bsc#1214069)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug  8 11:22:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Move loading the Pkg module to fix a failing unit test (bsc#1214069)
+- 4.6.2
+
+-------------------------------------------------------------------
 Thu Apr  6 10:17:23 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt test to changes in ruby-bindings when detecting Yast

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -17,6 +17,7 @@ require "packager/cfa/zypp_conf"
 require "packager/cfa/dnf_conf"
 
 Yast.import "InstURL"
+Yast.import "Pkg"
 
 module Yast
   # Finish client for packager
@@ -44,7 +45,6 @@ module Yast
       super
       textdomain "packager"
 
-      Yast.import "Pkg"
       Yast.import "Installation"
       Yast.import "Mode"
       Yast.import "Stage"


### PR DESCRIPTION
## Problem

An unit test was failing with:

```
#<Yast::Y2Logger:0x0000564073c899e8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x0000564073c89970 @datetime_format=nil>, @formatter=nil, @logdev=nil> received :warn with unexpected arguments
  expected: (/no repos in \/tmp\/d20230808-26505-18t0hzw\/repos.d/)
       got: ("No widget with ID `id (`contents) in the current dialog")
Diff:
@@ -1 +1 @@
-[/no repos in \/tmp\/d20230808-26505-18t0hzw\/repos.d/]
+["No widget with ID `id (`contents) in the current dialog"]
       
# /usr/share/YaST2/modules/Progress.rb:906:in `try_replace_widget'
# /usr/share/YaST2/modules/Progress.rb:450:in `New'
# /usr/share/YaST2/modules/PackageCallbacks.rb:2491:in `ProcessStart'
# ./src/lib/packager/clients/pkg_finish.rb:93:in `write'
# /usr/share/YaST2/lib/installation/finish_client.rb:57:in `run'
# ./test/pkg_finish_test.rb:349:in `block (5 levels) in <top (required)>'
```

After some experimenting it turned out that the `Pkg` mocking for some reason does not work if the `Pkg` module is loaded  later. It executed the real `Pkg` code resulting in the error above.