### PR TITLE
[SLE-15-SP6] Properly save the repo file (bsc#1214135)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Sep 20 09:08:59 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Properly save the repo file when changing URL of a repository
+  from a service (bsc#1214135)
+- Also display a warning when changing URL of a service repository,
+  the change might be lost after the service is refreshed
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.3
+Version:        4.6.4
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -38,8 +38,8 @@ BuildRequires:  yast2-storage-ng >= 4.0.141
 #!BuildIgnore: yast2-packager
 # Replace PackageSystem with Package
 BuildRequires:  yast2 >= 4.4.38
-# raw_name
-BuildRequires:  yast2-pkg-bindings >= 4.2.8
+# "service" attribute in Pkg.SourceEditSet()
+BuildRequires:  yast2-pkg-bindings >= 4.6.4
 # yast/rspec/helpers.rb
 BuildRequires:  yast2-ruby-bindings >= 4.4.7
 # Augeas lenses
@@ -48,8 +48,8 @@ BuildRequires:  ruby-solv
 
 # Newly added RPM
 Requires:       yast2-country-data >= 2.16.3
-# raw_name
-Requires:       yast2-pkg-bindings >= 4.2.8
+# "service" attribute in Pkg.SourceEditSet()
+Requires:       yast2-pkg-bindings >= 4.6.4
 # Replace PackageSystem with Package
 Requires:       yast2 >= 4.4.38
 # unzipping license file

--- a/src/lib/packager/clients/repositories.rb
+++ b/src/lib/packager/clients/repositories.rb
@@ -1854,6 +1854,8 @@ module Yast
         end
 
         if !same_url || plaindir != SourceDialogs.IsPlainDir
+          warn_service_repository(source_state)
+
           Builtins.y2milestone(
             "URL or plaindir flag changed, recreating the source"
           )
@@ -1896,13 +1898,15 @@ module Yast
                 "priority",
                 @default_priority
               )
+              service = source_state["service"] || ""
               Builtins.y2milestone(
                 "Restoring the original properties: enabled: %1, autorefresh: %2, " \
-                "keeppackages: %3, priority: %4",
+                "keeppackages: %3, priority: %4, service: %5",
                 enabled,
                 auto_refresh,
                 keeppackages,
-                priority
+                priority,
+                service
               )
 
               # set the original properties
@@ -1910,6 +1914,7 @@ module Yast
               Ops.set(addedSource, "keeppackages", keeppackages)
               Ops.set(addedSource, "enabled", enabled)
               Ops.set(addedSource, "priority", priority)
+              Ops.set(addedSource, "service", service)
 
               # get the ID of the old repo and mark it for removal
               srcid = Ops.get_integer(


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1214135
- When changing URL of a repository belonging to a service the service name is lost in the `*.repo` file
- The result is that the repository is not linked to the service and refreshing the service fails because there is a conflict between the "standalone" repository and the repository coming from the service

## Details

```console
# zypper install openSUSE-repos-Tumbleweed
# zypper refresh -s
** list the original repo file **
# cat /etc/zypp/repos.d/openSUSE\:repo-non-oss.repo 
[openSUSE:repo-non-oss]
name=repo-non-oss
enabled=1
autorefresh=1
baseurl=http://cdn.opensuse.org/tumbleweed//repo/non-oss
service=openSUSE
# yast2 repositories 
** change the URL of the repo-non-oss repository, just change the http:// protocol to https:// **
# cat /etc/zypp/repos.d/openSUSE\:repo-non-oss.repo 
[openSUSE:repo-non-oss]
name=repo-non-oss
enabled=1
autorefresh=1
baseurl=https://cdn.opensuse.org/tumbleweed//repo/non-oss
path=/
type=rpm-md
keeppackages=0
** the "service" line is missing here! **
# zypper ref -s
Refreshing service 'openSUSE'.
Adding repository 'repo-non-oss' ........................................[error]
Unexpected exception.
[openSUSE:repo-non-oss|http://cdn.opensuse.org/tumbleweed//repo/non-oss] Repository already exists.
** so then refreshing the service fails **
```
The problem is that the `service=openSUSE` line is lost. On the other hand it added some more lines, but these lines just contain the defaults, the meaning is the same as if they were missing.

## Solution

- Changing the URL is a bit tricky, in that case YaST actually deletes the old repository (to force removing all cached files) and creates a new repository with the new URL. Then YaST copies all attributes (enabled/disabled, priority,...) from the old repository to the new one.
- And here was the bug, YaST did not copy the "service" attribute so the new repository had the same name as the old one, but was not bound to the original service. For libzypp it looks like a standalone repository and when libzypp refreshed the service it found out that a conflicting repository already exists.
- Also see https://github.com/yast/yast-pkg-bindings/pull/181, this requires a small update in the pkg-bindings package

## Testing

- Tested manually

```console
# yast2 repositories
** change the URL of the repo-non-oss repository **
# cat /etc/zypp/repos.d/openSUSE\:repo-non-oss.repo 
[openSUSE:repo-non-oss]
name=repo-non-oss
enabled=1
autorefresh=1
baseurl=https://cdn.opensuse.org/tumbleweed//repo/non-oss
path=/
type=rpm-md
keeppackages=0
service=openSUSE
** the "service" line is correctly saved **
# zypper refresh -s
Refreshing service 'openSUSE'.
All services have been refreshed.
...
All repositories have been refreshed.
** refresh succeeded **
```

When changing a repository which does not belong to any service the `service` line is *not* added so there is no regression.

## Screenshots

- Additionally a warning is displayed when changing the repository URL
- The same warning is already displayed when changing other repository attributes (enabled/disabled, priority,...), it was missing when changing the URL
![service_warning](https://github.com/yast/yast-packager/assets/907998/506ddcab-8cd0-4efb-8e8b-43ce65bb4d9a)

