### PR TITLE
Drop libyui dependency in SLES (related to bsc#1254978)

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 15 08:26:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Drop libyui dependency in SLES (related to bsc#1254978)
+- 5.0.11
+
+-------------------------------------------------------------------
 Wed Dec  3 12:33:19 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Add dependency on rubygem-cgi which is separated in ruby4.

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        5.0.10
+Version:        5.0.11
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -72,8 +72,13 @@ Requires:       rubygem(%{rb_default_ruby_abi}:cfa) >= 0.5.0
 Requires:       rubygem(%{rb_default_ruby_abi}:nokogiri)
 # parsing URI
 Requires:       rubygem(%{rb_default_ruby_abi}:cgi)
+
+# require a libyui-pkg package only in openSUSE Tumbleweed or Leap
+%if 0%{?suse_version} == 1699 || 0%{?is_opensuse}
 # One of libyui-qt-pkg, libyui-ncurses-pkg, libyui-gtk-pkg
 Requires:       libyui_pkg
+%endif
+
 Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       ruby-solv
 


### PR DESCRIPTION
## Problem

- The YaST packages used by Agama still require libyui libraries, that means we have to maintain them in the SLES16 product
- Related PR https://github.com/yast/yast-ycp-ui-bindings-dummy/pull/1

## Solution

- Update the dependencies so in SLES the yast2-ycp-ui-bindings-dummy package is used instead of the regular bindings.

## Testing

- Tested manually
  - https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:dummy-ui project builds the Agama installer ISO for openSUSE Tumbleweed ([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images/x86_64/agama-installer:openSUSE/_log)) and openSUSE Leap([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images_Leap_16.0/x86_64/agama-installer-Leap:Leap_16.0/_log)), both logs show that the libyui is installed in the images (that's expected as both contain full YaST so we cannot drop the UI there)

  - https://build.suse.de/project/show/Devel:YaST:Agama:dummy-ui project (internal link) builds the SLES image, the libyui packages are not included in the image
