### PR TITLE
[SLE15-SP5] Fixed ERB template loading in self update (bsc#1219174)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb  8 13:49:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed ERB template loading in self update, if the template
+  cannot be found using a relative path then fallback to the
+  absolute path (bsc#1219174)
+- 4.5.19
+
+-------------------------------------------------------------------
 Tue Jan  9 13:39:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - After installation disable the empty installation repository

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.18
+Version:        4.5.19
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/dialogs/addon_selector.rb
+++ b/src/lib/y2packager/dialogs/addon_selector.rb
@@ -219,7 +219,18 @@ module Y2Packager
       end
 
       def product_description(product)
+        # first try the relative path
         erb_file = File.join(__dir__, "product_summary.erb")
+
+        # in self update mode the some files might be updated and placed in
+        # a different directory and symlinked, but as Ruby uses absolute path
+        # for __dir__ then the relative file might not be found
+        if !File.exist?(erb_file)
+          log.info "ERB template #{erb_file} not found"
+          # use the absolute path as a fallback
+          erb_file = "/usr/share/YaST2/lib/y2packager/dialogs/product_summary.erb"
+        end
+
         log.info "Loading ERB template #{erb_file}"
         erb = ERB.new(File.read(erb_file))
 


### PR DESCRIPTION
## Problem

![self_update_failure](https://github.com/yast/yast-packager/assets/907998/56f61151-a390-4f6a-be9e-2fe1dac56561)

- https://bugzilla.suse.com/show_bug.cgi?id=1219174 - YaST crashes after applying self updates
- The self update process overrides only the modified files to save memory in the inst-sys.
- The modified files are placed into `/mounts/yast_0000/...` subdirectory
- But as Ruby uses `/mounts/yast_0000/...` path for the `__dir__` value in the Ruby file then the relative ERB template is not found because it was not modified and still lives in the original location at `/usr/share/...`.

## Solution

- If the template cannot be found using a relative path then fallback to the absolute path

## Testing

- Tested manually, the crash is fixed


