### PR TITLE
Removed another reference to update-desktop-files. jsc#PED-14507

### DIFF
--- a/package/yast2-packager.changes
+++ b/package/yast2-packager.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 20 08:32:06 UTC 2026 - Michal Filka <mfilka@suse.com>
+
+- jsc#PED-14507
+  - Removed remaining reference to update-desktop-files embedded
+    deeper inside from spec file
+  - 5.0.13
+
+-------------------------------------------------------------------
 Tue Mar 10 09:00:28 UTC 2026 - Michal Filka <mfilka@suse.com>
 
 - jsc#PED-14507

--- a/package/yast2-packager.spec
+++ b/package/yast2-packager.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-packager
-Version:        5.0.12
+Version:        5.0.13
 Release:        0
 Summary:        YaST2 - Package Library
 License:        GPL-2.0-or-later
@@ -113,7 +113,6 @@ This package contains the libraries and modules for software management.
 
 %install
 %yast_install
-%suse_update_desktop_file org.opensuse.yast.Packager
 %yast_metainfo
 
 %files


### PR DESCRIPTION
## Problem

Some references to update_desktop_files were used in a way that original script didn't catch them.

Similar as in https://github.com/yast/yast-autoinstallation/pull/889