### PR TITLE
[SLE15-SP5] Fixed online migration from SLE_HPC to SLES SP6+ (bsc#1220567)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar  8 14:08:48 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Reimplemented the hardcoded product mapping to support also the
+  migration from SLE_HPC to SLES SP6+ (with the HPC module)
+  (bsc#1220567)
+- 4.5.20
+
+-------------------------------------------------------------------
 Thu Feb  8 13:49:00 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Fixed ERB template loading in self update, if the template

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.5.19
+Version:        4.5.20
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -77,6 +77,8 @@ Requires:       ruby-solv
 Conflicts:      yast2-core < 2.15.10
 # NotEnoughMemory-related functions moved to misc.ycp import-file
 Conflicts:      yast2-add-on < 2.15.15
+# changed API in Y2Packager::ProductUpgrade and Yast::AddOnProduct
+Conflicts:      yast2-registration < 4.5.9
 
 # ensure that 'checkmedia' is on the medium
 Recommends:     checkmedia

--- a/src/lib/y2packager/product_upgrade.rb
+++ b/src/lib/y2packager/product_upgrade.rb
@@ -25,9 +25,6 @@ module Y2Packager
     # maps installed products to a new available base product
     # rubocop:disable Layout/LineLength
     MAPPING = {
-      # SLES12 + HPC module => SLESHPC15
-      # (a bit tricky, the module became a new base product!)
-      ["SLES", "sle-module-hpc"]                                          => "SLE_HPC",
       ["SLES", "SUSE-Manager-Proxy"]                                      => "SUSE-Manager-Proxy",
       ["SLES", "SUSE-Manager-Server"]                                     => "SUSE-Manager-Server",
       ["SLES", "SUSE-Manager-Proxy", "SUSE-Manager-Retail-Branch-Server"] => "SUSE-Manager-Retail-Branch-Server",
@@ -52,6 +49,8 @@ module Y2Packager
       # in the src/modules/AddOnProduct.rb file, maybe it needs an update as well...
     }.freeze
 
+    private_constant :MAPPING
+
     # This maps uses a list of installed products as the key and the removed products as a value.
     # All products in key have to be installed.
     # It is used in special cases when the removed product is still available on the medium
@@ -65,7 +64,33 @@ module Y2Packager
     }.freeze
     # rubocop:enable Layout/LineLength
 
+    private_constant :UPGRADE_REMOVAL_MAPPING
+
     class << self
+      # flag for using old (<= SLE15-SP5-) or new (>= SLE15-SP6) product mapping
+      attr_accessor :new_renames
+
+      def mapping
+        # special handling for the HPC product
+        product_mapping = if new_renames
+          {
+            # in SLE15-SP6+ SLE_HPC is replaced by SLES + HPC module
+            ["SLE-HPC"] => "SLES",
+            ["SLE_HPC"] => "SLES"
+          }
+        else
+          {
+            # SLES12 + HPC module => SLESHPC15
+            # (a bit tricky, the module became a new base product!)
+            ["SLES", "sle-module-hpc"] => "SLE_HPC",
+            # different ID
+            ["SLE-HPC"]                => "SLE_HPC"
+          }
+        end
+
+        product_mapping.merge!(MAPPING)
+      end
+
       # Find a new available base product which upgrades the installed base product.
       #
       # The workflow to find the new base product is:
@@ -117,18 +142,20 @@ module Y2Packager
         installed = Y2Packager::Product.installed_products.map(&:name)
         selected_products = Y2Packager::Product.with_status(:selected).map(&:name)
 
+        product_mapping = mapping
+
         # the "sort_by(&:size).reverse" part ensures we try first the longer
         # mappings (more installed products) to find more specific matches
-        old_products = MAPPING.keys.sort_by(&:size).reverse.find do |products|
+        old_products = product_mapping.keys.sort_by(&:size).reverse.find do |products|
           # the product is included in the mapping key and all product mapping key
           # products are installed and the replacement products are selected
           products.include?(old_product_name) && (products - installed).empty? &&
-            selected_products.include?(MAPPING[products])
+            selected_products.include?(product_mapping[products])
         end
 
         return [] unless old_products
 
-        [MAPPING[old_products]]
+        [product_mapping[old_products]]
       end
 
       # Returns the products which are upgraded by the solver but should be actually
@@ -177,18 +204,20 @@ module Y2Packager
       def find_by_mapping(available)
         installed = Y2Packager::Product.installed_products
 
+        product_mapping = mapping
+
         # sort the keys by length, try more products first
         # to find the most specific upgrade, prefer the
         # SLES + sle-module-hpc => SLE_HPC upgrade to plain SLES => SLES upgrade
         # (if that would be in the list)
-        upgrade = MAPPING.keys.sort_by(&:size).reverse.find do |keys|
+        upgrade = product_mapping.keys.sort_by(&:size).reverse.find do |keys|
           keys.all? { |name| installed.any? { |p| p.name == name } }
         end
 
         log.info("Fallback upgrade for products: #{upgrade.inspect}")
         return nil unless upgrade
 
-        name = MAPPING[upgrade]
+        name = product_mapping[upgrade]
         product = available.find { |p| p.name == name }
         log.info("New product: #{product}")
         product

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -28,10 +28,6 @@ module Yast
       # SLE12 HA GEO is now included in SLE15 HA
       "sle-ha-geo"                        => ["sle-ha"],
       "SUSE_SLES_SAP"                     => ["SLES_SAP"],
-      # SLES-12 with HPC module can be replaced by SLE_HPC-15
-      "SLES"                              => ["SLE_HPC"],
-      # this is an internal product so far...
-      "SLE-HPC"                           => ["SLE_HPC"],
       # SMT is now integrated into the base SLES
       "sle-smt"                           => ["SLES"],
       # Live patching is a module now (bsc#1074154)
@@ -51,6 +47,29 @@ module Yast
       # NOTE: if you change anything here then check the MAPPING value
       # in the src/lib/y2packager/product_upgrade.rb file, maybe it needs an update as well...
     }.freeze
