### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,31 +2,19 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
-- backport:
--- Fixed crash when selecting incompatible modules/extensions from
-   the Full medium in SLED (bsc#1210668)
+- backport from TW:
+-- Move loading the Pkg module to fix a failing unit test (bsc#1214069)
+-- Adapt test to changes in ruby-bindings when detecting Yast
+   modules using public only methods (related to bsc#1210051)
+-- Comment out expensive debug calls to improve performance
+   (bsc#1210051)
 - 4.6.3
 
 -------------------------------------------------------------------
-Tue Aug  8 11:22:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
-
-- Move loading the Pkg module to fix a failing unit test (bsc#1214069)
-- 4.6.2
-
--------------------------------------------------------------------
-Thu Apr  6 10:17:23 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
-
-- Adapt test to changes in ruby-bindings when detecting Yast
-  modules using public only methods (related to bsc#1210051)
-- Comment out expensive debug calls to improve performance
-  (bsc#1210051)
-- 4.6.1
-
--------------------------------------------------------------------
-Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
-
-- Bump version to 4.6.0 (bsc#1208913)
-
+Fri May  5 08:34:49 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+- Fixed crash when selecting incompatible modules/extensions from
+  the Full medium in SLED (bsc#1210668)
+- 4.5.17
 -------------------------------------------------------------------
 Mon Feb 20 14:25:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 

--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -2,13 +2,30 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- backport:
+-- Fixed crash when selecting incompatible modules/extensions from
+   the Full medium in SLED (bsc#1210668)
+- 4.6.3
 
 -------------------------------------------------------------------
-Fri May  5 08:34:49 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+Tue Aug  8 11:22:18 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
-- Fixed crash when selecting incompatible modules/extensions from
-  the Full medium in SLED (bsc#1210668)
-- 4.5.17
+- Move loading the Pkg module to fix a failing unit test (bsc#1214069)
+- 4.6.2
+
+-------------------------------------------------------------------
+Thu Apr  6 10:17:23 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt test to changes in ruby-bindings when detecting Yast
+  modules using public only methods (related to bsc#1210051)
+- Comment out expensive debug calls to improve performance
+  (bsc#1210051)
+- 4.6.1
+
+-------------------------------------------------------------------
+Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump version to 4.6.0 (bsc#1208913)
 
 -------------------------------------------------------------------
 Mon Feb 20 14:25:37 UTC 2023 - Ladislav Slezák <lslezak@suse.com>

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.0
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -17,6 +17,7 @@ require "packager/cfa/zypp_conf"
 require "packager/cfa/dnf_conf"
 
 Yast.import "InstURL"
+Yast.import "Pkg"
 
 module Yast
   # Finish client for packager
@@ -44,7 +45,6 @@ module Yast
       super
       textdomain "packager"
 
-      Yast.import "Pkg"
       Yast.import "Installation"
       Yast.import "Mode"
       Yast.import "Stage"

--- a/src/lib/packager/product_patterns.rb
+++ b/src/lib/packager/product_patterns.rb
@@ -99,7 +99,8 @@ module Yast
         end
       end
 
-      log.debug "Product #{product} depependencies: #{product_dependencies}"
+      # commented out block debug call until issue is fixed: https://github.com/yast/yast-ruby-bindings/issues/290
+      # log.debug { "Product #{product} depependencies: #{product_dependencies}" }
 
       product_dependencies
     end
@@ -131,7 +132,8 @@ module Yast
         provides << prov if prov
       end
 
-      log.debug "Collected provides dependencies: #{provides.inspect}"
+      # commented out block debug call until issue is fixed: https://github.com/yast/yast-ruby-bindings/issues/290
+      # log.debug { "Collected provides dependencies: #{provides.inspect}" }
 
       provides
     end

--- a/test/addon_selector_test.rb
+++ b/test/addon_selector_test.rb
@@ -66,7 +66,8 @@ describe Y2Packager::Dialogs::AddonSelector do
 
       it "does not display any popup" do
         # stub empty Yast::Popup so any method call would raise an exception
-        stub_const("Yast::Popup", double)
+        # at least one public method is mandatory, otherwise import init it again
+        stub_const("Yast::Popup", double({ do_not_import_again: true }))
         subject.next_handler
       end
     end

--- a/test/pkg_finish_test.rb
+++ b/test/pkg_finish_test.rb
@@ -357,7 +357,7 @@ describe Yast::PkgFinishClient do
 
       context "if libzypp's minimalistic configuration is enabled" do
         let(:minimalistic_libzypp_config) { true }
-        let(:destdir) { tmpdir }
+        let(:destdir) { tmpdir.to_s }
 
         before do
           conf_file = File.join(tmpdir, Yast::Packager::CFA::ZyppConf::PATH)


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

Use both patches from master, but as it contain also patch that is not in master, it is not same code wise and needs also version bump.