### PR TITLE
[SLE15-SP6] Better summary for the SLE_HPC => SLES upgrade (jsc#PED-7841)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 22 09:34:54 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Display a better product summary for the SLE_HPC => SLES upgrade
+  (jsc#PED-7841)
+- 4.6.8
+
+-------------------------------------------------------------------
 Tue Feb 13 16:40:17 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - SLE HPC is not a base product anymore, it is replaced by

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.7
+Version:        4.6.8
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -28,9 +28,9 @@ module Yast
       # SLE12 HA GEO is now included in SLE15 HA
       "sle-ha-geo"                        => ["sle-ha"],
       "SUSE_SLES_SAP"                     => ["SLES_SAP"],
-      # SLE HPC is not a base product anymore, it is SLES + HPC module now
-      "SLE-HPC"                           => ["SLES", "sle-module-hpc"],
-      "SLE_HPC"                           => ["SLES", "sle-module-hpc"],
+      # SLE HPC is not a base product anymore, it is SLES (+ HPC module) now
+      "SLE-HPC"                           => ["SLES"],
+      "SLE_HPC"                           => ["SLES"],
       # SMT is now integrated into the base SLES
       "sle-smt"                           => ["SLES"],
       # Live patching is a module now (bsc#1074154)


### PR DESCRIPTION
## Problem

- Related to #650, https://jira.suse.com/browse/PED-7841
- The display product summary at a SLE_HPC upgrade was not perfect:
  - New SLES will be installed
  - SLE_HPC will be upgraded to HPC module
  ![hpc_upgrade_sp6](https://github.com/yast/yast-packager/assets/907998/5e5d2361-cf12-45a3-b7c0-1b75d9ad72f6)

- That is technically correct, but it actually is SLE_HPC => SLES base product upgrade/migration and the HPC module upgrade to a newer version


## Solution

- Update the product rename mapping

## Technical Details

Originally it was `"SLE_HPC" => ["SLES", "sle-module-hpc"]` mapping. But because the old SLE_HPC required the HPC module (a hard dependency, you cannot have SLE_HPC without the HPC module) then the real upgrade is not "SLE_HPC => SLES + HPC" but rather "SLE_HPC + HPC => SLES + HPC". And in that case we can remove the HPC module from the mapping because it will be automatically upgraded to the new available version.

If the HPC module was optional for SLE_HPC we would have to add it to the mapping, but as it was mandatory we can leave it out.

That mapping is used when finding the product upgrades for the upgrade summary. The extra HPC value confuses the algorithm and it thinks the SLE_HPC is upgraded to the HPC module.

## Testing

- Tested manually
  
![hpc_upgrade_sp6_better](https://github.com/yast/yast-packager/assets/907998/af30297f-5bfe-40eb-8f3b-e9dc92eed75e)