+
+    private_constant :DEFAULT_PRODUCT_RENAMES
+
+    attr_accessor :new_renames
+
+    def default_product_renames
+      # special handling for the HPC product
+      product_mapping = if new_renames
+        {
+          # in SLE15-SP6+ SLE_HPC is replaced by SLES + HPC module
+          "SLE-HPC" => ["SLES"],
+          "SLE_HPC" => ["SLES"]
+        }
+      else
+        {
+          # in SLE15 SP5 (or older) the SLES + HPC module is upgraded to SLE_HPC
+          "SLES"    => ["SLE_HPC"],
+          "SLE-HPC" => ["SLE_HPC"]
+        }
+      end
+
+      product_mapping.merge!(DEFAULT_PRODUCT_RENAMES)
+    end
 
     # @return [Hash] Product renames added externally through the #add_rename method
     attr_accessor :external_product_renames
@@ -2015,7 +2034,7 @@ module Yast
 
       # handle the product renames, if a renamed product was installed
       # replace it with the new product so the new product is preselected
-      DEFAULT_PRODUCT_RENAMES.each do |k, v|
+      default_product_renames.each do |k, v|
         next unless installed_addons.include?(k)
 
         installed_addons.delete(k)
@@ -2106,12 +2125,12 @@ module Yast
 
     # Determine whether a product rename is included in the fallback map
     #
-    # @see DEFAULT_PRODUCT_RENAMES
+    # @see default_product_renames
     # @see #renamed_at?
     def renamed_by_default?(old_name, new_name)
       log.info "Search #{old_name} -> #{new_name} rename in default map: " \
-               "#{DEFAULT_PRODUCT_RENAMES.inspect}"
-      renamed_at?(DEFAULT_PRODUCT_RENAMES, old_name, new_name)
+               "#{default_product_renames.inspect}"
+      renamed_at?(default_product_renames, old_name, new_name)
     end
 
     # Determine whether a product rename is present on a given hash


### PR DESCRIPTION
## Problem

- In SP6 the SLE_HPC product is dropped and replaced by SLES + HPC module
- We need to backport the #650 and #652 pulls to the SLE15-SP5 branch because in online migration (in installed system) the migration to SP6 runs using the original SP5 code. We need to fix the HPC SP5 -> SLES SP6 migration case.
- The problem is that YaST does not recognize the HPC -> SLES migration correctly, it sees installing SLES and removing HPC which is evaluated as a possibly dangerous operation and results in an error in the summary
- https://bugzilla.suse.com/show_bug.cgi?id=1220567

The original error:
![hpc_online_migration_sp5_sp6_broken](https://github.com/yast/yast-packager/assets/907998/aaacbead-55f2-4136-8582-fb036b9f67ff)
![hpc_online_migration_sp5_sp6_broken_summary](https://github.com/yast/yast-packager/assets/907998/ec305d98-2800-477c-9081-50ae7e90d94b)

## Notes

- Additional problem is that the SP5 maintenance update will sooner or later land in the SP5 QU media. And that medium can be used for the SLE_HPC-SP4 -> SLE_HPC-SP5 migration. With the original SP6 patches it would migrate SLE_HPC-SP4 to SLES-SP5 which is not wanted here as we still provide HPC for SP5, the migration to SLES is need only in SP6+.

## Solution

- The code need to return a different product mapping for SP5  and SP6 (and newer).
- That also needs a change in the API because that mapping cannot be a constant anymore, it depends on the migration target.
- See also https://github.com/yast/yast-registration/pull/595 which activates the correct product mapping depending on the target version installed
- Additionally I grepped all YaST code to ensure the now private constants are not used elsewhere. They were only used in yast-registration which has been updated in https://github.com/yast/yast-registration/pull/595

## Testing

Tested in online (installed system) SP5->SP6 migration in a registered system (using SCC) to test that the original problem is fixed:
![hpc_online_migration_sp5_sp6_fixed](https://github.com/yast/yast-packager/assets/907998/9ee871e0-976c-4e40-a61b-56f7a68b25ee)
![hpc_online_migration_sp5_sp6_fixed_summary](https://github.com/yast/yast-packager/assets/907998/18bce6b2-f0fa-4af5-a26b-b60f3f263376)

Tested in offline (boot from installation medium) SP4->SP5 migration in a registered system (using SCC) to test that there is no regression when the patch gets released in the next QU:
![hpc_offline_migration_scc_sp4_sp5_fixed](https://github.com/yast/yast-packager/assets/907998/0753991b-9093-46f3-b1a6-52722832802e)
![hpc_offline_migration_scc_sp4_sp5_fixed_summary](https://github.com/yast/yast-packager/assets/907998/7ba64b3d-ccba-4e16-8a4e-b1da9f85a687)

Tested in offline (boot from installation medium) SP4->SP5 migration in a non-registered system (using packages from DVD medium) to test that there is no regression when the patch gets released in the next QU:
![hpc_onffline_migration_medium_sp4_sp5_fixed](https://github.com/yast/yast-packager/assets/907998/e6ebd66b-bd95-4a99-bea6-603656ce3c76)

