### PR TITLE
Disable empty Online medium repository (bsc#1182303)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan  9 13:39:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- After installation disable the empty installation repository
+  from the SLE15 Online medium (bsc#1182303)
+- 4.5.18
+
+-------------------------------------------------------------------
 Fri May  5 08:34:49 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed crash when selecting incompatible modules/extensions from

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.17
+Version:        4.5.18
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/packager/clients/pkg_finish.rb
+++ b/src/lib/packager/clients/pkg_finish.rb
@@ -13,6 +13,7 @@
 
 require "installation/finish_client"
 require "y2packager/repository"
+require "y2packager/resolvable"
 require "packager/cfa/zypp_conf"
 require "packager/cfa/dnf_conf"
 
@@ -192,7 +193,10 @@ module Yast
       log.info "Not installed base products: #{non_installed_base.map(&:name)} "
 
       local_repos.each_with_object([]) do |repo, disabled|
-        if repo.products.empty?
+        # No product but the repository is not empty => most likely a 3rd party
+        # repository, do not touch it.
+        # The empty repository on the SLE Online medium is disabled by the code below.
+        if repo.products.empty? && Y2Packager::Resolvable.any?(kind: :package, source: repo.repo_id)
           log.info("Repo #{repo.repo_id} (#{repo.name}) does not have products; ignored")
           next
         end

--- a/test/pkg_finish_test.rb
+++ b/test/pkg_finish_test.rb
@@ -184,6 +184,7 @@ describe Yast::PkgFinishClient do
             .to receive(:GetBooleanFeature)
             .with("software", "disable_media_repo")
             .and_return(true)
+          allow(Y2Packager::Resolvable).to receive(:any?).and_return(false)
         end
 
         context "dvd repo is disabled even if base products aren't available using other repos" do
@@ -226,9 +227,10 @@ describe Yast::PkgFinishClient do
         end
       end
 
-      context "if does not contain any product" do
+      context "if does not contain any product but is not empty" do
         before do
           allow(local_repo).to receive(:products).and_return([])
+          allow(Y2Packager::Resolvable).to receive(:any?).and_return(true)
         end
 
         it "does not disable the local repository" do


### PR DESCRIPTION
## Problem

- After installation using the Online medium the empty repository in the system is enabled
- That might cause some troubles if libzypp for some reason wants to refresh the repository and the DVD medium had been removed in the meantime
- https://bugzilla.suse.com/show_bug.cgi?id=1182303

## Solution

- Do not skip empty repositories when disabling the local CD/DVD repositories

## Testing

- Updated unit test
- Tested manually

#### Original Behavior
```
# zypper lr -u | grep cd:
11 | SLES15-SP5-15.5-0 | SLES15-SP5-15.5-0 | Yes | (r ) Yes | No | cd:/?devices=/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376
```
y2log:
```
[Ruby] clients/pkg_finish.rb(block in disable_local_repos):196 Repo 24 (SLES15-SP5-15.5-0) does not have products; ignored
```

#### With the Fix

```
# zypper lr -u | grep cd:
11 | SLES15-SP5-15.5-0 | SLES15-SP5-15.5-0 | No | ----| ----| cd:/?devices=/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376
```

y2log:
```
[Ruby] clients/pkg_finish.rb(block in disable_local_repos):206 Repo 24 (SLES15-SP5-15.5-0) is at CD / DVD; disabling
```

I have tested that also with the Full installation medium and it keeps the original behavior unchanged:

```
# zypper lr -u 
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias                             | Name                           | Enabled | GPG Check | Refresh | URI
--+-----------------------------------+--------------------------------+---------+-----------+---------+----------------------------------------------------------
1 | Basesystem-Module_15.5-0          | sle-module-basesystem          | No      | ----      | ----    | cd:/?devices=/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376
2 | SLES15-SP5-15.5-0                 | SLES15-SP5-15.5-0              | No      | ----      | ----    | cd:/?devices=/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376
3 | Server-Applications-Module_15.5-0 | sle-module-server-applications | No      | ----      | ----    | cd:/?devices=/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376
```

y2log:
```
[Ruby] clients/pkg_finish.rb(block in disable_local_repos):206 Repo 2 (SLES15-SP5-15.5-0) is at CD / DVD; disabling
[Ruby] clients/pkg_finish.rb(block in disable_local_repos):206 Repo 6 (sle-module-basesystem) is at CD / DVD; disabling
[Ruby] clients/pkg_finish.rb(block in disable_local_repos):206 Repo 7 (sle-module-server-applications) is at CD / DVD; disabling
```
On the Full medium all installation repositories are always disabled.