### PR TITLE
SLE HPC is not a base product anymore (jsc#PED-7841)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 13 16:40:17 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- SLE HPC is not a base product anymore, it is replaced by
+  SLES + HPC module, added migration mapping (jsc#PED-7841)
+- 4.6.7
+
+-------------------------------------------------------------------
 Thu Feb  8 13:49:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed ERB template loading in self update, if the template

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.6
+Version:        4.6.7
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/lib/y2packager/product_upgrade.rb
+++ b/src/lib/y2packager/product_upgrade.rb
@@ -25,14 +25,12 @@ module Y2Packager
     # maps installed products to a new available base product
     # rubocop:disable Layout/LineLength
     MAPPING = {
-      # SLES12 + HPC module => SLESHPC15
-      # (a bit tricky, the module became a new base product!)
-      ["SLES", "sle-module-hpc"]                                          => "SLE_HPC",
       ["SLES", "SUSE-Manager-Proxy"]                                      => "SUSE-Manager-Proxy",
       ["SLES", "SUSE-Manager-Server"]                                     => "SUSE-Manager-Server",
       ["SLES", "SUSE-Manager-Proxy", "SUSE-Manager-Retail-Branch-Server"] => "SUSE-Manager-Retail-Branch-Server",
-      # this is an internal product so far...
-      ["SLE-HPC"]                                                         => "SLE_HPC",
+      # SLE HPC is not a base product anymore, it is SLES + HPC module now
+      ["SLE-HPC"]                                                         => "SLES",
+      ["SLE_HPC"]                                                         => "SLES",
       # SLES11 => SLES15
       ["SUSE_SLES"]                                                       => "SLES",
       # SLED11 => SLED15

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -28,10 +28,9 @@ module Yast
       # SLE12 HA GEO is now included in SLE15 HA
       "sle-ha-geo"                        => ["sle-ha"],
       "SUSE_SLES_SAP"                     => ["SLES_SAP"],
-      # SLES-12 with HPC module can be replaced by SLE_HPC-15
-      "SLES"                              => ["SLE_HPC"],
-      # this is an internal product so far...
-      "SLE-HPC"                           => ["SLE_HPC"],
+      # SLE HPC is not a base product anymore, it is SLES + HPC module now
+      "SLE-HPC"                           => ["SLES", "sle-module-hpc"],
+      "SLE_HPC"                           => ["SLES", "sle-module-hpc"],
       # SMT is now integrated into the base SLES
       "sle-smt"                           => ["SLES"],
       # Live patching is a module now (bsc#1074154)

--- a/test/lib/product_upgrade_test.rb
+++ b/test/lib/product_upgrade_test.rb
@@ -48,7 +48,7 @@ describe Y2Packager::ProductUpgrade do
     context "several base products are available" do
       before do
         expect(Y2Packager::ProductSpec).to receive(:base_products)
-          .and_return([product1, product2, sles, sles_hpc]).at_least(:once)
+          .and_return([product1, product2, sles]).at_least(:once)
       end
 
       context "the new base product is found in the fallback mapping" do
@@ -57,10 +57,10 @@ describe Y2Packager::ProductUpgrade do
           expect(described_class.new_base_product).to be(sles)
         end
 
-        it "returns SLE_HPC for SLES and HPC module installed" do
+        it "returns SLES for installed SLE-HPC" do
           expect(Y2Packager::Product).to receive(:installed_products)
-            .and_return([sles, hpc_module])
-          expect(described_class.new_base_product).to be(sles_hpc)
+            .and_return([sles_hpc])
+          expect(described_class.new_base_product).to be(sles)
         end
       end
 
@@ -86,7 +86,7 @@ describe Y2Packager::ProductUpgrade do
         expect(Y2Packager::Product).to receive(:installed_products)
           .and_return([sles, suma_proxy, suma_branch_server])
         expect(Y2Packager::ProductSpec).to receive(:base_products)
-          .and_return([sles, sles_hpc, suma_proxy, suma_branch_server])
+          .and_return([sles, suma_proxy, suma_branch_server])
 
         expect(described_class.new_base_product).to be(suma_branch_server)
       end
@@ -96,7 +96,7 @@ describe Y2Packager::ProductUpgrade do
   describe ".will_be_obsoleted_by" do
     before do
       expect(Y2Packager::Product).to receive(:with_status).with(:selected)
-        .and_return([Y2Packager::Product.new(name: "SLE_HPC")])
+        .and_return([Y2Packager::Product.new(name: "SLES")])
     end
 
     context "given product is not installed" do
@@ -110,7 +110,7 @@ describe Y2Packager::ProductUpgrade do
     context "given product is installed but not required module" do
       it "returns an empty array" do
         expect(Y2Packager::Product).to receive(:installed_products)
-          .and_return([sles, sles_hpc])
+          .and_return([sles])
         expect(described_class.will_be_obsoleted_by("SLES")).to be_empty
       end
     end
@@ -118,8 +118,8 @@ describe Y2Packager::ProductUpgrade do
     context "given product and the required module is installed" do
       it "returns the product which obsoletes the old one" do
         expect(Y2Packager::Product).to receive(:installed_products)
-          .and_return([sles, hpc_module])
-        expect(described_class.will_be_obsoleted_by("SLES")).to contain_exactly("SLE_HPC")
+          .and_return([sles_hpc, hpc_module])
+        expect(described_class.will_be_obsoleted_by("SLE_HPC")).to contain_exactly("SLES")
       end
     end
   end


### PR DESCRIPTION
## Problem

- In SP6 SLE-HPC won't be a separate base product, it will be replaced by SLES + HPC module
- We need to handle the product change during migration/upgrade
- https://jira.suse.com/browse/PED-7841

## Solution

- Updated product mapping

## Testing

- Updated unit test