### PR TITLE
[SLE15-SP6] Same product mapping API as in SP5 and older (bsc#1220567)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 12 13:43:26 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Change the product mapping API to be the same as in SP5 and older
+  (related to bsc#1220567)
+- 4.6.9
+
+-------------------------------------------------------------------
 Thu Feb 22 09:34:54 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Display a better product summary for the SLE_HPC => SLES upgrade

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        4.6.8
+Version:        4.6.9
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -77,6 +77,8 @@ Requires:       ruby-solv
 Conflicts:      yast2-core < 2.15.10
 # NotEnoughMemory-related functions moved to misc.ycp import-file
 Conflicts:      yast2-add-on < 2.15.15
+# changed API in Y2Packager::ProductUpgrade and Yast::AddOnProduct
+Conflicts:      yast2-registration < 4.6.1
 
 # ensure that 'checkmedia' is on the medium
 Recommends:     checkmedia

--- a/src/modules/AddOnProduct.rb
+++ b/src/modules/AddOnProduct.rb
@@ -51,6 +51,17 @@ module Yast
       # in the src/lib/y2packager/product_upgrade.rb file, maybe it needs an update as well...
     }.freeze
 
+    private_constant :DEFAULT_PRODUCT_RENAMES
+
+    # flag for using old or new product mapping, not used in SLE15-SP6+
+    attr_accessor :new_renames
+
+    def default_product_renames
+      # no special handling, the product renames is a static map in SLE15-SP6+,
+      # in SLE15-SP5 it is dynamic depending on the installed version
+      DEFAULT_PRODUCT_RENAMES
+    end
+
     # @return [Hash] Product renames added externally through the #add_rename method
     attr_accessor :external_product_renames
     private :external_product_renames, :external_product_renames=
@@ -2014,7 +2025,7 @@ module Yast
 
       # handle the product renames, if a renamed product was installed
       # replace it with the new product so the new product is preselected
-      DEFAULT_PRODUCT_RENAMES.each do |k, v|
+      default_product_renames.each do |k, v|
         next unless installed_addons.include?(k)
 
         installed_addons.delete(k)
@@ -2105,12 +2116,12 @@ module Yast
 
     # Determine whether a product rename is included in the fallback map
     #
-    # @see DEFAULT_PRODUCT_RENAMES
+    # @see default_product_renames
     # @see #renamed_at?
     def renamed_by_default?(old_name, new_name)
       log.info "Search #{old_name} -> #{new_name} rename in default map: " \
-               "#{DEFAULT_PRODUCT_RENAMES.inspect}"
-      renamed_at?(DEFAULT_PRODUCT_RENAMES, old_name, new_name)
+               "#{default_product_renames.inspect}"
+      renamed_at?(default_product_renames, old_name, new_name)
     end
 
     # Determine whether a product rename is present on a given hash


### PR DESCRIPTION
## Problem

- Related to #653
- That PR changed the API in SP5 and older
- Having a different API could make troubles in the future

## Solution

- Backport the API change to SP6

