### PR TITLE
Ruby 3.4 adaptation

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  6 10:45:35 UTC 2025 - Martin Vidner <mvidner@suse.com>
+
+- Adjust test for ruby-3.4 (bsc#1235099)
+- 5.0.6
+
+-------------------------------------------------------------------
 Tue Mar 12 13:43:26 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Change the product mapping API to be the same as in SP5 and older

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        5.0.5
+Version:        5.0.6
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later

--- a/test/packages_test.rb
+++ b/test/packages_test.rb
@@ -361,8 +361,9 @@ describe Yast::Packages do
 
       expect(Yast::Y2Logger.instance).to receive(:info) do |msg|
         expect(msg).to match(
-          /transaction\sstatus\s(begin|end)|resolvables\s
-           of\stype\s.*\sset\sby\s.*|:name=>.*:version=>/ix
+          /transaction\sstatus\s(begin|end)|
+           resolvables\sof\stype\s.*\sset\sby\s.*|
+           name[:=].*version[:=]/ix
         )
       end.exactly(8).times
 


### PR DESCRIPTION
## Problem

Hash#inspect output has changed
from `{:name=>"openSUSE", :version=>"13.1-1.10"}`
to   `{name: "openSUSE", version: "13.1-1.10"}`

the output goes to the log, is not parsed further

- https://bugzilla.suse.com/show_bug.cgi?id=1235099

## Solution

Relax the regex that checks what gets logged


## Testing

- Caught by existing unit tests

But you need to run them with both old (`rake osc:build`) and new Ruby: 

```sh
osc co openSUSE:Factory:Staging:L/yast2-packager
cd $_
rm *.tar.bz2
cp .../yast-packager/package/* .
osc ar .
osc build
```
## Screenshots

No
