### PR TITLE
[SLE15-SP3] Fixed migration from SLE_HPC to SLES SP6+ (bsc#1220567)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar 11 15:36:54 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Reimplemented the hardcoded product mapping to support also the
+  migration from SLE_HPC to SLES SP6+ (with the HPC module)
+  (bsc#1220567)
+- 4.3.27
+
+-------------------------------------------------------------------
 Tue Mar 15 12:50:30 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
 
 - do not keep file handle to repo metadata open accidentally (bsc#1196061)

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.3.26
+Version:        4.3.27
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -75,6 +75,8 @@ Requires:       ruby-solv
 Conflicts:      yast2-core < 2.15.10
 # NotEnoughMemory-related functions moved to misc.ycp import-file
 Conflicts:      yast2-add-on < 2.15.15
+# changed API in Yast::AddOnProduct
+Conflicts:      yast2-registration < 4.3.29
 
 # ensure that 'checkmedia' is on the medium
 Recommends:     checkmedia


### PR DESCRIPTION
This is a partial backport of https://github.com/yast/yast-packager/pull/653 to SLE15-SP4. The other part of that backport is in https://github.com/yast/yast-yast2/pull/1307.
